### PR TITLE
Decode HTML entities in RSS feed titles and authors

### DIFF
--- a/src/main/java/ca/ryanmorrison/chatterbox/features/rss/RssFetcher.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/rss/RssFetcher.java
@@ -4,6 +4,7 @@ import com.rometools.rome.feed.synd.SyndEntry;
 import com.rometools.rome.feed.synd.SyndFeed;
 import com.rometools.rome.io.FeedException;
 import com.rometools.rome.io.SyndFeedInput;
+import org.jsoup.parser.Parser;
 import org.xml.sax.InputSource;
 
 import java.io.ByteArrayInputStream;
@@ -67,7 +68,8 @@ final class RssFetcher {
     Validated validate(String rawUrl) throws FetchException {
         String normalised = normaliseUrl(rawUrl);
         SyndFeed feed = parse(load(normalised));
-        String title = feed.getTitle() == null ? "" : feed.getTitle().trim();
+        String rawTitle = feed.getTitle() == null ? "" : feed.getTitle();
+        String title = Parser.unescapeEntities(rawTitle, false).trim();
         if (title.isEmpty()) {
             throw new FetchException("The feed parsed successfully but has no title.");
         }

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/rss/RssPublisher.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/rss/RssPublisher.java
@@ -11,6 +11,7 @@ import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
+import org.jsoup.parser.Parser;
 
 import java.awt.Color;
 import java.time.OffsetDateTime;
@@ -43,9 +44,9 @@ final class RssPublisher {
 
         // Feed title sits in the embed's author slot so it's the first thing
         // a reader sees — useful when a channel aggregates multiple feeds.
-        eb.setAuthor(truncate(feed.title(), MessageEmbed.AUTHOR_MAX_LENGTH));
+        eb.setAuthor(truncate(decodeEntities(feed.title()), MessageEmbed.AUTHOR_MAX_LENGTH));
 
-        String title = stringOrFallback(latest.getTitle(), "(untitled)");
+        String title = stringOrFallback(decodeEntities(latest.getTitle()), "(untitled)");
         String link = latest.getLink();
         eb.setTitle(truncate(title, MessageEmbed.TITLE_MAX_LENGTH), nullIfBlank(link));
 
@@ -86,13 +87,13 @@ final class RssPublisher {
 
     private static Optional<String> authorName(SyndEntry entry) {
         if (entry.getAuthor() != null && !entry.getAuthor().isBlank()) {
-            return Optional.of(truncate(entry.getAuthor().trim(), MessageEmbed.AUTHOR_MAX_LENGTH));
+            return Optional.of(truncate(decodeEntities(entry.getAuthor()).trim(), MessageEmbed.AUTHOR_MAX_LENGTH));
         }
         List<SyndPerson> authors = entry.getAuthors();
         if (authors != null) {
             for (SyndPerson p : authors) {
                 if (p.getName() != null && !p.getName().isBlank()) {
-                    return Optional.of(truncate(p.getName().trim(), MessageEmbed.AUTHOR_MAX_LENGTH));
+                    return Optional.of(truncate(decodeEntities(p.getName()).trim(), MessageEmbed.AUTHOR_MAX_LENGTH));
                 }
             }
         }
@@ -211,6 +212,17 @@ final class RssPublisher {
 
     private static String stringOrFallback(String value, String fallback) {
         return (value == null || value.isBlank()) ? fallback : value.trim();
+    }
+
+    /**
+     * Decodes HTML entities (e.g. {@code &#8217;} → {@code '}, {@code &amp;} →
+     * {@code &}) without stripping or interpreting tags. Rome hands back title
+     * and author fields verbatim, so feeds that escape punctuation reach us
+     * with raw entities still in place.
+     */
+    private static String decodeEntities(String value) {
+        if (value == null) return null;
+        return Parser.unescapeEntities(value, false);
     }
 
     private static String nullIfBlank(String s) {

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/rss/RssPublisherTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/rss/RssPublisherTest.java
@@ -59,6 +59,30 @@ class RssPublisherTest {
     }
 
     @Test
+    void titleAndAuthorEntitiesAreDecoded() {
+        var entry = entry("Meta&#8217;s historic loss in court could cost a lot more than $375 million",
+                "https://example.com/articles/1",
+                "<p>body</p>",
+                "Jane &amp; John");
+        MessageEmbed embed = RssPublisher.buildEmbed(testFeed(), entry, 1);
+        assertEquals("Meta’s historic loss in court could cost a lot more than $375 million",
+                embed.getTitle());
+        assertNotNull(embed.getFooter());
+        assertEquals("Jane & John", embed.getFooter().getText());
+    }
+
+    @Test
+    void feedTitleEntitiesAreDecodedInAuthorSlot() {
+        Feed feed = new Feed(1L, 100L, 200L, "https://example.com/feed",
+                "Ben &amp; Jerry&#8217;s Blog",
+                7L, 60, Optional.empty(), Optional.empty(), Optional.empty(),
+                OffsetDateTime.now(ZoneOffset.UTC));
+        var entry = entry("t", "https://x", "<p>p</p>", null);
+        MessageEmbed embed = RssPublisher.buildEmbed(feed, entry, 1);
+        assertEquals("Ben & Jerry’s Blog", embed.getAuthor().getName());
+    }
+
+    @Test
     void footerShowsAuthorAndExtraCountWhenBothPresent() {
         var entry = entry("t", "https://x", "<p>p</p>", "Jane Doe");
         MessageEmbed embed = RssPublisher.buildEmbed(testFeed(), entry, 3);


### PR DESCRIPTION
## Summary
This PR adds HTML entity decoding for RSS feed titles and author names to ensure special characters are properly displayed in Discord embeds. Feeds that escape punctuation (e.g., `&#8217;` for apostrophes, `&amp;` for ampersands) now render correctly.

## Key Changes
- Added `decodeEntities()` helper method using jsoup's `Parser.unescapeEntities()` to decode HTML entities without stripping or interpreting tags
- Applied entity decoding to:
  - Feed titles (displayed in embed author slot)
  - Entry titles (displayed in embed title)
  - Entry authors (displayed in embed footer)
  - Feed titles during validation in `RssFetcher`
- Added comprehensive test coverage for entity decoding in both entry titles/authors and feed titles

## Implementation Details
- Uses jsoup's `Parser.unescapeEntities(value, false)` which safely decodes entities without HTML parsing
- The `false` parameter ensures tags are not stripped or interpreted
- Handles null values gracefully in the `decodeEntities()` method
- Decoding is applied before truncation to ensure accurate length calculations

https://claude.ai/code/session_015sYN8x1Lci148YUci3TMsx