### PR TITLE
Add CI workflow for automated testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '25'
+          cache: maven
+
+      - name: Run unit tests
+        run: mvn --batch-mode --no-transfer-progress test
+
+      - name: Upload Surefire reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: surefire-reports
+          path: '**/target/surefire-reports/**'
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary
This PR introduces a GitHub Actions CI workflow to automatically run unit tests on pull requests and pushes to the main branch.

## Key Changes
- Added `.github/workflows/ci.yml` with a complete CI pipeline that:
  - Triggers on pull requests and pushes to the main branch
  - Sets up JDK 25 (Temurin distribution) with Maven caching for faster builds
  - Runs Maven unit tests in batch mode with minimal output
  - Uploads Surefire test reports as artifacts for easy access to test results
  - Uses concurrency controls to cancel in-progress runs when new commits are pushed

## Notable Implementation Details
- Configured with a 20-minute timeout to catch hanging tests
- Uses `actions/upload-artifact@v4` to preserve test reports even if tests fail
- Implements concurrency grouping to prevent redundant workflow runs
- Minimal permissions set (read-only access to repository contents)

https://claude.ai/code/session_01SgRwaxFoVjqrVcvB3o22Dt