### PR TITLE
Update UID/GID and PostgreSQL volume mount path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ RUN --mount=type=cache,target=/root/.m2 mvn -B -ntp -q -DskipTests package
 FROM eclipse-temurin:25-jre
 WORKDIR /app
 
-RUN groupadd --system --gid 1000 chatterbox \
- && useradd  --system --uid 1000 --gid 1000 --no-create-home chatterbox
+RUN groupadd --system --gid 10001 chatterbox \
+ && useradd  --system --uid 10001 --gid 10001 --no-create-home chatterbox
 
 COPY --from=build /src/target/chatterbox.jar /app/chatterbox.jar
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-chatterbox}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql
     networks:
       - internal
     deploy:


### PR DESCRIPTION
## Summary
This PR updates the Docker configuration to use higher UID/GID values for the chatterbox user and adjusts the PostgreSQL volume mount path.

## Key Changes
- **Dockerfile**: Changed chatterbox user and group IDs from `1000` to `10001` to avoid conflicts with standard user ranges
- **docker-compose.yml**: Updated PostgreSQL volume mount from `/var/lib/postgresql/data` to `/var/lib/postgresql` to mount at the PostgreSQL data directory root

## Implementation Details
The UID/GID change to `10001` follows best practices for container security by using values outside the typical user range (0-1000), reducing the risk of privilege escalation if the container is compromised. The PostgreSQL volume path adjustment simplifies the mount configuration while maintaining proper data persistence.

https://claude.ai/code/session_01P24kx9sSfxazQdbMQU5pQF