### PR TITLE
Support multiple Chatterbox stacks with shared Traefik instance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,12 @@ LETSENCRYPT_CA_SERVER=https://acme-v02.api.letsencrypt.org/directory
 # multiple chatterbox stacks side-by-side (e.g. prod + staging on one VPS) to
 # avoid name collisions.
 TRAEFIK_NETWORK_NAME=chatterbox-web
+# Traefik router/service name for this stack. Must be unique across all
+# chatterbox stacks sharing the same Traefik instance — when prod + staging run
+# on one VPS they need different values here, otherwise Traefik logs "Router
+# defined multiple times with different configurations" and falls back to its
+# default cert. Set staging to e.g. chatterbox-staging.
+TRAEFIK_ROUTER_NAME=chatterbox
 
 # Postgres backup schedule (cron syntax or @daily/@hourly/@weekly).
 BACKUP_SCHEDULE=@daily

--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ private to the Docker network.
 | `LETSENCRYPT_EMAIL`     | yes                                 | —       | Email used for ACME registration / expiry notices. |
 | `LETSENCRYPT_CA_SERVER` | no                                  | LE prod | ACME directory URL. Use `https://acme-staging-v02.api.letsencrypt.org/directory` for non-production deployments to avoid the prod CA's tight rate limits. |
 | `TRAEFIK_NETWORK_NAME`  | no                                  | `chatterbox-web` | Docker network used between Traefik and the bot. Override on hosts running multiple chatterbox stacks side-by-side (e.g. prod + staging) so the network names don't collide. |
+| `TRAEFIK_ROUTER_NAME`   | no                                  | `chatterbox`     | Traefik router/service name and the value of the `chatterbox.stack` label that each Traefik instance filters on via constraint. Must be unique across all stacks any single Traefik instance is watching. Set staging to e.g. `chatterbox-staging` when prod and staging share a host, otherwise Traefik logs `Router defined multiple times with different configurations` and falls back to its default cert. |
 
 HTTP traffic on `:80` is unconditionally redirected to HTTPS on `:443`.
 Certificates are issued via the LetsEncrypt HTTP-01 challenge and persisted

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,11 +117,12 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.docker.network=${TRAEFIK_NETWORK_NAME:-chatterbox-web}"
-      - "traefik.http.routers.chatterbox.rule=Host(`${SHORTENER_DOMAIN:?SHORTENER_DOMAIN must be set}`)${SHORTENER_PATH_PREFIX:+ && PathPrefix(`${SHORTENER_PATH_PREFIX}`)}"
-      - "traefik.http.routers.chatterbox.entrypoints=websecure"
-      - "traefik.http.routers.chatterbox.tls=true"
-      - "traefik.http.routers.chatterbox.tls.certresolver=letsencrypt"
-      - "traefik.http.services.chatterbox.loadbalancer.server.port=${CHATTERBOX_HTTP_PORT:-8080}"
+      - "chatterbox.stack=${TRAEFIK_ROUTER_NAME:-chatterbox}"
+      - "traefik.http.routers.${TRAEFIK_ROUTER_NAME:-chatterbox}.rule=Host(`${SHORTENER_DOMAIN:?SHORTENER_DOMAIN must be set}`)${SHORTENER_PATH_PREFIX:+ && PathPrefix(`${SHORTENER_PATH_PREFIX}`)}"
+      - "traefik.http.routers.${TRAEFIK_ROUTER_NAME:-chatterbox}.entrypoints=websecure"
+      - "traefik.http.routers.${TRAEFIK_ROUTER_NAME:-chatterbox}.tls=true"
+      - "traefik.http.routers.${TRAEFIK_ROUTER_NAME:-chatterbox}.tls.certresolver=letsencrypt"
+      - "traefik.http.services.${TRAEFIK_ROUTER_NAME:-chatterbox}.loadbalancer.server.port=${CHATTERBOX_HTTP_PORT:-8080}"
     deploy:
       resources:
         limits:
@@ -139,6 +140,7 @@ services:
       - "--providers.docker=true"
       - "--providers.docker.exposedbydefault=false"
       - "--providers.docker.network=${TRAEFIK_NETWORK_NAME:-chatterbox-web}"
+      - "--providers.docker.constraints=Label(`chatterbox.stack`,`${TRAEFIK_ROUTER_NAME:-chatterbox}`)"
       - "--entrypoints.web.address=:80"
       - "--entrypoints.web.http.redirections.entrypoint.to=websecure"
       - "--entrypoints.web.http.redirections.entrypoint.scheme=https"


### PR DESCRIPTION
## Summary
This change enables running multiple Chatterbox stacks (e.g., production and staging) on the same host with a shared Traefik instance by introducing a configurable router/service name that prevents configuration collisions.

## Key Changes
- Added `TRAEFIK_ROUTER_NAME` environment variable (defaults to `chatterbox`) to make Traefik router and service names configurable
- Updated all Traefik labels in docker-compose.yml to use `${TRAEFIK_ROUTER_NAME:-chatterbox}` instead of hardcoded `chatterbox` references
- Added a `chatterbox.stack` label to the Chatterbox service for stack identification
- Configured Traefik to filter services using a Docker constraint on the `chatterbox.stack` label, ensuring each Traefik instance only manages its designated stack
- Updated `.env.example` with the new `TRAEFIK_ROUTER_NAME` variable and documentation
- Updated README.md with configuration table entry explaining the new variable and its purpose

## Implementation Details
The solution uses Traefik's Docker label constraints to isolate stacks. When multiple Chatterbox instances share a Traefik container, each stack must have a unique `TRAEFIK_ROUTER_NAME` value. This prevents the "Router defined multiple times with different configurations" error that would otherwise cause Traefik to fall back to default certificates.

Example: Set `TRAEFIK_ROUTER_NAME=chatterbox-staging` for a staging environment running alongside production with `TRAEFIK_ROUTER_NAME=chatterbox`.

https://claude.ai/code/session_0132oNuqJjJkwHKVF5dhq1gX