### PR TITLE
Add Docker Compose setup and GitHub Actions deployment workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,10 @@ CHATTERBOX_DEV_MODE=false
 
 # Root logger level: TRACE, DEBUG, INFO, WARN, ERROR.
 CHATTERBOX_LOG_LEVEL=INFO
+
+# Postgres backup schedule (cron syntax or @daily/@hourly/@weekly).
+BACKUP_SCHEDULE=@daily
+# Backup retention. Set any tier to 0 to disable it.
+BACKUP_KEEP_DAYS=7
+BACKUP_KEEP_WEEKS=4
+BACKUP_KEEP_MONTHS=0

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Copy to .env on the server and fill in real values.
+# docker compose reads this file automatically when it sits next to docker-compose.yml.
+
+# Discord bot token from the Discord Developer Portal.
+CHATTERBOX_DISCORD_TOKEN=replace-me-with-your-discord-bot-token
+
+# Postgres credentials. POSTGRES_PASSWORD must be set; the others have defaults.
+POSTGRES_DB=chatterbox
+POSTGRES_USER=chatterbox
+POSTGRES_PASSWORD=replace-me-with-a-strong-password
+
+# false = register slash commands globally (production).
+# true  = register per-guild for instant updates (development only).
+CHATTERBOX_DEV_MODE=false
+
+# Root logger level: TRACE, DEBUG, INFO, WARN, ERROR.
+CHATTERBOX_LOG_LEVEL=INFO

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,6 +70,6 @@ jobs:
           cd "$1"
           gunzip -c chatterbox.tar.gz | docker image load
           rm chatterbox.tar.gz
-          docker compose up -d --force-recreate chatterbox
+          docker compose up -d
           docker image prune -f
           REMOTE

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    environment: production
     timeout-minutes: 20
     steps:
       - name: Check out repository
@@ -48,14 +49,14 @@ jobs:
           printf '%s\n' "$KNOWN_HOSTS" > ~/.ssh/known_hosts
           chmod 644 ~/.ssh/known_hosts
 
-      - name: Copy image to VPS
+      - name: Copy image and compose file to VPS
         env:
           SSH_HOST: ${{ secrets.DEPLOY_HOST }}
           SSH_USER: ${{ secrets.DEPLOY_USER }}
           DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
         run: |
-          scp -i ~/.ssh/id_ed25519 chatterbox.tar.gz \
-            "$SSH_USER@$SSH_HOST:$DEPLOY_PATH/chatterbox.tar.gz"
+          scp -i ~/.ssh/id_ed25519 chatterbox.tar.gz docker-compose.yml \
+            "$SSH_USER@$SSH_HOST:$DEPLOY_PATH/"
 
       - name: Load image and restart container
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,74 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: false
+          load: true
+          tags: chatterbox:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Save image to gzipped tarball
+        run: docker image save chatterbox:latest | gzip > chatterbox.tar.gz
+
+      - name: Configure SSH
+        env:
+          SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          KNOWN_HOSTS: ${{ secrets.DEPLOY_KNOWN_HOSTS }}
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          printf '%s\n' "$KNOWN_HOSTS" > ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+
+      - name: Copy image to VPS
+        env:
+          SSH_HOST: ${{ secrets.DEPLOY_HOST }}
+          SSH_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+        run: |
+          scp -i ~/.ssh/id_ed25519 chatterbox.tar.gz \
+            "$SSH_USER@$SSH_HOST:$DEPLOY_PATH/chatterbox.tar.gz"
+
+      - name: Load image and restart container
+        env:
+          SSH_HOST: ${{ secrets.DEPLOY_HOST }}
+          SSH_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+        run: |
+          ssh -i ~/.ssh/id_ed25519 "$SSH_USER@$SSH_HOST" \
+            bash -s -- "$DEPLOY_PATH" <<'REMOTE'
+          set -euo pipefail
+          cd "$1"
+          gunzip -c chatterbox.tar.gz | docker image load
+          rm chatterbox.tar.gz
+          docker compose up -d --force-recreate chatterbox
+          docker image prune -f
+          REMOTE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:17-alpine
+    image: postgres:18-alpine
     restart: unless-stopped
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-chatterbox}
@@ -16,6 +16,31 @@ services:
       timeout: 5s
       retries: 5
       start_period: 30s
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  postgres-backup:
+    image: prodrigestivill/postgres-backup-local:18-alpine
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      POSTGRES_HOST: postgres
+      POSTGRES_DB: ${POSTGRES_DB:-chatterbox}
+      POSTGRES_USER: ${POSTGRES_USER:-chatterbox}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}
+      SCHEDULE: ${BACKUP_SCHEDULE:-@daily}
+      BACKUP_KEEP_DAYS: ${BACKUP_KEEP_DAYS:-7}
+      BACKUP_KEEP_WEEKS: ${BACKUP_KEEP_WEEKS:-4}
+      BACKUP_KEEP_MONTHS: ${BACKUP_KEEP_MONTHS:-0}
+    volumes:
+      - postgres-backups:/backups
+    networks:
+      - internal
     logging:
       driver: json-file
       options:
@@ -49,3 +74,4 @@ networks:
 
 volumes:
   postgres-data:
+  postgres-backups:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,10 @@ services:
       - postgres-data:/var/lib/postgresql/data
     networks:
       - internal
+    deploy:
+      resources:
+        limits:
+          memory: 256M
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-chatterbox} -d ${POSTGRES_DB:-chatterbox}"]
       interval: 10s
@@ -41,6 +45,10 @@ services:
       - postgres-backups:/backups
     networks:
       - internal
+    deploy:
+      resources:
+        limits:
+          memory: 64M
     logging:
       driver: json-file
       options:
@@ -60,8 +68,13 @@ services:
       CHATTERBOX_DB_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}
       CHATTERBOX_DEV_MODE: ${CHATTERBOX_DEV_MODE:-false}
       CHATTERBOX_LOG_LEVEL: ${CHATTERBOX_LOG_LEVEL:-INFO}
+      JAVA_TOOL_OPTIONS: -XX:MaxRAMPercentage=75.0
     networks:
       - internal
+    deploy:
+      resources:
+        limits:
+          memory: 384M
     logging:
       driver: json-file
       options:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,51 @@
+services:
+  postgres:
+    image: postgres:17-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-chatterbox}
+      POSTGRES_USER: ${POSTGRES_USER:-chatterbox}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    networks:
+      - internal
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-chatterbox} -d ${POSTGRES_DB:-chatterbox}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  chatterbox:
+    image: chatterbox:latest
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      CHATTERBOX_DISCORD_TOKEN: ${CHATTERBOX_DISCORD_TOKEN:?CHATTERBOX_DISCORD_TOKEN must be set}
+      CHATTERBOX_DB_URL: jdbc:postgresql://postgres:5432/${POSTGRES_DB:-chatterbox}
+      CHATTERBOX_DB_USER: ${POSTGRES_USER:-chatterbox}
+      CHATTERBOX_DB_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}
+      CHATTERBOX_DEV_MODE: ${CHATTERBOX_DEV_MODE:-false}
+      CHATTERBOX_LOG_LEVEL: ${CHATTERBOX_LOG_LEVEL:-INFO}
+    networks:
+      - internal
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+networks:
+  internal:
+    driver: bridge
+
+volumes:
+  postgres-data:


### PR DESCRIPTION
## Summary
This PR adds containerized deployment infrastructure for the Chatterbox Discord bot, including a complete Docker Compose configuration for local and production environments, along with an automated CI/CD pipeline for building and deploying the application.

## Key Changes

- **docker-compose.yml**: Complete multi-service orchestration setup including:
  - PostgreSQL 18 Alpine database with health checks and resource limits (256MB memory)
  - Automated daily database backups with configurable retention policies (7 days/4 weeks)
  - Chatterbox application service with proper dependency ordering and resource constraints (384MB memory)
  - Internal bridge network for service communication
  - Structured logging with rotation (10MB max size, 3 files)

- **.github/workflows/deploy.yml**: Automated deployment pipeline that:
  - Builds Docker image on pushes to main branch with GitHub Actions cache optimization
  - Exports image as gzipped tarball for efficient transfer
  - Securely deploys to VPS via SSH with key-based authentication
  - Loads image and restarts services with `docker compose up -d`
  - Cleans up dangling images post-deployment

- **.env.example**: Configuration template documenting all required and optional environment variables:
  - Discord bot token requirement
  - Database credentials with secure password requirement
  - Development vs. production mode toggle
  - Logging level configuration
  - Backup schedule and retention policies

## Notable Implementation Details

- All required secrets (Discord token, database password) use the `?` syntax to enforce configuration at deployment time
- Health checks on PostgreSQL ensure the database is ready before dependent services start
- Memory limits prevent resource exhaustion (256M for DB, 64M for backups, 384M for app)
- SSH key configuration uses Ed25519 for modern security practices
- Deployment uses `cancel-in-progress: false` to prevent concurrent deployments

https://claude.ai/code/session_01P24kx9sSfxazQdbMQU5pQF