### PR TITLE
Reorganize RSS embed layout: feed title to author, article author to footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,11 +375,14 @@ channel. If more than one item is new, the embed footer shows
 a stale marker (e.g. one that has aged out of the feed window) from
 replaying the entire archive.
 
-The embed contains the article title (linked to the article URL),
-author when present, a thumbnail (media:thumbnail / image enclosure /
-first `<img>` tag, in that order), and a plain-text preview built from
-the description or content body — HTML stripped via jsoup, whitespace
-collapsed, truncated to 400 chars with an ellipsis.
+The embed leads with the feed title (in the embed's author slot, so a
+channel aggregating multiple feeds is easy to scan), followed by the
+article title linked to the article URL, a thumbnail (media:thumbnail
+/ image enclosure / first `<img>` tag, in that order), and a
+plain-text preview built from the description or content body — HTML
+stripped via jsoup, whitespace collapsed, truncated to 400 chars with
+an ellipsis. The footer carries the article author when present and
+the `+N more items` tail when applicable.
 
 Fetch failures (network errors, HTTP non-2xx, oversized bodies,
 unparseable XML) are logged at error level and skip the post; the

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/rss/RssPublisher.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/rss/RssPublisher.java
@@ -41,11 +41,14 @@ final class RssPublisher {
     static MessageEmbed buildEmbed(Feed feed, SyndEntry latest, int newCount) {
         EmbedBuilder eb = new EmbedBuilder().setColor(EMBED_COLOR);
 
+        // Feed title sits in the embed's author slot so it's the first thing
+        // a reader sees — useful when a channel aggregates multiple feeds.
+        eb.setAuthor(truncate(feed.title(), MessageEmbed.AUTHOR_MAX_LENGTH));
+
         String title = stringOrFallback(latest.getTitle(), "(untitled)");
         String link = latest.getLink();
         eb.setTitle(truncate(title, MessageEmbed.TITLE_MAX_LENGTH), nullIfBlank(link));
 
-        authorName(latest).ifPresent(eb::setAuthor);
         thumbnail(latest).ifPresent(eb::setThumbnail);
 
         String preview = preview(latest);
@@ -58,14 +61,25 @@ final class RssPublisher {
             eb.setTimestamp(published);
         }
 
-        String footer = feed.title();
-        int extra = newCount - 1;
-        if (extra > 0) {
-            footer += "  ·  +" + extra + " more " + (extra == 1 ? "item" : "items");
+        // Footer carries the article author (when known) and the "+N more"
+        // tail. Either, both, or neither may be present.
+        String footer = buildFooter(authorName(latest), newCount);
+        if (!footer.isEmpty()) {
+            eb.setFooter(truncate(footer, MessageEmbed.TEXT_MAX_LENGTH));
         }
-        eb.setFooter(truncate(footer, MessageEmbed.TEXT_MAX_LENGTH));
 
         return eb.build();
+    }
+
+    private static String buildFooter(Optional<String> author, int newCount) {
+        StringBuilder sb = new StringBuilder();
+        author.ifPresent(sb::append);
+        int extra = newCount - 1;
+        if (extra > 0) {
+            if (sb.length() > 0) sb.append("  ·  ");
+            sb.append("+").append(extra).append(" more ").append(extra == 1 ? "item" : "items");
+        }
+        return sb.toString();
     }
 
     // ---- helpers ----

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/rss/RssPublisherTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/rss/RssPublisherTest.java
@@ -40,36 +40,59 @@ class RssPublisherTest {
     }
 
     @Test
-    void embedHasLinkedTitleAuthorAndCleanedDescription() {
+    void embedHasFeedTitleAtTopLinkedTitleAuthorInFooterAndCleanedDescription() {
         var entry = entry("Article Title",
                 "https://example.com/articles/1",
                 "<p>Hello <b>world</b>! &amp; goodbye.</p>",
                 "Jane Doe");
         MessageEmbed embed = RssPublisher.buildEmbed(testFeed(), entry, 1);
 
+        assertNotNull(embed.getAuthor());
+        assertEquals("Test Feed", embed.getAuthor().getName(),
+                "feed title should occupy the embed's author slot");
         assertEquals("Article Title", embed.getTitle());
         assertEquals("https://example.com/articles/1", embed.getUrl());
-        assertNotNull(embed.getAuthor());
-        assertEquals("Jane Doe", embed.getAuthor().getName());
         assertEquals("Hello world! & goodbye.", embed.getDescription());
-        assertEquals("Test Feed", embed.getFooter().getText());
+        assertNotNull(embed.getFooter());
+        assertEquals("Jane Doe", embed.getFooter().getText(),
+                "article author should now be in the footer");
     }
 
     @Test
-    void footerShowsExtraCount() {
+    void footerShowsAuthorAndExtraCountWhenBothPresent() {
+        var entry = entry("t", "https://x", "<p>p</p>", "Jane Doe");
+        MessageEmbed embed = RssPublisher.buildEmbed(testFeed(), entry, 3);
+        String footer = embed.getFooter().getText();
+        assertTrue(footer.contains("Jane Doe"), () -> "got: " + footer);
+        assertTrue(footer.contains("+2 more items"), () -> "got: " + footer);
+    }
+
+    @Test
+    void footerShowsOnlyExtraCountWhenAuthorMissing() {
         var entry = entry("t", "https://x", "<p>p</p>", null);
         MessageEmbed embed = RssPublisher.buildEmbed(testFeed(), entry, 3);
-        assertTrue(embed.getFooter().getText().contains("+2 more items"),
-                () -> "got: " + embed.getFooter().getText());
+        assertEquals("+2 more items", embed.getFooter().getText());
+    }
+
+    @Test
+    void footerShowsOnlyAuthorWhenSingleNewItem() {
+        var entry = entry("t", "https://x", "<p>p</p>", "Jane Doe");
+        MessageEmbed embed = RssPublisher.buildEmbed(testFeed(), entry, 1);
+        assertEquals("Jane Doe", embed.getFooter().getText());
+    }
+
+    @Test
+    void footerOmittedWhenNeitherAuthorNorExtra() {
+        var entry = entry("t", "https://x", "<p>p</p>", null);
+        MessageEmbed embed = RssPublisher.buildEmbed(testFeed(), entry, 1);
+        assertNull(embed.getFooter());
     }
 
     @Test
     void singleExtraIsSingular() {
         var entry = entry("t", "https://x", "<p>p</p>", null);
         MessageEmbed embed = RssPublisher.buildEmbed(testFeed(), entry, 2);
-        assertTrue(embed.getFooter().getText().contains("+1 more item"),
-                () -> "got: " + embed.getFooter().getText());
-        assertTrue(!embed.getFooter().getText().contains("items"));
+        assertEquals("+1 more item", embed.getFooter().getText());
     }
 
     @Test


### PR DESCRIPTION
## Summary
Restructured the RSS embed layout to improve readability when a Discord channel aggregates multiple feeds. The feed title now appears prominently at the top (in the embed's author slot), while the article author moves to the footer alongside the "+N more items" indicator.

## Key Changes
- **Feed title positioning**: Now set as the embed author (first thing readers see) instead of in the footer, making it easier to identify which feed an article came from in multi-feed channels
- **Article author relocation**: Moved from embed author to footer, where it appears alongside the extra item count
- **Footer logic refactored**: Introduced `buildFooter()` method to intelligently construct footer text containing:
  - Article author (when present)
  - "+N more items" tail (when applicable)
  - Proper formatting with separator when both are present
  - Omitted entirely when neither author nor extra items exist
- **Test coverage expanded**: Added comprehensive test cases covering all footer combinations (author + extra, author only, extra only, neither)

## Implementation Details
- The footer is now conditionally set only when it has content (author and/or extra count), avoiding empty footers
- Footer construction uses a StringBuilder to cleanly handle optional components and proper formatting
- All existing functionality preserved; this is purely a layout reorganization
- Documentation updated to reflect the new embed structure

https://claude.ai/code/session_0132q4aduwx11VQWeL1SsMX8