### PR TITLE
Add /shout-stats command with channel statistics and leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,24 @@ non-moderator's in the same channel.
 The permission is re-checked on every interaction (slash and button), so
 losing the role mid-pagination immediately removes the moderation buttons.
 
+#### `/shout-stats`
+
+Ephemeral, guild-only stats snapshot for the current channel. Shows:
+
+- **Total shouts** — live count.
+- **Distinct shouters** — unique authors with at least one live shout.
+- **Last 7 days** — live shouts authored in the trailing week.
+- **Top shouters** — the top three contributors with medal emoji and counts.
+- **First shout** / **Most recent** — author and timestamp of the channel's
+  oldest and newest live shouts, with jump-to-message links.
+- **Longest** — the longest live shout by character count, plus a 200-char
+  preview and jump link.
+- **Hall of fame** — the live shout the bot has re-emitted most often
+  (joined through `shout_history`), with replay count and jump link.
+
+All counts and lookups exclude soft-deleted shouts so the figures match
+what's browseable via `/shout-history`. There is no moderator-only view.
+
 ### Autoreply
 
 Channel-scoped automated replies. Moderators (Manage Messages) configure

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/shout/ShoutModule.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/shout/ShoutModule.java
@@ -17,7 +17,8 @@ import java.util.Set;
  * previously-stored shout from the same channel.
  *
  * <p>Also exposes {@code /shout-history} (ephemeral, guild-only) so users can
- * page back through emissions in the channel.
+ * page back through emissions in the channel, and {@code /shout-stats}
+ * (ephemeral, guild-only) for a per-channel stats snapshot.
  *
  * <p>Requires the {@code MESSAGE_CONTENT} privileged intent. Enable it on the
  * bot's application page in the Discord Developer Portal.
@@ -40,15 +41,19 @@ public final class ShoutModule implements Module {
     public List<EventListener> listeners(InitContext ctx) {
         var shouts = new ShoutRepository(ctx.database());
         var history = new ShoutHistoryRepository(ctx.database());
+        var stats = new ShoutStatsRepository(ctx.database());
         return List.of(
                 new ShoutListener(new ShoutDetector(), shouts, history),
-                new ShoutHistoryHandler(shouts, history));
+                new ShoutHistoryHandler(shouts, history),
+                new ShoutStatsHandler(stats));
     }
 
     @Override
     public List<SlashCommandData> slashCommands(InitContext ctx) {
         return List.of(
                 Commands.slash(ShoutHistoryView.CMD_NAME, "Browse the bot's shout history for this channel.")
+                        .setContexts(InteractionContextType.GUILD),
+                Commands.slash(ShoutStatsView.CMD_NAME, "Show fun stats about shouts in this channel.")
                         .setContexts(InteractionContextType.GUILD));
     }
 }

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/shout/ShoutStats.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/shout/ShoutStats.java
@@ -1,0 +1,47 @@
+package ca.ryanmorrison.chatterbox.features.shout;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Aggregated stats for a single channel, computed once and rendered into the
+ * {@code /shout-stats} embed. All counts and lookups exclude soft-deleted
+ * shouts so the figures match what users can browse via {@code /shout-history}.
+ *
+ * @param totalShouts        live shouts in the channel
+ * @param distinctShouters   unique authors with at least one live shout
+ * @param shoutsLast7Days    live shouts authored in the trailing seven days
+ * @param topShouters        top contributors, descending by count; capped by
+ *                           the caller (typically 3)
+ * @param oldest             earliest live shout, by {@code authored_at}
+ * @param newest             latest live shout, by {@code authored_at}
+ * @param longest            live shout with the most characters of {@code content}
+ * @param mostReplayed       shout with the most {@code shout_history} rows
+ *                           pointing at it; empty if no live shout has been
+ *                           replayed yet
+ */
+record ShoutStats(
+        int totalShouts,
+        int distinctShouters,
+        int shoutsLast7Days,
+        List<ShouterCount> topShouters,
+        Optional<ShoutSummary> oldest,
+        Optional<ShoutSummary> newest,
+        Optional<ShoutSummary> longest,
+        Optional<ReplayedShout> mostReplayed) {
+
+    boolean isEmpty() {
+        return totalShouts == 0;
+    }
+
+    /** Single user's contribution count for the leaderboard. */
+    record ShouterCount(long userId, int count) {}
+
+    /** The shout fields needed to render a row in the embed. */
+    record ShoutSummary(long shoutId, long messageId, long authorId,
+                        String content, OffsetDateTime authoredAt) {}
+
+    /** A shout plus how many times the bot has re-emitted it in this channel. */
+    record ReplayedShout(ShoutSummary shout, int replayCount) {}
+}

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/shout/ShoutStatsHandler.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/shout/ShoutStatsHandler.java
@@ -1,0 +1,122 @@
+package ca.ryanmorrison.chatterbox.features.shout;
+
+import ca.ryanmorrison.chatterbox.features.shout.ShoutStats.ReplayedShout;
+import ca.ryanmorrison.chatterbox.features.shout.ShoutStats.ShoutSummary;
+import ca.ryanmorrison.chatterbox.features.shout.ShoutStats.ShouterCount;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.exceptions.ErrorResponseException;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.requests.ErrorResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+/**
+ * Slash handler for {@code /shout-stats}. Loads the channel's stat snapshot,
+ * resolves all referenced user IDs to Discord mentions in parallel, and
+ * renders a single embed via {@link ShoutStatsView}.
+ *
+ * <p>All counts and lookups exclude soft-deleted shouts so the figures
+ * always match what's browseable via {@code /shout-history}.
+ */
+final class ShoutStatsHandler extends ListenerAdapter {
+
+    static final int TOP_SHOUTER_LIMIT = 3;
+    private static final String UNKNOWN_MEMBER = "Former member";
+
+    private static final Logger log = LoggerFactory.getLogger(ShoutStatsHandler.class);
+
+    private final ShoutStatsRepository stats;
+
+    ShoutStatsHandler(ShoutStatsRepository stats) {
+        this.stats = stats;
+    }
+
+    @Override
+    public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
+        if (!ShoutStatsView.CMD_NAME.equals(event.getName())) return;
+
+        Guild guild = event.getGuild();
+        Member member = event.getMember();
+        if (guild == null || member == null) {
+            event.reply("This command is only available in servers.").setEphemeral(true).queue();
+            return;
+        }
+
+        long channelId = event.getChannel().getIdLong();
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        ShoutStats snapshot = stats.loadAll(channelId, now, TOP_SHOUTER_LIMIT);
+
+        if (snapshot.isEmpty()) {
+            event.replyEmbeds(ShoutStatsView.embedEmpty()).setEphemeral(true).queue();
+            return;
+        }
+
+        // Defer because resolving user references makes REST calls.
+        event.deferReply(true).queue();
+        buildEmbed(guild, channelId, snapshot)
+                .thenAccept(embed -> event.getHook().editOriginalEmbeds(embed).queue());
+    }
+
+    private CompletableFuture<MessageEmbed> buildEmbed(Guild guild, long channelId, ShoutStats snapshot) {
+        List<CompletableFuture<String>> topRefs = new ArrayList<>(snapshot.topShouters().size());
+        for (ShouterCount sc : snapshot.topShouters()) {
+            topRefs.add(resolveMember(guild, sc.userId()));
+        }
+        CompletableFuture<String> oldest = optionalRef(guild, snapshot.oldest().map(ShoutSummary::authorId));
+        CompletableFuture<String> newest = optionalRef(guild, snapshot.newest().map(ShoutSummary::authorId));
+        CompletableFuture<String> longest = optionalRef(guild, snapshot.longest().map(ShoutSummary::authorId));
+        CompletableFuture<String> hallOfFame = optionalRef(guild,
+                snapshot.mostReplayed().map(ReplayedShout::shout).map(ShoutSummary::authorId));
+
+        CompletableFuture<List<String>> resolvedTop = CompletableFuture.allOf(topRefs.toArray(CompletableFuture[]::new))
+                .thenApply(v -> topRefs.stream().map(CompletableFuture::join).toList());
+
+        return CompletableFuture.allOf(resolvedTop, oldest, newest, longest, hallOfFame)
+                .thenApply(v -> ShoutStatsView.embed(
+                        snapshot,
+                        guild.getIdLong(),
+                        channelId,
+                        resolvedTop.join(),
+                        oldest.join(),
+                        newest.join(),
+                        longest.join(),
+                        hallOfFame.join()));
+    }
+
+    private static CompletableFuture<String> optionalRef(Guild guild, Optional<Long> userId) {
+        return userId.map(id -> resolveMember(guild, id))
+                .orElse(CompletableFuture.completedFuture(null));
+    }
+
+    /**
+     * Returns a Discord user mention ({@code <@id>}) when the member still
+     * exists in the guild, or the {@link #UNKNOWN_MEMBER} fallback otherwise.
+     * Mentions in embed fields render as the user's name without producing a
+     * notification, which is the desired UX here.
+     */
+    private static CompletableFuture<String> resolveMember(Guild guild, long userId) {
+        return guild.retrieveMemberById(userId).submit()
+                .thenApply(Member::getAsMention)
+                .exceptionally(throwable -> {
+                    Throwable cause = (throwable instanceof CompletionException ce) ? ce.getCause() : throwable;
+                    if (cause instanceof ErrorResponseException ere
+                            && ere.getErrorResponse() == ErrorResponse.UNKNOWN_MEMBER) {
+                        return UNKNOWN_MEMBER;
+                    }
+                    log.warn("Failed to resolve member {} in guild {}: {}",
+                            userId, guild.getId(), cause.toString());
+                    return UNKNOWN_MEMBER;
+                });
+    }
+}

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/shout/ShoutStatsRepository.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/shout/ShoutStatsRepository.java
@@ -1,0 +1,160 @@
+package ca.ryanmorrison.chatterbox.features.shout;
+
+import ca.ryanmorrison.chatterbox.features.shout.ShoutStats.ReplayedShout;
+import ca.ryanmorrison.chatterbox.features.shout.ShoutStats.ShoutSummary;
+import ca.ryanmorrison.chatterbox.features.shout.ShoutStats.ShouterCount;
+import org.jooq.DSLContext;
+import org.jooq.Record;
+import org.jooq.impl.DSL;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static ca.ryanmorrison.chatterbox.db.generated.Tables.SHOUTS;
+import static ca.ryanmorrison.chatterbox.db.generated.Tables.SHOUT_HISTORY;
+
+/**
+ * jOOQ-backed read-only access for the {@code /shout-stats} command. All
+ * queries filter soft-deleted shouts ({@code deleted_at IS NOT NULL}) so the
+ * stats reflect what's actually browseable.
+ *
+ * <p>Each helper runs its own SQL — there's no transaction wrapping the
+ * eight queries together. A shout authored mid-call could appear in some
+ * counts and not others, but the inconsistency window is sub-second and
+ * the rendered embed is best-effort anyway.
+ */
+final class ShoutStatsRepository {
+
+    private final DSLContext dsl;
+
+    ShoutStatsRepository(DSLContext dsl) {
+        this.dsl = dsl;
+    }
+
+    int countLive(long channelId) {
+        return dsl.fetchCount(SHOUTS,
+                SHOUTS.CHANNEL_ID.eq(channelId)
+                        .and(SHOUTS.DELETED_AT.isNull()));
+    }
+
+    int countDistinctShouters(long channelId) {
+        Integer n = dsl.select(DSL.countDistinct(SHOUTS.AUTHOR_ID))
+                .from(SHOUTS)
+                .where(SHOUTS.CHANNEL_ID.eq(channelId))
+                .and(SHOUTS.DELETED_AT.isNull())
+                .fetchOne(0, Integer.class);
+        return n == null ? 0 : n;
+    }
+
+    int countLiveSince(long channelId, OffsetDateTime since) {
+        return dsl.fetchCount(SHOUTS,
+                SHOUTS.CHANNEL_ID.eq(channelId)
+                        .and(SHOUTS.DELETED_AT.isNull())
+                        .and(SHOUTS.AUTHORED_AT.ge(since)));
+    }
+
+    List<ShouterCount> topShouters(long channelId, int limit) {
+        var countField = DSL.count().as("c");
+        return dsl.select(SHOUTS.AUTHOR_ID, countField)
+                .from(SHOUTS)
+                .where(SHOUTS.CHANNEL_ID.eq(channelId))
+                .and(SHOUTS.DELETED_AT.isNull())
+                .groupBy(SHOUTS.AUTHOR_ID)
+                .orderBy(countField.desc(), SHOUTS.AUTHOR_ID.asc())
+                .limit(limit)
+                .fetch()
+                .map(r -> new ShouterCount(r.get(SHOUTS.AUTHOR_ID), r.get(countField)));
+    }
+
+    Optional<ShoutSummary> oldest(long channelId) {
+        return dsl.selectFrom(SHOUTS)
+                .where(SHOUTS.CHANNEL_ID.eq(channelId))
+                .and(SHOUTS.DELETED_AT.isNull())
+                .orderBy(SHOUTS.AUTHORED_AT.asc(), SHOUTS.ID.asc())
+                .limit(1)
+                .fetchOptional()
+                .map(ShoutStatsRepository::toSummary);
+    }
+
+    Optional<ShoutSummary> newest(long channelId) {
+        return dsl.selectFrom(SHOUTS)
+                .where(SHOUTS.CHANNEL_ID.eq(channelId))
+                .and(SHOUTS.DELETED_AT.isNull())
+                .orderBy(SHOUTS.AUTHORED_AT.desc(), SHOUTS.ID.desc())
+                .limit(1)
+                .fetchOptional()
+                .map(ShoutStatsRepository::toSummary);
+    }
+
+    /**
+     * Longest shout by character count of {@code content}. Ties broken by
+     * earliest {@code authored_at} so the result is deterministic.
+     */
+    Optional<ShoutSummary> longest(long channelId) {
+        var lenField = DSL.charLength(SHOUTS.CONTENT);
+        return dsl.selectFrom(SHOUTS)
+                .where(SHOUTS.CHANNEL_ID.eq(channelId))
+                .and(SHOUTS.DELETED_AT.isNull())
+                .orderBy(lenField.desc(), SHOUTS.AUTHORED_AT.asc(), SHOUTS.ID.asc())
+                .limit(1)
+                .fetchOptional()
+                .map(ShoutStatsRepository::toSummary);
+    }
+
+    /**
+     * The most-replayed live shout in this channel: groups {@code shout_history}
+     * rows by their referenced shout, joins back to {@code shouts} for the
+     * fields the embed needs. Returns empty when no live shout has ever been
+     * replayed (history table empty for the channel, or every replayed shout
+     * has since been soft-deleted).
+     */
+    Optional<ReplayedShout> mostReplayed(long channelId) {
+        var replayCount = DSL.count().as("replay_count");
+        return dsl.select(
+                        SHOUTS.ID,
+                        SHOUTS.MESSAGE_ID,
+                        SHOUTS.AUTHOR_ID,
+                        SHOUTS.CONTENT,
+                        SHOUTS.AUTHORED_AT,
+                        replayCount)
+                .from(SHOUT_HISTORY)
+                .join(SHOUTS).on(SHOUTS.ID.eq(SHOUT_HISTORY.SHOUT_ID))
+                .where(SHOUT_HISTORY.CHANNEL_ID.eq(channelId))
+                .and(SHOUTS.DELETED_AT.isNull())
+                .groupBy(SHOUTS.ID, SHOUTS.MESSAGE_ID, SHOUTS.AUTHOR_ID, SHOUTS.CONTENT, SHOUTS.AUTHORED_AT)
+                .orderBy(replayCount.desc(), SHOUTS.ID.asc())
+                .limit(1)
+                .fetchOptional()
+                .map(r -> new ReplayedShout(
+                        new ShoutSummary(
+                                r.get(SHOUTS.ID),
+                                r.get(SHOUTS.MESSAGE_ID),
+                                r.get(SHOUTS.AUTHOR_ID),
+                                r.get(SHOUTS.CONTENT),
+                                r.get(SHOUTS.AUTHORED_AT)),
+                        r.get(replayCount)));
+    }
+
+    /** Loads every stat used by {@link ShoutStatsView} in one place. */
+    ShoutStats loadAll(long channelId, OffsetDateTime now, int topShouterLimit) {
+        return new ShoutStats(
+                countLive(channelId),
+                countDistinctShouters(channelId),
+                countLiveSince(channelId, now.minusDays(7)),
+                topShouters(channelId, topShouterLimit),
+                oldest(channelId),
+                newest(channelId),
+                longest(channelId),
+                mostReplayed(channelId));
+    }
+
+    private static ShoutSummary toSummary(Record r) {
+        return new ShoutSummary(
+                r.get(SHOUTS.ID),
+                r.get(SHOUTS.MESSAGE_ID),
+                r.get(SHOUTS.AUTHOR_ID),
+                r.get(SHOUTS.CONTENT),
+                r.get(SHOUTS.AUTHORED_AT));
+    }
+}

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/shout/ShoutStatsView.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/shout/ShoutStatsView.java
@@ -1,0 +1,125 @@
+package ca.ryanmorrison.chatterbox.features.shout;
+
+import ca.ryanmorrison.chatterbox.features.shout.ShoutStats.ReplayedShout;
+import ca.ryanmorrison.chatterbox.features.shout.ShoutStats.ShouterCount;
+import ca.ryanmorrison.chatterbox.features.shout.ShoutStats.ShoutSummary;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+
+import java.util.List;
+
+/**
+ * Pure rendering for the {@code /shout-stats} response. The handler resolves
+ * raw shouts to their public-facing references (Discord mentions, jump-to-
+ * message links, truncated content previews) and passes everything in via
+ * value records, so this class makes no DB or REST calls and is unit-testable.
+ */
+final class ShoutStatsView {
+
+    static final String CMD_NAME = "shout-stats";
+
+    /** Cap on content shown inline so a 2000-char shout doesn't blow the embed field. */
+    static final int CONTENT_PREVIEW_LIMIT = 200;
+
+    private ShoutStatsView() {}
+
+    static MessageEmbed embedEmpty() {
+        return new EmbedBuilder()
+                .setTitle("Shout stats")
+                .setDescription("No shouts have been recorded in this channel yet.")
+                .build();
+    }
+
+    /**
+     * @param stats              the loaded snapshot
+     * @param guildId            for jump-to-message URLs
+     * @param channelId          for jump-to-message URLs
+     * @param topShouterRefs     pre-resolved mentions / fallbacks for each entry in
+     *                           {@code stats.topShouters()}, in the same order
+     * @param oldestRef          mention/fallback for the oldest shout's author
+     * @param newestRef          mention/fallback for the newest shout's author
+     * @param longestRef         mention/fallback for the longest shout's author
+     * @param mostReplayedRef    mention/fallback for the hall-of-fame shout's author
+     */
+    static MessageEmbed embed(ShoutStats stats,
+                              long guildId,
+                              long channelId,
+                              List<String> topShouterRefs,
+                              String oldestRef,
+                              String newestRef,
+                              String longestRef,
+                              String mostReplayedRef) {
+        var b = new EmbedBuilder().setTitle("Shout stats");
+
+        b.addField("Total shouts", Integer.toString(stats.totalShouts()), true);
+        b.addField("Distinct shouters", Integer.toString(stats.distinctShouters()), true);
+        b.addField("Last 7 days", Integer.toString(stats.shoutsLast7Days()), true);
+
+        if (!stats.topShouters().isEmpty()) {
+            b.addField("Top shouters", renderLeaderboard(stats.topShouters(), topShouterRefs), false);
+        }
+
+        stats.oldest().ifPresent(o ->
+                b.addField("First shout",
+                        renderShoutLine(o, guildId, channelId, oldestRef), false));
+        stats.newest().ifPresent(n ->
+                b.addField("Most recent",
+                        renderShoutLine(n, guildId, channelId, newestRef), false));
+
+        stats.longest().ifPresent(l ->
+                b.addField("Longest (" + l.content().length() + " chars)",
+                        renderShoutPreview(l, guildId, channelId, longestRef), false));
+
+        stats.mostReplayed().ifPresent(r ->
+                b.addField("Hall of fame (replayed " + r.replayCount() + " "
+                                + (r.replayCount() == 1 ? "time" : "times") + ")",
+                        renderShoutPreview(r.shout(), guildId, channelId, mostReplayedRef), false));
+
+        return b.build();
+    }
+
+    static String renderLeaderboard(List<ShouterCount> rows, List<String> refs) {
+        if (rows.size() != refs.size()) {
+            throw new IllegalArgumentException("topShouterRefs size must match topShouters size");
+        }
+        var sb = new StringBuilder();
+        for (int i = 0; i < rows.size(); i++) {
+            int rank = i + 1;
+            sb.append(medal(rank)).append(' ')
+              .append(refs.get(i))
+              .append(" — ").append(rows.get(i).count())
+              .append(rows.get(i).count() == 1 ? " shout" : " shouts");
+            if (i < rows.size() - 1) sb.append('\n');
+        }
+        return sb.toString();
+    }
+
+    private static String medal(int rank) {
+        return switch (rank) {
+            case 1 -> "🥇";
+            case 2 -> "🥈";
+            case 3 -> "🥉";
+            default -> rank + ".";
+        };
+    }
+
+    static String renderShoutLine(ShoutSummary s, long guildId, long channelId, String authorRef) {
+        long ts = s.authoredAt().toEpochSecond();
+        return authorRef + " on <t:" + ts + ":F> · ["
+                + "jump](" + jumpUrl(guildId, channelId, s.messageId()) + ")";
+    }
+
+    static String renderShoutPreview(ShoutSummary s, long guildId, long channelId, String authorRef) {
+        return renderShoutLine(s, guildId, channelId, authorRef)
+                + "\n> " + truncate(s.content(), CONTENT_PREVIEW_LIMIT).replace("\n", " ");
+    }
+
+    static String truncate(String s, int max) {
+        if (s.length() <= max) return s;
+        return s.substring(0, max - 1) + "…";
+    }
+
+    private static String jumpUrl(long guildId, long channelId, long messageId) {
+        return "https://discord.com/channels/" + guildId + "/" + channelId + "/" + messageId;
+    }
+}

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/shout/ShoutStatsRepositorySqliteTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/shout/ShoutStatsRepositorySqliteTest.java
@@ -1,0 +1,225 @@
+package ca.ryanmorrison.chatterbox.features.shout;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.flywaydb.core.Flyway;
+import org.jooq.DSLContext;
+import org.jooq.SQLDialect;
+import org.jooq.conf.Settings;
+import org.jooq.impl.DSL;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import static ca.ryanmorrison.chatterbox.db.generated.Tables.SHOUTS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end SQLite coverage for {@link ShoutStatsRepository}: confirms each
+ * query both compiles against the generated jOOQ classes and produces the
+ * expected aggregate against a real schema.
+ */
+class ShoutStatsRepositorySqliteTest {
+
+    private static final long CHANNEL = 1L;
+    private static final long OTHER_CHANNEL = 2L;
+    private static final long MOD = 9999L;
+    private static final OffsetDateTime BASE =
+            OffsetDateTime.of(2026, 5, 1, 12, 0, 0, 0, ZoneOffset.UTC);
+
+    private Path dbFile;
+    private HikariDataSource dataSource;
+    private DSLContext dsl;
+    private ShoutRepository shouts;
+    private ShoutHistoryRepository history;
+    private ShoutStatsRepository stats;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbFile = Files.createTempFile("chatterbox-stats-test", ".db");
+        Files.delete(dbFile);
+
+        var hc = new HikariConfig();
+        hc.setJdbcUrl("jdbc:sqlite:" + dbFile);
+        hc.setMaximumPoolSize(1);
+        hc.setConnectionInitSql("PRAGMA foreign_keys = ON");
+        dataSource = new HikariDataSource(hc);
+
+        Flyway.configure()
+                .dataSource(dataSource)
+                .locations("classpath:db/migration/shout/sqlite")
+                .load()
+                .migrate();
+
+        dsl = DSL.using(dataSource, SQLDialect.SQLITE, new Settings().withRenderSchema(false));
+        shouts = new ShoutRepository(dsl);
+        history = new ShoutHistoryRepository(dsl);
+        stats = new ShoutStatsRepository(dsl);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (dataSource != null) dataSource.close();
+        if (dbFile != null) Files.deleteIfExists(dbFile);
+    }
+
+    @Test
+    void emptyChannelHasZeroes() {
+        assertEquals(0, stats.countLive(CHANNEL));
+        assertEquals(0, stats.countDistinctShouters(CHANNEL));
+        assertTrue(stats.oldest(CHANNEL).isEmpty());
+        assertTrue(stats.newest(CHANNEL).isEmpty());
+        assertTrue(stats.longest(CHANNEL).isEmpty());
+        assertTrue(stats.mostReplayed(CHANNEL).isEmpty());
+        assertTrue(stats.topShouters(CHANNEL, 3).isEmpty());
+    }
+
+    @Test
+    void countsLiveAndExcludesDeletedAndOtherChannels() {
+        long live1 = shout(CHANNEL, 100L, "ALPHA", 1L, BASE);
+        long live2 = shout(CHANNEL, 101L, "BETA",  2L, BASE.plusMinutes(1));
+        long del   = shout(CHANNEL, 102L, "GAMMA", 3L, BASE.plusMinutes(2));
+        shouts.softDelete(del, MOD);
+        shout(OTHER_CHANNEL, 200L, "DELTA", 4L, BASE);
+
+        assertEquals(2, stats.countLive(CHANNEL));
+        assertEquals(2, stats.countDistinctShouters(CHANNEL),
+                "two distinct authors have live shouts; the third author's only shout was deleted; "
+                + "the fourth shouts in another channel");
+        assertNotEquals(live1, live2);
+    }
+
+    @Test
+    void distinctShoutersCountsUniqueAuthors() {
+        shout(CHANNEL, 100L, "A", 1L, BASE);
+        shout(CHANNEL, 101L, "B", 1L, BASE.plusMinutes(1));
+        shout(CHANNEL, 102L, "C", 2L, BASE.plusMinutes(2));
+        shout(CHANNEL, 103L, "D", 3L, BASE.plusMinutes(3));
+        assertEquals(3, stats.countDistinctShouters(CHANNEL));
+    }
+
+    @Test
+    void countLiveSinceFiltersByAuthoredAt() {
+        shout(CHANNEL, 100L, "OLD",    1L, BASE.minusDays(30));
+        shout(CHANNEL, 101L, "MEDIUM", 1L, BASE.minusDays(8));
+        shout(CHANNEL, 102L, "RECENT", 1L, BASE.minusDays(2));
+        shout(CHANNEL, 103L, "FRESH",  1L, BASE.minusHours(1));
+        assertEquals(2, stats.countLiveSince(CHANNEL, BASE.minusDays(7)));
+    }
+
+    @Test
+    void topShoutersOrdersByCountDesc() {
+        // user 1 → 3 shouts; user 2 → 2; user 3 → 1
+        shout(CHANNEL, 100L, "A1", 1L, BASE);
+        shout(CHANNEL, 101L, "A2", 1L, BASE.plusMinutes(1));
+        shout(CHANNEL, 102L, "A3", 1L, BASE.plusMinutes(2));
+        shout(CHANNEL, 103L, "B1", 2L, BASE.plusMinutes(3));
+        shout(CHANNEL, 104L, "B2", 2L, BASE.plusMinutes(4));
+        shout(CHANNEL, 105L, "C1", 3L, BASE.plusMinutes(5));
+
+        List<ShoutStats.ShouterCount> top = stats.topShouters(CHANNEL, 3);
+        assertEquals(3, top.size());
+        assertEquals(1L, top.get(0).userId()); assertEquals(3, top.get(0).count());
+        assertEquals(2L, top.get(1).userId()); assertEquals(2, top.get(1).count());
+        assertEquals(3L, top.get(2).userId()); assertEquals(1, top.get(2).count());
+    }
+
+    @Test
+    void topShoutersHonoursLimit() {
+        shout(CHANNEL, 100L, "A1", 1L, BASE);
+        shout(CHANNEL, 101L, "B1", 2L, BASE.plusMinutes(1));
+        shout(CHANNEL, 102L, "C1", 3L, BASE.plusMinutes(2));
+        assertEquals(2, stats.topShouters(CHANNEL, 2).size());
+    }
+
+    @Test
+    void topShoutersIgnoresDeleted() {
+        shout(CHANNEL, 100L, "A1", 1L, BASE);
+        long deletedFromUser2 = shout(CHANNEL, 101L, "B1", 2L, BASE.plusMinutes(1));
+        shouts.softDelete(deletedFromUser2, MOD);
+
+        List<ShoutStats.ShouterCount> top = stats.topShouters(CHANNEL, 5);
+        assertEquals(1, top.size());
+        assertEquals(1L, top.get(0).userId());
+    }
+
+    @Test
+    void oldestAndNewestPickByAuthoredAt() {
+        shout(CHANNEL, 100L, "MIDDLE", 1L, BASE.plusMinutes(5));
+        shout(CHANNEL, 101L, "FIRST",  2L, BASE);
+        shout(CHANNEL, 102L, "LAST",   3L, BASE.plusMinutes(10));
+
+        assertEquals("FIRST", stats.oldest(CHANNEL).orElseThrow().content());
+        assertEquals("LAST",  stats.newest(CHANNEL).orElseThrow().content());
+    }
+
+    @Test
+    void longestPicksByCharCount() {
+        shout(CHANNEL, 100L, "SHORT",        1L, BASE);
+        shout(CHANNEL, 101L, "MUCH LONGER",  1L, BASE.plusMinutes(1));
+        shout(CHANNEL, 102L, "MEDIUM ONE",   1L, BASE.plusMinutes(2));
+        assertEquals("MUCH LONGER", stats.longest(CHANNEL).orElseThrow().content());
+    }
+
+    @Test
+    void mostReplayedJoinsHistoryAndCounts() {
+        long s1 = shout(CHANNEL, 100L, "ONCE",     1L, BASE);
+        long s2 = shout(CHANNEL, 101L, "TWICE",    1L, BASE.plusMinutes(1));
+        long s3 = shout(CHANNEL, 102L, "THRICE",   1L, BASE.plusMinutes(2));
+
+        history.record(CHANNEL, s1);
+        history.record(CHANNEL, s2); history.record(CHANNEL, s2);
+        history.record(CHANNEL, s3); history.record(CHANNEL, s3); history.record(CHANNEL, s3);
+
+        ShoutStats.ReplayedShout top = stats.mostReplayed(CHANNEL).orElseThrow();
+        assertEquals("THRICE", top.shout().content());
+        assertEquals(3, top.replayCount());
+    }
+
+    @Test
+    void mostReplayedSkipsDeletedShouts() {
+        long popular = shout(CHANNEL, 100L, "WAS POPULAR", 1L, BASE);
+        long alive   = shout(CHANNEL, 101L, "STILL HERE",   1L, BASE.plusMinutes(1));
+
+        history.record(CHANNEL, popular); history.record(CHANNEL, popular); history.record(CHANNEL, popular);
+        history.record(CHANNEL, alive);
+
+        shouts.softDelete(popular, MOD);
+
+        ShoutStats.ReplayedShout top = stats.mostReplayed(CHANNEL).orElseThrow();
+        assertEquals("STILL HERE", top.shout().content());
+        assertEquals(1, top.replayCount());
+    }
+
+    @Test
+    void loadAllAssemblesEverything() {
+        shout(CHANNEL, 100L, "OLD ONE",  1L, BASE);
+        shout(CHANNEL, 101L, "NEW ONE",  2L, BASE.plusMinutes(5));
+        long replayed = shout(CHANNEL, 102L, "FAMOUS LONGEST", 1L, BASE.plusMinutes(2));
+        history.record(CHANNEL, replayed);
+        history.record(CHANNEL, replayed);
+
+        ShoutStats snapshot = stats.loadAll(CHANNEL, BASE.plusMinutes(10), 3);
+        assertEquals(3, snapshot.totalShouts());
+        assertEquals(2, snapshot.distinctShouters());
+        assertEquals(3, snapshot.shoutsLast7Days());
+        assertEquals("OLD ONE", snapshot.oldest().orElseThrow().content());
+        assertEquals("NEW ONE", snapshot.newest().orElseThrow().content());
+        assertEquals("FAMOUS LONGEST", snapshot.longest().orElseThrow().content());
+        assertEquals("FAMOUS LONGEST", snapshot.mostReplayed().orElseThrow().shout().content());
+        assertEquals(2, snapshot.mostReplayed().orElseThrow().replayCount());
+    }
+
+    private long shout(long channelId, long messageId, String content, long authorId, OffsetDateTime authoredAt) {
+        shouts.tryInsert(channelId, messageId, content, authorId, authoredAt);
+        return dsl.select(SHOUTS.ID).from(SHOUTS).where(SHOUTS.MESSAGE_ID.eq(messageId)).fetchOne(SHOUTS.ID);
+    }
+}

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/shout/ShoutStatsViewTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/shout/ShoutStatsViewTest.java
@@ -1,0 +1,147 @@
+package ca.ryanmorrison.chatterbox.features.shout;
+
+import ca.ryanmorrison.chatterbox.features.shout.ShoutStats.ReplayedShout;
+import ca.ryanmorrison.chatterbox.features.shout.ShoutStats.ShoutSummary;
+import ca.ryanmorrison.chatterbox.features.shout.ShoutStats.ShouterCount;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ShoutStatsViewTest {
+
+    private static final long GUILD = 100L;
+    private static final long CHANNEL = 200L;
+    private static final OffsetDateTime T =
+            OffsetDateTime.of(2026, 5, 1, 12, 0, 0, 0, ZoneOffset.UTC);
+
+    @Test
+    void emptyEmbedReadsClearly() {
+        MessageEmbed embed = ShoutStatsView.embedEmpty();
+        assertEquals("Shout stats", embed.getTitle());
+        assertNotNull(embed.getDescription());
+        assertTrue(embed.getDescription().contains("No shouts"));
+    }
+
+    @Test
+    void leaderboardUsesMedalsAndPluralisesShouts() {
+        var rows = List.of(
+                new ShouterCount(1L, 7),
+                new ShouterCount(2L, 1),
+                new ShouterCount(3L, 4));
+        var refs = List.of("<@1>", "<@2>", "<@3>");
+        String rendered = ShoutStatsView.renderLeaderboard(rows, refs);
+
+        assertTrue(rendered.contains("🥇 <@1> — 7 shouts"));
+        assertTrue(rendered.contains("🥈 <@2> — 1 shout"),
+                "single shout should be singular");
+        assertTrue(rendered.contains("🥉 <@3> — 4 shouts"));
+    }
+
+    @Test
+    void leaderboardRefsLengthMustMatch() {
+        var rows = List.of(new ShouterCount(1L, 7), new ShouterCount(2L, 4));
+        var refs = List.of("<@1>");
+        assertThrows(IllegalArgumentException.class,
+                () -> ShoutStatsView.renderLeaderboard(rows, refs));
+    }
+
+    @Test
+    void embedIncludesTotalsAndAllSections() {
+        var oldest = new ShoutSummary(1L, 1001L, 11L, "FIRST EVER", T);
+        var newest = new ShoutSummary(2L, 1002L, 22L, "LATEST", T.plusDays(1));
+        var longest = new ShoutSummary(3L, 1003L, 33L, "X".repeat(123), T.plusHours(5));
+        var hallShout = new ShoutSummary(4L, 1004L, 44L, "MEMETIC GOLD", T.plusHours(8));
+        var snapshot = new ShoutStats(
+                42, 6, 9,
+                List.of(new ShouterCount(11L, 12), new ShouterCount(22L, 7)),
+                Optional.of(oldest), Optional.of(newest), Optional.of(longest),
+                Optional.of(new ReplayedShout(hallShout, 5)));
+
+        MessageEmbed embed = ShoutStatsView.embed(
+                snapshot, GUILD, CHANNEL,
+                List.of("<@11>", "<@22>"),
+                "<@11>", "<@22>", "<@33>", "<@44>");
+
+        Map<String, MessageEmbed.Field> fields = fieldsByName(embed);
+        assertEquals("42", fields.get("Total shouts").getValue());
+        assertEquals("6",  fields.get("Distinct shouters").getValue());
+        assertEquals("9",  fields.get("Last 7 days").getValue());
+
+        assertTrue(fields.containsKey("Top shouters"));
+        assertTrue(fields.containsKey("First shout"));
+        assertTrue(fields.containsKey("Most recent"));
+        assertTrue(fields.keySet().stream().anyMatch(k -> k.startsWith("Longest (123 chars)")));
+        assertTrue(fields.keySet().stream().anyMatch(k -> k.startsWith("Hall of fame (replayed 5 times)")));
+    }
+
+    @Test
+    void hallOfFameSingularWhenReplayedOnce() {
+        var hallShout = new ShoutSummary(4L, 1004L, 44L, "ONLY ONCE", T);
+        var snapshot = new ShoutStats(
+                1, 1, 1,
+                List.of(new ShouterCount(11L, 1)),
+                Optional.of(hallShout), Optional.of(hallShout), Optional.of(hallShout),
+                Optional.of(new ReplayedShout(hallShout, 1)));
+        MessageEmbed embed = ShoutStatsView.embed(snapshot, GUILD, CHANNEL,
+                List.of("<@11>"), "<@11>", "<@11>", "<@11>", "<@11>");
+        assertTrue(fieldsByName(embed).keySet().stream()
+                .anyMatch(k -> k.startsWith("Hall of fame (replayed 1 time)")),
+                "single replay should read as 1 time");
+    }
+
+    @Test
+    void shoutLineIncludesAuthorTimestampAndJumpLink() {
+        var s = new ShoutSummary(1L, 9999L, 11L, "HELLO", T);
+        String line = ShoutStatsView.renderShoutLine(s, GUILD, CHANNEL, "<@11>");
+        assertTrue(line.contains("<@11>"));
+        assertTrue(line.contains("<t:" + T.toEpochSecond() + ":F>"));
+        assertTrue(line.contains("https://discord.com/channels/" + GUILD + "/" + CHANNEL + "/9999"));
+    }
+
+    @Test
+    void previewTruncatesLongContentAndQuotesIt() {
+        String huge = "X".repeat(ShoutStatsView.CONTENT_PREVIEW_LIMIT + 50);
+        var s = new ShoutSummary(1L, 9999L, 11L, huge, T);
+        String preview = ShoutStatsView.renderShoutPreview(s, GUILD, CHANNEL, "<@11>");
+        assertTrue(preview.contains("\n> "));
+        assertTrue(preview.contains("…"));
+        assertFalse(preview.contains(huge), "raw long content should not pass through unredacted");
+    }
+
+    @Test
+    void truncateLeavesShortStringsAlone() {
+        assertEquals("HI", ShoutStatsView.truncate("HI", 100));
+        assertEquals("ABCD…", ShoutStatsView.truncate("ABCDEFGH", 5));
+    }
+
+    @Test
+    void embedSkipsOptionalSectionsWhenAbsent() {
+        var snapshot = new ShoutStats(
+                3, 1, 3,
+                List.of(new ShouterCount(11L, 3)),
+                Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+        MessageEmbed embed = ShoutStatsView.embed(snapshot, GUILD, CHANNEL,
+                List.of("<@11>"), null, null, null, null);
+        Map<String, MessageEmbed.Field> fields = fieldsByName(embed);
+        assertFalse(fields.containsKey("First shout"));
+        assertFalse(fields.containsKey("Most recent"));
+        assertFalse(fields.keySet().stream().anyMatch(k -> k.startsWith("Longest")));
+        assertFalse(fields.keySet().stream().anyMatch(k -> k.startsWith("Hall of fame")));
+    }
+
+    private static Map<String, MessageEmbed.Field> fieldsByName(MessageEmbed embed) {
+        return embed.getFields().stream()
+                .collect(java.util.stream.Collectors.toMap(MessageEmbed.Field::getName, f -> f));
+    }
+}


### PR DESCRIPTION
## Summary
Implements the `/shout-stats` slash command, which provides an ephemeral, guild-only statistics snapshot for the current channel. The command aggregates shout data and renders a rich embed showing totals, leaderboards, and notable shouts.

## Key Changes

- **ShoutStats.java** — Value record holding aggregated statistics: total shouts, distinct shouters, 7-day count, top contributors, and notable shouts (oldest, newest, longest, most-replayed).

- **ShoutStatsRepository.java** — jOOQ-backed read-only data access layer with eight focused queries:
  - `countLive()` — total live shouts in a channel
  - `countDistinctShouters()` — unique authors with live shouts
  - `countLiveSince()` — shouts authored within a time window
  - `topShouters()` — leaderboard of top contributors by count
  - `oldest()` / `newest()` — earliest/latest shouts by authored_at
  - `longest()` — shout with most characters
  - `mostReplayed()` — shout with most history entries (joined through `shout_history`)
  - `loadAll()` — convenience method to load all stats in one place
  
  All queries filter soft-deleted shouts so stats match what users can browse.

- **ShoutStatsView.java** — Pure rendering layer (no DB/REST calls) that builds the embed:
  - `embedEmpty()` — fallback when no shouts exist
  - `embed()` — main embed builder with all sections (totals, leaderboard, notable shouts)
  - `renderLeaderboard()` — formats top shouters with medal emoji (🥇🥈🥉) and pluralized counts
  - `renderShoutLine()` — author mention, timestamp, and jump-to-message link
  - `renderShoutPreview()` — shout line plus truncated content preview (200 char limit)
  - `truncate()` — utility for safe string truncation with ellipsis

- **ShoutStatsHandler.java** — Slash command listener that:
  - Loads the channel's stat snapshot
  - Resolves all referenced user IDs to Discord mentions in parallel (with fallback for departed members)
  - Renders the embed via ShoutStatsView
  - Defers the reply since member resolution makes REST calls

- **ShoutStatsRepositorySqliteTest.java** — Comprehensive end-to-end test suite (225 lines) covering:
  - Empty channel behavior (all zeros/empty optionals)
  - Live/deleted/cross-channel filtering
  - Distinct shouter counting
  - Time-window filtering
  - Leaderboard ordering and limits
  - Oldest/newest/longest selection logic
  - Most-replayed join and aggregation
  - Full snapshot assembly via `loadAll()`

- **ShoutStatsViewTest.java** — Unit tests for rendering logic:
  - Empty embed clarity
  - Leaderboard formatting with medals and singular/plural shouts
  - Embed field assembly and optional section skipping
  - Shout line and preview rendering with truncation
  - Author reference resolution

- **README.md** — Documentation of the new command and its output sections.

- **ShoutModule.java** — Updated module docstring to mention the new command.

## Notable Implementation Details

- **No transaction wrapping** — The eight queries in `ShoutStatsRepository` run independently, so a shout authored mid-call could appear in some counts and not others. The inconsistency window is sub-second and acceptable for best-effort stats.

- **Soft-delete filtering** — All queries check `DELETED_AT IS NOT NULL` so stats always reflect what's browseable via `/shout-history`.

- **Parallel member resolution** — The handler uses `CompletableFuture` to resolve all user IDs concurrently, with graceful fallback to "Former member" for departed users or resolution failures.

- **Deterministic ordering** — Tie-breaking in `longest()` and `mostReplayed()` uses secondary sort keys (authored_at, ID) to ensure consistent results across

https://claude.ai/code/session_0132oNuqJjJkwHKVF5dhq1gX