### PR TITLE
Add path filters to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,11 @@ name: Build and Deploy
 on:
   push:
     branches: [main]
+    paths:
+      - 'src/**'
+      - 'pom.xml'
+      - 'Dockerfile'
+      - 'docker-compose.yml'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
Updated the GitHub Actions deploy workflow to only trigger on pushes that modify specific files, reducing unnecessary workflow runs.

## Key Changes
- Added `paths` filter to the `push` trigger in the deploy workflow
- Configured workflow to run only when changes are made to:
  - Source code in `src/**`
  - `pom.xml` (Maven configuration)
  - `Dockerfile` (container image definition)
  - `docker-compose.yml` (container orchestration)

## Details
This change prevents the deploy workflow from running on every push to the main branch. The workflow will now only execute when files relevant to the build and deployment process are modified, improving CI/CD efficiency and reducing unnecessary resource consumption.

https://claude.ai/code/session_01AXpUqtgb2dbxuvEm82md3w