### PR TITLE
Add message source links to shout history embeds

### DIFF
--- a/src/main/java/ca/ryanmorrison/chatterbox/features/shout/HistoryEntry.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/shout/HistoryEntry.java
@@ -11,6 +11,8 @@ import java.util.Optional;
  *                    pagination cursor.
  * @param shoutId     primary key in {@code shouts}; used by moderation
  *                    actions (delete / restore).
+ * @param messageId   Discord message ID of the original shout; used to
+ *                    build a jump link to the source message.
  * @param content     the shout text the bot emitted.
  * @param authorId    Discord user ID of the original author.
  * @param authoredAt  when the original message was first written.
@@ -21,6 +23,7 @@ import java.util.Optional;
 record HistoryEntry(
         long historyId,
         long shoutId,
+        long messageId,
         String content,
         long authorId,
         OffsetDateTime authoredAt,

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/shout/ShoutHistoryHandler.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/shout/ShoutHistoryHandler.java
@@ -33,7 +33,7 @@ import java.util.concurrent.CompletionException;
 final class ShoutHistoryHandler extends ListenerAdapter {
 
     private static final Logger log = LoggerFactory.getLogger(ShoutHistoryHandler.class);
-    private static final String UNKNOWN_AUTHOR = "Former member";
+    private static final String UNKNOWN_MEMBER = "Former member";
 
     private final ShoutRepository shouts;
     private final ShoutHistoryRepository history;
@@ -153,7 +153,7 @@ final class ShoutHistoryHandler extends ListenerAdapter {
         var newer = history.findNewer(channelId, entry.historyId(), canModerate);
         var pos = history.position(channelId, entry.historyId(), canModerate);
 
-        buildEmbed(guild, entry, pos).thenAccept(embed ->
+        buildEmbed(guild, channelId, entry, pos).thenAccept(embed ->
                 event.replyEmbeds(embed)
                         .setEphemeral(true)
                         .setComponents(ShoutHistoryView.components(entry, older, newer, canModerate))
@@ -166,25 +166,26 @@ final class ShoutHistoryHandler extends ListenerAdapter {
         var newer = history.findNewer(channelId, entry.historyId(), canModerate);
         var pos = history.position(channelId, entry.historyId(), canModerate);
 
-        buildEmbed(guild, entry, pos).thenAccept(embed ->
+        buildEmbed(guild, channelId, entry, pos).thenAccept(embed ->
                 event.editMessageEmbeds(embed)
                         .setComponents(ShoutHistoryView.components(entry, older, newer, canModerate))
                         .queue());
     }
 
     /**
-     * Resolves author and (if soft-deleted) deleter member names in parallel,
-     * then assembles the embed. Returns a future so the caller can chain a
-     * {@code reply} or {@code editMessage} when ready.
+     * Resolves author and (if soft-deleted) deleter member references in
+     * parallel, then assembles the embed. Returns a future so the caller can
+     * chain a {@code reply} or {@code editMessage} when ready.
      */
-    private CompletableFuture<MessageEmbed> buildEmbed(Guild guild, HistoryEntry entry,
+    private CompletableFuture<MessageEmbed> buildEmbed(Guild guild, long channelId, HistoryEntry entry,
                                                        ShoutHistoryRepository.Position pos) {
-        CompletableFuture<String> author = resolveDisplayName(guild, entry.authorId());
+        CompletableFuture<String> author = resolveMember(guild, entry.authorId());
         CompletableFuture<String> deleter = entry.deletion()
-                .map(d -> resolveDisplayName(guild, d.deletedBy()))
+                .map(d -> resolveMember(guild, d.deletedBy()))
                 .orElse(CompletableFuture.completedFuture(null));
         return author.thenCombine(deleter,
-                (authorName, deleterName) -> ShoutHistoryView.embed(entry, authorName, deleterName, pos));
+                (authorRef, deleterRef) -> ShoutHistoryView.embed(
+                        entry, guild.getIdLong(), channelId, authorRef, deleterRef, pos));
     }
 
     private static long parseCursor(String customId) {
@@ -196,18 +197,24 @@ final class ShoutHistoryHandler extends ListenerAdapter {
         return member.hasPermission(channel, Permission.MESSAGE_MANAGE);
     }
 
-    private static CompletableFuture<String> resolveDisplayName(Guild guild, long userId) {
+    /**
+     * Returns a Discord user mention ({@code <@id>}) when the member still
+     * exists in the guild, or the {@link #UNKNOWN_MEMBER} fallback otherwise.
+     * Mentions in embed fields render as the user's name without producing a
+     * notification, which is the desired UX here.
+     */
+    private static CompletableFuture<String> resolveMember(Guild guild, long userId) {
         return guild.retrieveMemberById(userId).submit()
-                .thenApply(Member::getEffectiveName)
+                .thenApply(Member::getAsMention)
                 .exceptionally(throwable -> {
                     Throwable cause = (throwable instanceof CompletionException ce) ? ce.getCause() : throwable;
                     if (cause instanceof ErrorResponseException ere
                             && ere.getErrorResponse() == ErrorResponse.UNKNOWN_MEMBER) {
-                        return UNKNOWN_AUTHOR;
+                        return UNKNOWN_MEMBER;
                     }
                     log.warn("Failed to resolve member {} in guild {}: {}",
                             userId, guild.getId(), cause.toString());
-                    return UNKNOWN_AUTHOR;
+                    return UNKNOWN_MEMBER;
                 });
     }
 }

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/shout/ShoutHistoryRepository.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/shout/ShoutHistoryRepository.java
@@ -97,6 +97,7 @@ final class ShoutHistoryRepository {
         Record record = dsl.select(
                         SHOUT_HISTORY.ID,
                         SHOUT_HISTORY.SHOUT_ID,
+                        SHOUTS.MESSAGE_ID,
                         SHOUTS.CONTENT,
                         SHOUTS.AUTHOR_ID,
                         SHOUTS.AUTHORED_AT,
@@ -119,6 +120,7 @@ final class ShoutHistoryRepository {
         return Optional.of(new HistoryEntry(
                 record.get(SHOUT_HISTORY.ID),
                 record.get(SHOUT_HISTORY.SHOUT_ID),
+                record.get(SHOUTS.MESSAGE_ID),
                 record.get(SHOUTS.CONTENT),
                 record.get(SHOUTS.AUTHOR_ID),
                 record.get(SHOUTS.AUTHORED_AT),

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/shout/ShoutHistoryView.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/shout/ShoutHistoryView.java
@@ -35,25 +35,33 @@ final class ShoutHistoryView {
     /**
      * Builds the embed.
      *
-     * @param deleterDisplayName  ignored unless {@code entry.deletion()} is
-     *                            present; required when present.
+     * <p>{@code authorReference} and {@code deleterReference} are rendered
+     * verbatim into the embed: typically a {@code <@id>} mention when the
+     * member still exists, or a plain-text fallback string otherwise.
+     *
+     * @param deleterReference  ignored unless {@code entry.deletion()} is
+     *                          present; required when present.
      */
     static MessageEmbed embed(HistoryEntry entry,
-                              String authorDisplayName,
-                              String deleterDisplayName,
+                              long guildId,
+                              long channelId,
+                              String authorReference,
+                              String deleterReference,
                               ShoutHistoryRepository.Position pos) {
         long ts = entry.authoredAt().toEpochSecond();
+        String jumpUrl = "https://discord.com/channels/" + guildId + "/" + channelId + "/" + entry.messageId();
         var builder = new EmbedBuilder()
                 .setTitle("Shout history")
                 .setDescription(entry.content())
-                .addField("Author", authorDisplayName, true)
+                .addField("Author", authorReference, true)
                 .addField("Originally written", "<t:" + ts + ":F>", true)
+                .addField("Source", "[Jump to message](" + jumpUrl + ")", true)
                 .setFooter("Entry " + pos.rank() + " of " + pos.total());
 
         if (entry.deletion().isPresent()) {
             builder.setColor(DELETED_COLOR);
-            if (deleterDisplayName != null) {
-                builder.addField("Deleted by", deleterDisplayName, true);
+            if (deleterReference != null) {
+                builder.addField("Deleted by", deleterReference, true);
             }
         }
         return builder.build();

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/shout/ShoutListener.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/shout/ShoutListener.java
@@ -47,7 +47,7 @@ final class ShoutListener extends ListenerAdapter {
         }
 
         shouts.randomPeer(channelId, messageId).ifPresent(peer ->
-                event.getChannel().sendMessage(peer.content()).queue(
+                event.getChannel().sendMessage("**" + peer.content() + "**").queue(
                         sent -> recordHistory(channelId, peer.shoutId()),
                         err -> log.warn("Failed to send shout reply: {}", err.toString())));
     }

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/shout/ShoutHistoryRepositoryTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/shout/ShoutHistoryRepositoryTest.java
@@ -88,6 +88,7 @@ class ShoutHistoryRepositoryTest {
         assertTrue(latest.isPresent());
         assertEquals("FIRST SHOUT IN CHANNEL", latest.get().content());
         assertEquals(s1, latest.get().shoutId());
+        assertEquals(100L, latest.get().messageId());
         assertEquals(AUTHOR, latest.get().authorId());
         assertTrue(latest.get().deletion().isEmpty());
     }

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/shout/ShoutHistoryViewTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/shout/ShoutHistoryViewTest.java
@@ -23,46 +23,67 @@ class ShoutHistoryViewTest {
     private static final OffsetDateTime DELETED_AT =
             OffsetDateTime.of(2026, 4, 30, 13, 0, 0, 0, ZoneOffset.UTC);
     private static final long EPOCH = AUTHORED_AT.toEpochSecond();
+    private static final long GUILD = 1111L;
+    private static final long CHANNEL = 2222L;
+    private static final long MESSAGE = 3333L;
+    private static final long AUTHOR = 7777L;
     private static final long DELETER = 9999L;
 
     private static HistoryEntry active(long id) {
-        return new HistoryEntry(id, 700L + id, "WHY ARE WE STILL HERE", 7777L, AUTHORED_AT, Optional.empty());
+        return new HistoryEntry(id, 700L + id, MESSAGE + id, "WHY ARE WE STILL HERE", AUTHOR, AUTHORED_AT,
+                Optional.empty());
     }
 
     private static HistoryEntry deleted(long id) {
-        return new HistoryEntry(id, 700L + id, "WHY ARE WE STILL HERE", 7777L, AUTHORED_AT,
+        return new HistoryEntry(id, 700L + id, MESSAGE + id, "WHY ARE WE STILL HERE", AUTHOR, AUTHORED_AT,
                 Optional.of(new HistoryEntry.Deletion(DELETER, DELETED_AT)));
     }
 
     @Test
-    void embedIncludesContentAuthorTimestampAndPosition() {
+    void embedIncludesContentAuthorTimestampSourceAndPosition() {
+        HistoryEntry entry = active(42L);
         MessageEmbed embed = ShoutHistoryView.embed(
-                active(42L), "Alice", null, new ShoutHistoryRepository.Position(2, 5));
+                entry, GUILD, CHANNEL, "<@" + AUTHOR + ">", null,
+                new ShoutHistoryRepository.Position(2, 5));
 
         assertEquals("Shout history", embed.getTitle());
         assertEquals("WHY ARE WE STILL HERE", embed.getDescription());
         assertEquals("Entry 2 of 5", embed.getFooter().getText());
         assertNull(embed.getColor(), "active entries don't have a color override");
 
+        String expectedJump = "https://discord.com/channels/" + GUILD + "/" + CHANNEL + "/" + entry.messageId();
+
         var fields = embed.getFields();
-        assertEquals(2, fields.size());
+        assertEquals(3, fields.size());
         assertEquals("Author", fields.get(0).getName());
-        assertEquals("Alice", fields.get(0).getValue());
+        assertEquals("<@" + AUTHOR + ">", fields.get(0).getValue());
         assertEquals("Originally written", fields.get(1).getName());
         assertEquals("<t:" + EPOCH + ":F>", fields.get(1).getValue());
+        assertEquals("Source", fields.get(2).getName());
+        assertEquals("[Jump to message](" + expectedJump + ")", fields.get(2).getValue());
+    }
+
+    @Test
+    void embedAuthorFallsBackToPlainTextWhenMemberIsGone() {
+        MessageEmbed embed = ShoutHistoryView.embed(
+                active(42L), GUILD, CHANNEL, "Former member", null,
+                new ShoutHistoryRepository.Position(1, 1));
+
+        assertEquals("Former member", embed.getFields().get(0).getValue());
     }
 
     @Test
     void deletedEntryGetsRedColorAndDeletedByField() {
         MessageEmbed embed = ShoutHistoryView.embed(
-                deleted(42L), "Alice", "Mod Bob", new ShoutHistoryRepository.Position(2, 5));
+                deleted(42L), GUILD, CHANNEL, "<@" + AUTHOR + ">", "<@" + DELETER + ">",
+                new ShoutHistoryRepository.Position(2, 5));
 
         assertEquals(new Color(0xED, 0x42, 0x45).getRGB(), embed.getColor().getRGB());
 
         var fields = embed.getFields();
-        assertEquals(3, fields.size());
-        assertEquals("Deleted by", fields.get(2).getName());
-        assertEquals("Mod Bob", fields.get(2).getValue());
+        assertEquals(4, fields.size());
+        assertEquals("Deleted by", fields.get(3).getName());
+        assertEquals("<@" + DELETER + ">", fields.get(3).getValue());
     }
 
     @Test


### PR DESCRIPTION
## Summary
Enhanced the shout history feature to display jump links to the original Discord messages and improved member reference handling in embeds.

## Key Changes
- **Added message source links**: History embeds now include a "Source" field with a clickable jump link to the original message in Discord
- **Improved member references**: Changed from displaying member names to using Discord mentions (`<@id>`), which render cleanly in embeds without triggering notifications
- **Enhanced HistoryEntry record**: Added `messageId` field to track the Discord message ID of the original shout, enabling jump link generation
- **Updated database queries**: Modified `ShoutHistoryRepository` to fetch `MESSAGE_ID` from the `SHOUTS` table
- **Improved member resolution**: Renamed `resolveDisplayName()` to `resolveMember()` and updated it to return mentions instead of names, with a "Former member" fallback for deleted accounts
- **Updated test coverage**: Added comprehensive tests for the new "Source" field and member fallback behavior
- **Minor formatting**: Wrapped peer shout replies in bold markdown for better visibility

## Implementation Details
- The jump URL format follows Discord's standard: `https://discord.com/channels/{guildId}/{channelId}/{messageId}`
- Member mentions in embed fields render as usernames without producing notifications, providing better UX than plain text names
- Error handling gracefully falls back to "Former member" text when a user is no longer in the guild
- The `buildEmbed()` method now accepts `channelId` as a parameter to support jump link generation

https://claude.ai/code/session_01UHshmiVoQcxaeuJ7jhCVT9