### PR TITLE
Add delete and peek subcommands to /shorten; soft-delete support

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,22 +342,54 @@ Two workflows under `.github/workflows/`:
 Stores HTTP(S) URLs against a 6-character lowercase alphanumeric token and
 exposes a redirect endpoint behind the bot's HTTP server.
 
-#### `/shorten url:<URL>`
+#### `/shorten create url:<URL>`
 
 Validates the URL (must be HTTP or HTTPS with a host) and replies privately
-with the short URL constructed from `CHATTERBOX_SHORTENER_BASE_URL`. The
-URL is deduplicated globally — if any user has already shortened the same
-URL, that user's existing token is returned. Token collisions retry up to
-ten times before surfacing an error.
+with the short URL constructed from `CHATTERBOX_SHORTENER_BASE_URL`. Live
+URLs are deduplicated globally — if any user has already shortened the same
+URL and the row is still active, that token is returned. Token collisions
+retry up to ten times before surfacing an error.
 
 The original creator (Discord user id) and the slash command's timestamp
 are recorded alongside each row.
 
+#### `/shorten delete target:<URL or token>`
+
+Restricted to users with the **Manage Messages** permission in the channel.
+Accepts either the bare 6-character short code or the full short URL (the
+prefix must match `CHATTERBOX_SHORTENER_BASE_URL`). Replies ephemerally
+with an embed showing the destination, the original creator (as a Discord
+mention), and the creation timestamp, plus **Delete** / **Cancel** buttons.
+
+On confirmation the row is **soft-deleted**: `deleted_at` and `deleted_by`
+are stamped onto the row and live lookups stop returning it. The token is
+permanently retired (the unique index covers deleted rows too) so the same
+short URL can never resolve to anything else later. The original
+destination URL becomes available for re-shortening — a fresh request mints
+a brand-new token. There is no restore path.
+
+The Manage Messages check runs again on the **Delete** button click to
+defend against role removal between rendering and confirming.
+
+#### `/shorten peek target:<URL or token> [share:<bool>]`
+
+Available to everyone. Reveals where a short URL points without following
+it — useful for vetting a suspicious link before clicking. Replies
+ephemerally by default; pass `share:true` to post the result to the channel
+instead (e.g. so a moderator can warn others publicly).
+
 #### `GET /{token}`
 
-Public endpoint exposed via Javalin. Returns `301 Moved Permanently` with
-the original URL in the `Location` header on hit, or `404` on miss. Token
-lookups are case-insensitive.
+Public endpoint exposed via Javalin. Outcomes:
+
+- **Live token** — `301 Moved Permanently` with the original URL in the
+  `Location` header plus a tiny HTML body carrying an anchor (matches
+  bit.ly's shape so Discord's preview crawler unfurls it correctly).
+- **Soft-deleted token** — `410 Gone`. Tokens are never reissued, so this
+  is a permanent state; 410 communicates that more accurately than 404.
+- **Unknown token** — `404 Not Found`.
+
+Token lookups are case-insensitive.
 
 ### Shout
 

--- a/src/generated/jooq/ca/ryanmorrison/chatterbox/db/generated/tables/ShortenedUrls.java
+++ b/src/generated/jooq/ca/ryanmorrison/chatterbox/db/generated/tables/ShortenedUrls.java
@@ -80,6 +80,16 @@ public class ShortenedUrls extends TableImpl<ShortenedUrlsRecord> {
      */
     public final TableField<ShortenedUrlsRecord, OffsetDateTime> CREATED_AT = createField(DSL.name("created_at"), SQLDataType.TIMESTAMPWITHTIMEZONE(6).nullable(false), this, "");
 
+    /**
+     * The column <code>public.shortened_urls.deleted_at</code>.
+     */
+    public final TableField<ShortenedUrlsRecord, OffsetDateTime> DELETED_AT = createField(DSL.name("deleted_at"), SQLDataType.TIMESTAMPWITHTIMEZONE(6), this, "");
+
+    /**
+     * The column <code>public.shortened_urls.deleted_by</code>.
+     */
+    public final TableField<ShortenedUrlsRecord, Long> DELETED_BY = createField(DSL.name("deleted_by"), SQLDataType.BIGINT, this, "");
+
     private ShortenedUrls(Name alias, Table<ShortenedUrlsRecord> aliased) {
         this(alias, aliased, (Field<?>[]) null, null);
     }

--- a/src/generated/jooq/ca/ryanmorrison/chatterbox/db/generated/tables/records/ShortenedUrlsRecord.java
+++ b/src/generated/jooq/ca/ryanmorrison/chatterbox/db/generated/tables/records/ShortenedUrlsRecord.java
@@ -90,6 +90,34 @@ public class ShortenedUrlsRecord extends UpdatableRecordImpl<ShortenedUrlsRecord
         return (OffsetDateTime) get(4);
     }
 
+    /**
+     * Setter for <code>public.shortened_urls.deleted_at</code>.
+     */
+    public void setDeletedAt(OffsetDateTime value) {
+        set(5, value);
+    }
+
+    /**
+     * Getter for <code>public.shortened_urls.deleted_at</code>.
+     */
+    public OffsetDateTime getDeletedAt() {
+        return (OffsetDateTime) get(5);
+    }
+
+    /**
+     * Setter for <code>public.shortened_urls.deleted_by</code>.
+     */
+    public void setDeletedBy(Long value) {
+        set(6, value);
+    }
+
+    /**
+     * Getter for <code>public.shortened_urls.deleted_by</code>.
+     */
+    public Long getDeletedBy() {
+        return (Long) get(6);
+    }
+
     // -------------------------------------------------------------------------
     // Primary key information
     // -------------------------------------------------------------------------
@@ -113,7 +141,7 @@ public class ShortenedUrlsRecord extends UpdatableRecordImpl<ShortenedUrlsRecord
     /**
      * Create a detached, initialised ShortenedUrlsRecord
      */
-    public ShortenedUrlsRecord(Long id, String token, String url, Long createdBy, OffsetDateTime createdAt) {
+    public ShortenedUrlsRecord(Long id, String token, String url, Long createdBy, OffsetDateTime createdAt, OffsetDateTime deletedAt, Long deletedBy) {
         super(ShortenedUrls.SHORTENED_URLS);
 
         setId(id);
@@ -121,6 +149,8 @@ public class ShortenedUrlsRecord extends UpdatableRecordImpl<ShortenedUrlsRecord
         setUrl(url);
         setCreatedBy(createdBy);
         setCreatedAt(createdAt);
+        setDeletedAt(deletedAt);
+        setDeletedBy(deletedBy);
         resetTouchedOnNotNull();
     }
 }

--- a/src/main/java/ca/ryanmorrison/chatterbox/common/permissions/Permissions.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/common/permissions/Permissions.java
@@ -1,0 +1,64 @@
+package ca.ryanmorrison.chatterbox.common.permissions;
+
+import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
+import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback;
+
+/**
+ * Shared permission checks. Centralises the {@link Permission#MESSAGE_MANAGE}
+ * "channel moderator" gate that several modules used to roll inline; routes
+ * a single user-facing rejection message so feedback is consistent.
+ */
+public final class Permissions {
+
+    private static final String NOT_A_GUILD_MESSAGE =
+            "This command is only available in servers.";
+    private static final String MISSING_MANAGE_MESSAGES_MESSAGE =
+            "You need the **Manage Messages** permission in this channel to do that.";
+
+    private Permissions() {}
+
+    /**
+     * Pure check: does {@code member} have {@link Permission#MESSAGE_MANAGE}
+     * in {@code channel}? Tolerant of {@code null} inputs (returns false) so
+     * callers can pass through DM/system contexts without pre-validating.
+     */
+    public static boolean canManageMessages(Member member, GuildChannel channel) {
+        return member != null
+                && channel != null
+                && member.hasPermission(channel, Permission.MESSAGE_MANAGE);
+    }
+
+    /**
+     * Same as {@link #canManageMessages(Member, GuildChannel)} but pulls the
+     * member and channel off the interaction event for convenience at slash /
+     * button handler entry points.
+     */
+    public static boolean canManageMessages(IReplyCallback event) {
+        return canManageMessages(event.getMember(), event.getGuildChannel());
+    }
+
+    /**
+     * Gate for the start of an interaction handler: returns true if the caller
+     * is a channel moderator, otherwise replies with an ephemeral rejection
+     * message and returns false. Caller should early-return on false.
+     *
+     * <p>Distinguishes the "not in a guild" case (DMs, system messages) from
+     * the "in a guild but lacks the permission" case so the error message
+     * actually tells the user why.
+     */
+    public static boolean requireManageMessages(IReplyCallback event) {
+        Member member = event.getMember();
+        GuildChannel channel = event.getGuildChannel();
+        if (member == null || channel == null) {
+            event.reply(NOT_A_GUILD_MESSAGE).setEphemeral(true).queue();
+            return false;
+        }
+        if (!member.hasPermission(channel, Permission.MESSAGE_MANAGE)) {
+            event.reply(MISSING_MANAGE_MESSAGES_MESSAGE).setEphemeral(true).queue();
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/autoreply/AutoReplyHandler.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/autoreply/AutoReplyHandler.java
@@ -1,6 +1,6 @@
 package ca.ryanmorrison.chatterbox.features.autoreply;
 
-import net.dv8tion.jda.api.Permission;
+import ca.ryanmorrison.chatterbox.common.permissions.Permissions;
 import net.dv8tion.jda.api.components.actionrow.ActionRow;
 import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.components.label.Label;
@@ -8,14 +8,11 @@ import net.dv8tion.jda.api.components.selections.SelectOption;
 import net.dv8tion.jda.api.components.selections.StringSelectMenu;
 import net.dv8tion.jda.api.components.textinput.TextInput;
 import net.dv8tion.jda.api.components.textinput.TextInputStyle;
-import net.dv8tion.jda.api.entities.Member;
-import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
 import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.component.StringSelectInteractionEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
-import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback;
 import net.dv8tion.jda.api.modals.Modal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,7 +72,7 @@ final class AutoReplyHandler extends ListenerAdapter {
     @Override
     public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
         if (!CMD_NAME.equals(event.getName())) return;
-        if (!requireModerator(event)) return;
+        if (!Permissions.requireManageMessages(event)) return;
         String sub = event.getSubcommandName();
         if (sub == null) return;
         switch (sub) {
@@ -135,7 +132,7 @@ final class AutoReplyHandler extends ListenerAdapter {
     public void onModalInteraction(ModalInteractionEvent event) {
         String id = event.getModalId();
         if (!id.startsWith(PREFIX)) return;
-        if (!requireModerator(event)) return;
+        if (!Permissions.requireManageMessages(event)) return;
 
         if (id.equals(MODAL_ADD)) {
             handleAddSubmit(event);
@@ -219,7 +216,7 @@ final class AutoReplyHandler extends ListenerAdapter {
     public void onStringSelectInteraction(StringSelectInteractionEvent event) {
         String id = event.getComponentId();
         if (!id.startsWith(PREFIX)) return;
-        if (!requireModerator(event)) return;
+        if (!Permissions.requireManageMessages(event)) return;
 
         long ruleId;
         try {
@@ -254,7 +251,7 @@ final class AutoReplyHandler extends ListenerAdapter {
     public void onButtonInteraction(ButtonInteractionEvent event) {
         String id = event.getComponentId();
         if (!id.startsWith(PREFIX)) return;
-        if (!requireModerator(event)) return;
+        if (!Permissions.requireManageMessages(event)) return;
 
         if (id.startsWith(OVERRIDE_CONFIRM)) {
             handleOverrideConfirm(event, id.substring(OVERRIDE_CONFIRM.length()));
@@ -403,20 +400,5 @@ final class AutoReplyHandler extends ListenerAdapter {
 
     private static String truncate(String s, int max) {
         return s.length() <= max ? s : s.substring(0, max - 1) + "…";
-    }
-
-    private static boolean requireModerator(IReplyCallback event) {
-        Member member = event.getMember();
-        GuildChannel channel = event.getGuildChannel();
-        if (member == null || channel == null) {
-            event.reply("This command is only available in servers.").setEphemeral(true).queue();
-            return false;
-        }
-        if (!member.hasPermission(channel, Permission.MESSAGE_MANAGE)) {
-            event.reply("You need the **Manage Messages** permission in this channel to use `/autoreply`.")
-                    .setEphemeral(true).queue();
-            return false;
-        }
-        return true;
     }
 }

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/rss/RssHandler.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/rss/RssHandler.java
@@ -1,12 +1,11 @@
 package ca.ryanmorrison.chatterbox.features.rss;
 
-import net.dv8tion.jda.api.Permission;
+import ca.ryanmorrison.chatterbox.common.permissions.Permissions;
 import net.dv8tion.jda.api.components.actionrow.ActionRow;
 import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.components.selections.SelectOption;
 import net.dv8tion.jda.api.components.selections.StringSelectMenu;
 import net.dv8tion.jda.api.entities.Member;
-import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.component.StringSelectInteractionEvent;
@@ -139,7 +138,7 @@ final class RssHandler extends ListenerAdapter {
     private void handleRemove(SlashCommandInteractionEvent event) {
         long channelId = event.getChannel().getIdLong();
         long userId = event.getUser().getIdLong();
-        boolean isModerator = hasManageMessages(event);
+        boolean isModerator = Permissions.canManageMessages(event);
 
         List<Feed> all = repo.listByChannel(channelId);
         List<Feed> visible = isModerator
@@ -277,14 +276,8 @@ final class RssHandler extends ListenerAdapter {
         return true;
     }
 
-    private static boolean hasManageMessages(IReplyCallback event) {
-        Member member = event.getMember();
-        GuildChannel channel = event.getGuildChannel();
-        return member != null && channel != null && member.hasPermission(channel, Permission.MESSAGE_MANAGE);
-    }
-
     private static boolean canRemove(IReplyCallback event, Feed feed) {
-        if (hasManageMessages(event)) return true;
+        if (Permissions.canManageMessages(event)) return true;
         Member m = event.getMember();
         return m != null && m.getIdLong() == feed.addedBy();
     }

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/shortener/ShortenedUrl.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/shortener/ShortenedUrl.java
@@ -1,5 +1,18 @@
 package ca.ryanmorrison.chatterbox.features.shortener;
 
 import java.time.OffsetDateTime;
+import java.util.Optional;
 
-record ShortenedUrl(long id, String token, String url, long createdBy, OffsetDateTime createdAt) {}
+record ShortenedUrl(
+        long id,
+        String token,
+        String url,
+        long createdBy,
+        OffsetDateTime createdAt,
+        Optional<OffsetDateTime> deletedAt,
+        Optional<Long> deletedBy) {
+
+    boolean isDeleted() {
+        return deletedAt.isPresent();
+    }
+}

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/shortener/ShortenerHandler.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/shortener/ShortenerHandler.java
@@ -1,7 +1,13 @@
 package ca.ryanmorrison.chatterbox.features.shortener;
 
+import ca.ryanmorrison.chatterbox.common.permissions.Permissions;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.components.actionrow.ActionRow;
+import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -10,22 +16,46 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 /**
- * Handles {@code /shorten <url>}. Responsibilities:
- * <ol>
- *   <li>Validate the input URL (HTTP/HTTPS only).</li>
- *   <li>Return an existing token if the URL has been shortened before.</li>
- *   <li>Otherwise generate a token, insert, and retry on collision up to
- *       {@link #MAX_TOKEN_ATTEMPTS} times.</li>
- *   <li>Resolve the short URL prefix lazily — only fail when the command is
- *       actually invoked, so the bot can run without the shortener configured
- *       as long as nobody calls the command.</li>
- * </ol>
+ * Handles all interactions for the {@code /shorten} command. Subcommands:
+ * <ul>
+ *   <li>{@code create url:<URL>} — anyone; mints (or returns the existing)
+ *       short URL.</li>
+ *   <li>{@code delete target:<URL or token>} — moderators only ({@link
+ *       Permissions#requireManageMessages}); soft-deletes after a button
+ *       confirmation showing destination, creator, and creation time.</li>
+ *   <li>{@code peek target:<URL or token> [share:<bool>]} — anyone; reveals
+ *       the destination URL. Ephemeral by default; the caller can opt in to a
+ *       channel-visible reply with {@code share:true}.</li>
+ * </ul>
+ *
+ * <p>Also handles the confirm/cancel buttons attached to delete prompts. The
+ * row id is encoded in the component id, and the moderator permission is
+ * re-checked on the click in case the role was lost between rendering and
+ * confirming.
+ *
+ * <p>Resolves the public-facing base URL lazily — callers that don't use the
+ * shortener never trigger the {@code CHATTERBOX_SHORTENER_BASE_URL} requirement.
  */
 final class ShortenerHandler extends ListenerAdapter {
 
     static final String COMMAND = "shorten";
+    static final String SUB_CREATE = "create";
+    static final String SUB_DELETE = "delete";
+    static final String SUB_PEEK = "peek";
     static final String OPTION_URL = "url";
+    static final String OPTION_TARGET = "target";
+    static final String OPTION_SHARE = "share";
     static final int MAX_TOKEN_ATTEMPTS = 10;
+
+    static final String BUTTON_DELETE_CONFIRM_PREFIX = "shorten:delete-confirm:";
+    static final String BUTTON_DELETE_CANCEL_PREFIX = "shorten:delete-cancel:";
+
+    private static final String NOT_FOUND_MESSAGE =
+            "No short URL matches that target.";
+    private static final String NOT_CONFIGURED_MESSAGE =
+            "URL shortener is not configured on this bot.";
+    private static final String INVALID_TARGET_MESSAGE =
+            "Target must be a 6-character short code or a full short URL.";
 
     private static final Logger log = LoggerFactory.getLogger(ShortenerHandler.class);
 
@@ -43,8 +73,30 @@ final class ShortenerHandler extends ListenerAdapter {
     @Override
     public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
         if (!COMMAND.equals(event.getName())) return;
+        String sub = event.getSubcommandName();
+        if (sub == null) return;
+        switch (sub) {
+            case SUB_CREATE -> handleCreate(event);
+            case SUB_DELETE -> handleDelete(event);
+            case SUB_PEEK   -> handlePeek(event);
+            default -> { /* unknown subcommand — silently ignore */ }
+        }
+    }
 
-        var urlOption = event.getOption(OPTION_URL);
+    @Override
+    public void onButtonInteraction(ButtonInteractionEvent event) {
+        String id = event.getComponentId();
+        if (id.startsWith(BUTTON_DELETE_CONFIRM_PREFIX)) {
+            handleDeleteConfirm(event, id.substring(BUTTON_DELETE_CONFIRM_PREFIX.length()));
+        } else if (id.startsWith(BUTTON_DELETE_CANCEL_PREFIX)) {
+            handleDeleteCancel(event);
+        }
+    }
+
+    // -- create -------------------------------------------------------------
+
+    private void handleCreate(SlashCommandInteractionEvent event) {
+        OptionMapping urlOption = event.getOption(OPTION_URL);
         String url = urlOption == null ? null : urlOption.getAsString();
 
         if (!UrlValidator.isValidHttpUrl(url)) {
@@ -52,14 +104,8 @@ final class ShortenerHandler extends ListenerAdapter {
             return;
         }
 
-        String baseUrl;
-        try {
-            baseUrl = baseUrlSupplier.get();
-        } catch (RuntimeException e) {
-            log.warn("Shortener invoked without a configured base URL.", e);
-            event.reply("URL shortener is not configured on this bot.").setEphemeral(true).queue();
-            return;
-        }
+        String baseUrl = resolveBaseUrlOrReply(event);
+        if (baseUrl == null) return;
 
         String trimmedUrl = url.trim();
 
@@ -92,7 +138,135 @@ final class ShortenerHandler extends ListenerAdapter {
                 .setEphemeral(true).queue();
     }
 
+    // -- delete -------------------------------------------------------------
+
+    private void handleDelete(SlashCommandInteractionEvent event) {
+        if (!Permissions.requireManageMessages(event)) return;
+
+        String baseUrl = resolveBaseUrlOrReply(event);
+        if (baseUrl == null) return;
+
+        String target = optionString(event, OPTION_TARGET);
+        Optional<String> token = TargetParser.extractToken(target, baseUrl);
+        if (token.isEmpty()) {
+            event.reply(INVALID_TARGET_MESSAGE).setEphemeral(true).queue();
+            return;
+        }
+
+        Optional<ShortenedUrl> match = repository.findByToken(token.get());
+        if (match.isEmpty()) {
+            event.reply(NOT_FOUND_MESSAGE).setEphemeral(true).queue();
+            return;
+        }
+
+        ShortenedUrl entry = match.get();
+        event.replyEmbeds(buildDeleteConfirmEmbed(entry, baseUrl))
+                .setEphemeral(true)
+                .setComponents(ActionRow.of(
+                        Button.danger(BUTTON_DELETE_CONFIRM_PREFIX + entry.id(), "Delete"),
+                        Button.secondary(BUTTON_DELETE_CANCEL_PREFIX + entry.id(), "Cancel")))
+                .queue();
+    }
+
+    private void handleDeleteConfirm(ButtonInteractionEvent event, String idStr) {
+        if (!Permissions.requireManageMessages(event)) return;
+
+        long id;
+        try {
+            id = Long.parseLong(idStr);
+        } catch (NumberFormatException e) {
+            event.editMessage("Invalid delete request.").setComponents().queue();
+            return;
+        }
+
+        Optional<ShortenedUrl> entry = repository.findByIdIncludingDeleted(id);
+        if (entry.isEmpty()) {
+            event.editMessage("That short URL no longer exists.").setEmbeds().setComponents().queue();
+            return;
+        }
+        if (entry.get().isDeleted()) {
+            event.editMessage("Already deleted.").setEmbeds().setComponents().queue();
+            return;
+        }
+
+        long deletedBy = event.getUser().getIdLong();
+        OffsetDateTime deletedAt = event.getTimeCreated();
+        int updated = repository.softDelete(id, deletedBy, deletedAt);
+        if (updated == 0) {
+            // Race: someone else just deleted it.
+            event.editMessage("Already deleted.").setEmbeds().setComponents().queue();
+            return;
+        }
+
+        event.editMessage("Deleted `" + entry.get().token() + "`.").setEmbeds().setComponents().queue();
+    }
+
+    private void handleDeleteCancel(ButtonInteractionEvent event) {
+        event.editMessage("Cancelled.").setEmbeds().setComponents().queue();
+    }
+
+    // -- peek ---------------------------------------------------------------
+
+    private void handlePeek(SlashCommandInteractionEvent event) {
+        String baseUrl = resolveBaseUrlOrReply(event);
+        if (baseUrl == null) return;
+
+        String target = optionString(event, OPTION_TARGET);
+        Optional<String> token = TargetParser.extractToken(target, baseUrl);
+        if (token.isEmpty()) {
+            event.reply(INVALID_TARGET_MESSAGE).setEphemeral(true).queue();
+            return;
+        }
+
+        Optional<ShortenedUrl> match = repository.findByToken(token.get());
+        if (match.isEmpty()) {
+            event.reply(NOT_FOUND_MESSAGE).setEphemeral(true).queue();
+            return;
+        }
+
+        boolean share = optionBoolean(event, OPTION_SHARE, false);
+        ShortenedUrl entry = match.get();
+        String reply = "`" + buildShortUrl(baseUrl, entry.token()) + "` → " + entry.url();
+        event.reply(reply).setEphemeral(!share).queue();
+    }
+
+    // -- helpers ------------------------------------------------------------
+
+    private String resolveBaseUrlOrReply(net.dv8tion.jda.api.interactions.callbacks.IReplyCallback event) {
+        try {
+            return baseUrlSupplier.get();
+        } catch (RuntimeException e) {
+            log.warn("Shortener invoked without a configured base URL.", e);
+            event.reply(NOT_CONFIGURED_MESSAGE).setEphemeral(true).queue();
+            return null;
+        }
+    }
+
+    private static String optionString(SlashCommandInteractionEvent event, String name) {
+        OptionMapping opt = event.getOption(name);
+        return opt == null ? null : opt.getAsString();
+    }
+
+    private static boolean optionBoolean(SlashCommandInteractionEvent event, String name, boolean fallback) {
+        OptionMapping opt = event.getOption(name);
+        return opt == null ? fallback : opt.getAsBoolean();
+    }
+
     private static String buildShortUrl(String baseUrl, String token) {
         return baseUrl.endsWith("/") ? baseUrl + token : baseUrl + "/" + token;
+    }
+
+    private static net.dv8tion.jda.api.entities.MessageEmbed buildDeleteConfirmEmbed(
+            ShortenedUrl entry, String baseUrl) {
+        long createdAtSeconds = entry.createdAt().toEpochSecond();
+        return new EmbedBuilder()
+                .setTitle("Delete short URL?")
+                .setColor(0xE74C3C)
+                .addField("Short URL", "`" + buildShortUrl(baseUrl, entry.token()) + "`", false)
+                .addField("Destination", entry.url(), false)
+                .addField("Created by", "<@" + entry.createdBy() + ">", true)
+                .addField("Created", "<t:" + createdAtSeconds + ":f> (<t:" + createdAtSeconds + ":R>)", true)
+                .setFooter("This cannot be undone. The token will not be reissued.")
+                .build();
     }
 }

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/shortener/ShortenerModule.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/shortener/ShortenerModule.java
@@ -7,18 +7,26 @@ import net.dv8tion.jda.api.hooks.EventListener;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
+import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
 
 import java.util.List;
 
 /**
  * URL shortener feature.
  *
- * <p>Slash command: {@code /shorten <url>}. Stores HTTP(S) URLs against a
- * 6-character lowercase alphanumeric token, deduplicating by URL across users.
+ * <p>Slash command: {@code /shorten} with three subcommands:
+ * <ul>
+ *   <li>{@code create url:<URL>} — anyone; mints (or returns the existing)
+ *       short URL for an HTTP(S) URL.</li>
+ *   <li>{@code delete target:<URL or token>} — moderators only; soft-deletes
+ *       a short URL after a button confirmation.</li>
+ *   <li>{@code peek target:<URL or token> [share:<bool>]} — anyone; reveals
+ *       a short URL's destination, ephemerally by default.</li>
+ * </ul>
  *
- * <p>HTTP route: {@code GET /{token}} → 301 redirect to the original URL, or
- * 404 if unknown. The bot-wide HTTP server only binds when this (or another)
- * module registers a route.
+ * <p>HTTP route: {@code GET /{token}} → 301 redirect to the original URL,
+ * 410 Gone if the token has been soft-deleted, 404 if unknown. The bot-wide
+ * HTTP server only binds when this (or another) module registers a route.
  *
  * <p>Configuration: the public-facing prefix used to construct the link
  * returned to Discord users is read lazily from
@@ -41,9 +49,21 @@ public final class ShortenerModule implements Module {
 
     @Override
     public List<SlashCommandData> slashCommands(InitContext ctx) {
-        return List.of(Commands.slash(ShortenerHandler.COMMAND, "Shorten an HTTP(S) URL.")
-                .addOption(OptionType.STRING, ShortenerHandler.OPTION_URL,
-                        "The HTTP(S) URL to shorten.", true));
+        return List.of(Commands.slash(ShortenerHandler.COMMAND, "Manage short URLs.")
+                .addSubcommands(
+                        new SubcommandData(ShortenerHandler.SUB_CREATE, "Shorten an HTTP(S) URL.")
+                                .addOption(OptionType.STRING, ShortenerHandler.OPTION_URL,
+                                        "The HTTP(S) URL to shorten.", true),
+                        new SubcommandData(ShortenerHandler.SUB_DELETE,
+                                "Soft-delete a short URL (Manage Messages required).")
+                                .addOption(OptionType.STRING, ShortenerHandler.OPTION_TARGET,
+                                        "Full short URL or 6-character short code.", true),
+                        new SubcommandData(ShortenerHandler.SUB_PEEK,
+                                "Show where a short URL points without following it.")
+                                .addOption(OptionType.STRING, ShortenerHandler.OPTION_TARGET,
+                                        "Full short URL or 6-character short code.", true)
+                                .addOption(OptionType.BOOLEAN, ShortenerHandler.OPTION_SHARE,
+                                        "Post the result to the channel instead of just to you.", false)));
     }
 
     @Override

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/shortener/ShortenerRedirectHandler.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/shortener/ShortenerRedirectHandler.java
@@ -8,10 +8,18 @@ import java.util.Locale;
 import java.util.Optional;
 
 /**
- * Javalin handler for {@code GET /{token}}. On hit, returns 301 with the
- * original URL in the {@code Location} header plus a tiny HTML body
- * carrying an anchor to the destination — matches the shape bit.ly serves,
- * which Discord's link-preview crawler unfurls correctly. On miss, 404.
+ * Javalin handler for {@code GET /{token}}.
+ *
+ * <p>Outcomes:
+ * <ul>
+ *   <li><b>Live token</b>: 301 with the original URL in the {@code Location}
+ *       header plus a tiny HTML body carrying an anchor — matches bit.ly's
+ *       shape, which Discord's link-preview crawler unfurls correctly.</li>
+ *   <li><b>Soft-deleted token</b>: 410 Gone. Tokens are never reissued, so
+ *       this is a permanent state — 410 communicates that more accurately
+ *       than 404 to crawlers.</li>
+ *   <li><b>Unknown token</b>: 404.</li>
+ * </ul>
  *
  * <p>Tokens are looked up in lowercase since the alphabet is case-insensitive.
  */
@@ -30,12 +38,17 @@ final class ShortenerRedirectHandler implements Handler {
     public void handle(Context ctx) {
         String token = ctx.pathParam(PATH_PARAM).toLowerCase(Locale.ROOT);
 
-        Optional<ShortenedUrl> match = repository.findByToken(token);
+        Optional<ShortenedUrl> match = repository.findByTokenIncludingDeleted(token);
         if (match.isEmpty()) {
             ctx.status(HttpStatus.NOT_FOUND).result("Not found.");
             return;
         }
-        String url = match.get().url();
+        ShortenedUrl entry = match.get();
+        if (entry.isDeleted()) {
+            ctx.status(HttpStatus.GONE).result("This short URL has been removed.");
+            return;
+        }
+        String url = entry.url();
         ctx.status(HttpStatus.MOVED_PERMANENTLY)
                 .header("Location", url)
                 .contentType("text/html; charset=utf-8")

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/shortener/ShortenerRepository.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/shortener/ShortenerRepository.java
@@ -12,14 +12,19 @@ import static ca.ryanmorrison.chatterbox.db.generated.Tables.SHORTENED_URLS;
 /**
  * jOOQ-backed access for the {@code shortened_urls} table.
  *
- * <p>Concurrency notes:
+ * <p>Concurrency / dedup notes:
  * <ul>
- *   <li>{@code token} is unique — {@link #insert} surfaces an empty Optional on
- *       collision so the caller can retry with a fresh token.</li>
- *   <li>{@code url} is unique — global dedup is enforced at the DB level.
- *       Callers should {@link #findByUrl} first; if two requests race past
- *       that check, the loser also gets an empty Optional and can re-read.</li>
+ *   <li>{@code token} is unconditionally unique — even soft-deleted rows hold
+ *       their token reservation, so a reissued short link can never collide
+ *       with a deleted one (the moderator's intent: no token reuse).</li>
+ *   <li>{@code url} uniqueness is partial: only enforced for live rows
+ *       ({@code WHERE deleted_at IS NULL}). After a delete, the same URL can
+ *       be shortened again, producing a fresh token in a new row.</li>
  * </ul>
+ *
+ * <p>Lookups exclude soft-deleted rows by default. Methods with the
+ * {@code IncludingDeleted} suffix are provided for the redirect handler so
+ * tombstoned tokens can return {@code 410 Gone} rather than {@code 404}.
  */
 final class ShortenerRepository {
 
@@ -32,6 +37,21 @@ final class ShortenerRepository {
     Optional<ShortenedUrl> findByToken(String token) {
         return dsl.selectFrom(SHORTENED_URLS)
                 .where(SHORTENED_URLS.TOKEN.eq(token))
+                .and(SHORTENED_URLS.DELETED_AT.isNull())
+                .fetchOptional()
+                .map(ShortenerRepository::toShortenedUrl);
+    }
+
+    Optional<ShortenedUrl> findByTokenIncludingDeleted(String token) {
+        return dsl.selectFrom(SHORTENED_URLS)
+                .where(SHORTENED_URLS.TOKEN.eq(token))
+                .fetchOptional()
+                .map(ShortenerRepository::toShortenedUrl);
+    }
+
+    Optional<ShortenedUrl> findByIdIncludingDeleted(long id) {
+        return dsl.selectFrom(SHORTENED_URLS)
+                .where(SHORTENED_URLS.ID.eq(id))
                 .fetchOptional()
                 .map(ShortenerRepository::toShortenedUrl);
     }
@@ -39,6 +59,7 @@ final class ShortenerRepository {
     Optional<ShortenedUrl> findByUrl(String url) {
         return dsl.selectFrom(SHORTENED_URLS)
                 .where(SHORTENED_URLS.URL.eq(url))
+                .and(SHORTENED_URLS.DELETED_AT.isNull())
                 .fetchOptional()
                 .map(ShortenerRepository::toShortenedUrl);
     }
@@ -60,12 +81,27 @@ final class ShortenerRepository {
         }
     }
 
+    /**
+     * Idempotent: a second call against an already-deleted row is a no-op,
+     * preserving the original deleter and timestamp.
+     */
+    int softDelete(long id, long deletedBy, OffsetDateTime deletedAt) {
+        return dsl.update(SHORTENED_URLS)
+                .set(SHORTENED_URLS.DELETED_AT, deletedAt)
+                .set(SHORTENED_URLS.DELETED_BY, deletedBy)
+                .where(SHORTENED_URLS.ID.eq(id))
+                .and(SHORTENED_URLS.DELETED_AT.isNull())
+                .execute();
+    }
+
     private static ShortenedUrl toShortenedUrl(Record r) {
         return new ShortenedUrl(
                 r.get(SHORTENED_URLS.ID),
                 r.get(SHORTENED_URLS.TOKEN),
                 r.get(SHORTENED_URLS.URL),
                 r.get(SHORTENED_URLS.CREATED_BY),
-                r.get(SHORTENED_URLS.CREATED_AT));
+                r.get(SHORTENED_URLS.CREATED_AT),
+                Optional.ofNullable(r.get(SHORTENED_URLS.DELETED_AT)),
+                Optional.ofNullable(r.get(SHORTENED_URLS.DELETED_BY)));
     }
 }

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/shortener/TargetParser.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/shortener/TargetParser.java
@@ -1,0 +1,60 @@
+package ca.ryanmorrison.chatterbox.features.shortener;
+
+import java.util.Locale;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+/**
+ * Parses the {@code target} option for {@code /shorten delete} and
+ * {@code /shorten peek} into a token. Accepts either:
+ * <ul>
+ *   <li>a bare 6-char base36 token (e.g. {@code "abc123"}), or</li>
+ *   <li>a full short URL whose prefix matches the bot's configured base
+ *       (e.g. {@code "https://example.com/abc123"}).</li>
+ * </ul>
+ * Lookup by the original destination URL is intentionally not supported —
+ * destinations may be ambiguous or sensitive.
+ */
+final class TargetParser {
+
+    private static final Pattern TOKEN_PATTERN =
+            Pattern.compile("^[a-z0-9]{" + TokenGenerator.LENGTH + "}$");
+
+    private TargetParser() {}
+
+    /**
+     * @param target  user-supplied input (may be null/blank)
+     * @param baseUrl the configured short URL prefix; used to recognise full
+     *                short URLs. Trailing slash optional.
+     * @return the token if recognised, or empty.
+     */
+    static Optional<String> extractToken(String target, String baseUrl) {
+        if (target == null) return Optional.empty();
+        String t = target.trim().toLowerCase(Locale.ROOT);
+        if (t.isEmpty()) return Optional.empty();
+
+        if (TOKEN_PATTERN.matcher(t).matches()) {
+            return Optional.of(t);
+        }
+
+        if (baseUrl != null) {
+            String prefix = baseUrl.trim().toLowerCase(Locale.ROOT);
+            if (!prefix.endsWith("/")) prefix = prefix + "/";
+            if (t.startsWith(prefix)) {
+                String tail = t.substring(prefix.length());
+                // Token must be the next path segment; tolerate trailing slash,
+                // query string, or fragment — but they shouldn't be part of the token.
+                int cut = tail.length();
+                for (int i = 0; i < tail.length(); i++) {
+                    char c = tail.charAt(i);
+                    if (c == '/' || c == '?' || c == '#') { cut = i; break; }
+                }
+                String candidate = tail.substring(0, cut);
+                if (TOKEN_PATTERN.matcher(candidate).matches()) {
+                    return Optional.of(candidate);
+                }
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/shout/ShoutHistoryHandler.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/shout/ShoutHistoryHandler.java
@@ -1,6 +1,6 @@
 package ca.ryanmorrison.chatterbox.features.shout;
 
-import net.dv8tion.jda.api.Permission;
+import ca.ryanmorrison.chatterbox.common.permissions.Permissions;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.MessageEmbed;
@@ -194,7 +194,7 @@ final class ShoutHistoryHandler extends ListenerAdapter {
     }
 
     private static boolean canModerate(Member member, GuildChannel channel) {
-        return member.hasPermission(channel, Permission.MESSAGE_MANAGE);
+        return Permissions.canManageMessages(member, channel);
     }
 
     /**

--- a/src/main/resources/db/migration/shortener/postgresql/V20260503020000__shortener_soft_delete.sql
+++ b/src/main/resources/db/migration/shortener/postgresql/V20260503020000__shortener_soft_delete.sql
@@ -1,0 +1,11 @@
+ALTER TABLE shortened_urls ADD COLUMN deleted_at TIMESTAMPTZ;
+ALTER TABLE shortened_urls ADD COLUMN deleted_by BIGINT;
+
+-- Replace the strict url uniqueness with a partial index so deleting a row
+-- frees up its destination URL for re-shortening (with a fresh token). The
+-- token unique index stays unconditional so deleted tokens can never be
+-- reissued.
+DROP INDEX shortened_urls_url_uniq;
+CREATE UNIQUE INDEX shortened_urls_url_uniq
+    ON shortened_urls (url)
+    WHERE deleted_at IS NULL;

--- a/src/main/resources/db/migration/shortener/sqlite/V20260503020000__shortener_soft_delete.sql
+++ b/src/main/resources/db/migration/shortener/sqlite/V20260503020000__shortener_soft_delete.sql
@@ -1,0 +1,11 @@
+ALTER TABLE shortened_urls ADD COLUMN deleted_at TEXT;
+ALTER TABLE shortened_urls ADD COLUMN deleted_by INTEGER;
+
+-- Replace the strict url uniqueness with a partial index so deleting a row
+-- frees up its destination URL for re-shortening (with a fresh token). The
+-- token unique index stays unconditional so deleted tokens can never be
+-- reissued.
+DROP INDEX shortened_urls_url_uniq;
+CREATE UNIQUE INDEX shortened_urls_url_uniq
+    ON shortened_urls (url)
+    WHERE deleted_at IS NULL;

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/shortener/ShortenerRedirectHandlerTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/shortener/ShortenerRedirectHandlerTest.java
@@ -1,0 +1,35 @@
+package ca.ryanmorrison.chatterbox.features.shortener;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ShortenerRedirectHandlerTest {
+
+    @Test
+    void escapeAttrEncodesAllDangerousChars() {
+        assertEquals("a&amp;b&lt;c&gt;d&quot;e&#39;f",
+                ShortenerRedirectHandler.escapeAttr("a&b<c>d\"e'f"));
+    }
+
+    @Test
+    void escapeAttrLeavesSafeStringsAlone() {
+        assertEquals("https://example.com/abc123",
+                ShortenerRedirectHandler.escapeAttr("https://example.com/abc123"));
+    }
+
+    @Test
+    void escapeAttrTolersNull() {
+        assertEquals("", ShortenerRedirectHandler.escapeAttr(null));
+    }
+
+    @Test
+    void escapeAttrPreventsScriptInjection() {
+        String hostile = "https://example.com/?q=<script>alert(1)</script>";
+        String escaped = ShortenerRedirectHandler.escapeAttr(hostile);
+        assertFalse(escaped.contains("<script>"));
+        assertTrue(escaped.contains("&lt;script&gt;"));
+    }
+}

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/shortener/ShortenerRepositorySqliteTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/shortener/ShortenerRepositorySqliteTest.java
@@ -18,14 +18,19 @@ import java.time.ZoneOffset;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/** Verifies the SQLite migration is wire-compatible with the generated jOOQ classes. */
+/** Verifies the SQLite migrations are wire-compatible with the generated jOOQ classes. */
 class ShortenerRepositorySqliteTest {
 
     private static final long USER = 4242L;
+    private static final long MOD = 9999L;
     private static final OffsetDateTime NOW =
             OffsetDateTime.of(2026, 5, 3, 12, 0, 0, 0, ZoneOffset.UTC);
+    private static final OffsetDateTime LATER =
+            OffsetDateTime.of(2026, 5, 3, 13, 0, 0, 0, ZoneOffset.UTC);
 
     private Path dbFile;
     private HikariDataSource dataSource;
@@ -66,6 +71,7 @@ class ShortenerRepositorySqliteTest {
         ShortenedUrl found = repo.findByToken("abc123").orElseThrow();
         assertEquals("https://example.com/x", found.url());
         assertEquals(USER, found.createdBy());
+        assertFalse(found.isDeleted());
     }
 
     @Test
@@ -76,14 +82,14 @@ class ShortenerRepositorySqliteTest {
     }
 
     @Test
-    void duplicateUrlInsertReturnsEmpty() {
+    void duplicateLiveUrlInsertReturnsEmpty() {
         repo.insert("aaaaaa", "https://example.com/x", USER, NOW);
         Optional<ShortenedUrl> dup = repo.insert("bbbbbb", "https://example.com/x", USER, NOW);
         assertTrue(dup.isEmpty());
     }
 
     @Test
-    void findByUrlReturnsExisting() {
+    void findByUrlReturnsExistingLive() {
         repo.insert("abc123", "https://example.com/x", USER, NOW);
         ShortenedUrl found = repo.findByUrl("https://example.com/x").orElseThrow();
         assertEquals("abc123", found.token());
@@ -92,5 +98,62 @@ class ShortenerRepositorySqliteTest {
     @Test
     void findByMissingTokenIsEmpty() {
         assertTrue(repo.findByToken("nope12").isEmpty());
+    }
+
+    @Test
+    void softDeleteHidesFromLiveLookups() {
+        long id = repo.insert("abc123", "https://example.com/x", USER, NOW).orElseThrow().id();
+        int updated = repo.softDelete(id, MOD, LATER);
+        assertEquals(1, updated);
+
+        assertTrue(repo.findByToken("abc123").isEmpty(),
+                "deleted token should not surface from live lookup");
+        assertTrue(repo.findByUrl("https://example.com/x").isEmpty(),
+                "deleted url should not surface from live lookup");
+
+        ShortenedUrl tombstone = repo.findByTokenIncludingDeleted("abc123").orElseThrow();
+        assertTrue(tombstone.isDeleted());
+        assertEquals(MOD, tombstone.deletedBy().orElseThrow());
+        assertEquals(LATER, tombstone.deletedAt().orElseThrow());
+    }
+
+    @Test
+    void softDeleteIsIdempotent() {
+        long id = repo.insert("abc123", "https://example.com/x", USER, NOW).orElseThrow().id();
+        repo.softDelete(id, MOD, LATER);
+        // Second call: no-op, preserves original deleter and timestamp.
+        int updated = repo.softDelete(id, 1234L, NOW);
+        assertEquals(0, updated);
+        ShortenedUrl tombstone = repo.findByTokenIncludingDeleted("abc123").orElseThrow();
+        assertEquals(MOD, tombstone.deletedBy().orElseThrow());
+        assertEquals(LATER, tombstone.deletedAt().orElseThrow());
+    }
+
+    @Test
+    void deletedUrlCanBeReshortenedWithFreshToken() {
+        repo.insert("aaaaaa", "https://example.com/x", USER, NOW);
+        repo.softDelete(repo.findByToken("aaaaaa").orElseThrow().id(), MOD, LATER);
+
+        Optional<ShortenedUrl> fresh = repo.insert("bbbbbb", "https://example.com/x", USER, LATER);
+        assertTrue(fresh.isPresent(), "partial unique index should allow re-insert after delete");
+        assertEquals("bbbbbb", fresh.get().token());
+        assertNotEquals("aaaaaa", fresh.get().token());
+    }
+
+    @Test
+    void deletedTokenCannotBeReissued() {
+        long id = repo.insert("abc123", "https://example.com/x", USER, NOW).orElseThrow().id();
+        repo.softDelete(id, MOD, LATER);
+        // Token unique index is unconditional → re-using the same token must fail.
+        Optional<ShortenedUrl> reuse = repo.insert("abc123", "https://example.com/y", USER, LATER);
+        assertTrue(reuse.isEmpty());
+    }
+
+    @Test
+    void findByIdIncludingDeletedReturnsTombstone() {
+        long id = repo.insert("abc123", "https://example.com/x", USER, NOW).orElseThrow().id();
+        repo.softDelete(id, MOD, LATER);
+        ShortenedUrl byId = repo.findByIdIncludingDeleted(id).orElseThrow();
+        assertTrue(byId.isDeleted());
     }
 }

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/shortener/TargetParserTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/shortener/TargetParserTest.java
@@ -1,0 +1,89 @@
+package ca.ryanmorrison.chatterbox.features.shortener;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class TargetParserTest {
+
+    private static final String BASE_NO_SLASH    = "https://example.com";
+    private static final String BASE_WITH_SLASH  = "https://example.com/";
+    private static final String BASE_WITH_PATH   = "https://example.com/links/";
+
+    @Test
+    void acceptsBareToken() {
+        assertEquals(Optional.of("abc123"), TargetParser.extractToken("abc123", BASE_NO_SLASH));
+    }
+
+    @Test
+    void lowercasesBareToken() {
+        assertEquals(Optional.of("abc123"), TargetParser.extractToken("ABC123", BASE_NO_SLASH));
+    }
+
+    @Test
+    void trimsWhitespace() {
+        assertEquals(Optional.of("abc123"), TargetParser.extractToken("  abc123  ", BASE_NO_SLASH));
+    }
+
+    @Test
+    void rejectsWrongLengthToken() {
+        assertFalse(TargetParser.extractToken("abc12", BASE_NO_SLASH).isPresent());
+        assertFalse(TargetParser.extractToken("abc1234", BASE_NO_SLASH).isPresent());
+    }
+
+    @Test
+    void rejectsNonAlphanumericToken() {
+        assertFalse(TargetParser.extractToken("abc-12", BASE_NO_SLASH).isPresent());
+        assertFalse(TargetParser.extractToken("abc 12", BASE_NO_SLASH).isPresent());
+    }
+
+    @Test
+    void extractsTokenFromShortUrl() {
+        assertEquals(Optional.of("abc123"),
+                TargetParser.extractToken("https://example.com/abc123", BASE_NO_SLASH));
+        assertEquals(Optional.of("abc123"),
+                TargetParser.extractToken("https://example.com/abc123", BASE_WITH_SLASH));
+    }
+
+    @Test
+    void toleratesTrailingSlashAndQueryAndFragment() {
+        assertEquals(Optional.of("abc123"),
+                TargetParser.extractToken("https://example.com/abc123/", BASE_NO_SLASH));
+        assertEquals(Optional.of("abc123"),
+                TargetParser.extractToken("https://example.com/abc123?foo=bar", BASE_NO_SLASH));
+        assertEquals(Optional.of("abc123"),
+                TargetParser.extractToken("https://example.com/abc123#x", BASE_NO_SLASH));
+    }
+
+    @Test
+    void extractsTokenWhenBaseHasPath() {
+        assertEquals(Optional.of("abc123"),
+                TargetParser.extractToken("https://example.com/links/abc123", BASE_WITH_PATH));
+    }
+
+    @Test
+    void rejectsShortUrlFromWrongHost() {
+        assertFalse(TargetParser.extractToken("https://other.example/abc123", BASE_NO_SLASH).isPresent());
+    }
+
+    @Test
+    void rejectsBareDestinationUrl() {
+        assertFalse(TargetParser.extractToken("https://google.com", BASE_NO_SLASH).isPresent());
+    }
+
+    @Test
+    void rejectsBlankAndNull() {
+        assertFalse(TargetParser.extractToken(null, BASE_NO_SLASH).isPresent());
+        assertFalse(TargetParser.extractToken("", BASE_NO_SLASH).isPresent());
+        assertFalse(TargetParser.extractToken("   ", BASE_NO_SLASH).isPresent());
+    }
+
+    @Test
+    void caseInsensitiveOnShortUrlScheme() {
+        assertEquals(Optional.of("abc123"),
+                TargetParser.extractToken("HTTPS://EXAMPLE.COM/ABC123", BASE_NO_SLASH));
+    }
+}


### PR DESCRIPTION
## Summary

Extends the URL shortener feature with two new subcommands (`/shorten delete` and `/shorten peek`) and implements soft-deletion semantics for shortened URLs. Introduces a shared `Permissions` utility for consistent moderator permission checks across modules.

## Key Changes

- **New subcommands for `/shorten`:**
  - `create url:<URL>` — existing functionality, now a subcommand
  - `delete target:<URL or token>` — moderators only; soft-deletes with button confirmation showing destination, creator, and creation time
  - `peek target:<URL or token> [share:<bool>]` — reveals destination URL, ephemeral by default or shareable to channel

- **Soft-deletion implementation:**
  - Added `deleted_at` and `deleted_by` columns to `shortened_urls` table
  - Live lookups (`findByToken`, `findByUrl`) exclude soft-deleted rows
  - New `findByTokenIncludingDeleted` and `findByIdIncludingDeleted` methods for redirect handler (returns 410 Gone for deleted tokens)
  - Partial unique index on `url` (only live rows) allows re-shortening deleted URLs with fresh tokens
  - Token uniqueness remains unconditional — deleted tokens are never reissued

- **New `TargetParser` utility:**
  - Parses delete/peek `target` option as either bare 6-char token or full short URL
  - Case-insensitive, tolerates trailing slashes and query/fragment components
  - Validates token format and base URL prefix matching

- **New `Permissions` utility class:**
  - Centralizes `MESSAGE_MANAGE` permission checks (previously inline in autoreply, RSS, shout modules)
  - Provides both pure checks (`canManageMessages`) and gated entry points (`requireManageMessages`)
  - Distinguishes DM/system contexts from permission denials in error messages

- **Button interaction handling:**
  - Delete confirmation/cancellation buttons with component IDs encoding the row ID
  - Permission re-checked on button click to defend against role removal between render and confirm
  - Idempotent soft-delete (second delete is a no-op, preserves original deleter/timestamp)

- **Refactored modules:**
  - `AutoReplyHandler`, `RssHandler`, `ShoutHistoryHandler` now use shared `Permissions.requireManageMessages()`
  - `ShortenerRedirectHandler` updated to return 410 Gone for soft-deleted tokens

- **Tests:**
  - New `TargetParserTest` covering token extraction, URL parsing, and edge cases
  - Extended `ShortenerRepositorySqliteTest` with soft-delete scenarios (idempotency, re-shortening, token reuse prevention)
  - New `ShortenerRedirectHandlerTest` for HTML attribute escaping

## Notable Details

- Soft-delete is idempotent: re-deleting a row is a no-op, preserving the original moderator and timestamp
- Tokens are permanently retired even after deletion (unconditional unique index), preventing accidental reuse
- Destination URLs become available for re-shortening after deletion (partial unique index), allowing fresh tokens for the same link
- Base URL resolution remains lazy — only triggered when a shortener command is actually invoked

https://claude.ai/code/session_0132oNuqJjJkwHKVF5dhq1gX