### PR TITLE
Add auto-shortener feature to replace long URLs in messages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,15 @@ CHATTERBOX_SHORTENER_BASE_URL=https://example.com
 # Port the bot's internal HTTP server binds to. Traefik routes traffic here;
 # the port is not published on the host.
 CHATTERBOX_HTTP_PORT=8080
+# Auto-shorten long URLs in guild messages. When true, the bot watches
+# messages for HTTP(S) URLs longer than the threshold below, mints short
+# links, and replaces the original message. Requires the bot to have
+# Manage Messages in each channel where shortening should happen.
+# Wrap a URL in angle brackets (<https://...>) to opt out per-message.
+CHATTERBOX_AUTOSHORTEN_ENABLED=true
+# Minimum URL length (characters) that triggers auto-shortening.
+# Defaults err on the side of leaving URLs alone.
+CHATTERBOX_AUTOSHORTEN_THRESHOLD=160
 
 # Reverse proxy / TLS configuration.
 # These values produce the Traefik labels on the chatterbox container; the

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ deployment.
 | `CHATTERBOX_DEV_MODE`      | no       | `false` | When `true`, slash commands register per-guild for instant updates. When `false`, they register globally. The opposite scope is cleared on each startup, so switching modes never leaves duplicates. |
 | `CHATTERBOX_LOG_LEVEL`     | no       | `INFO`  | Root logger level. |
 | `CHATTERBOX_HTTP_PORT`     | no       | `8080`  | Port the bot's internal HTTP server binds to. The server only starts when at least one module registers a route. |
-| `CHATTERBOX_SHORTENER_BASE_URL` | no  | —       | Public-facing prefix for the URL shortener (e.g. `https://example.com`). Required only when `/shorten` is invoked; the bot can run without it set. |
+| `CHATTERBOX_SHORTENER_BASE_URL` | no  | —       | Public-facing prefix for the URL shortener (e.g. `https://example.com`). Required only when `/shorten` is invoked or `CHATTERBOX_AUTOSHORTEN_ENABLED=true`; the bot can run without it set. |
+| `CHATTERBOX_AUTOSHORTEN_ENABLED` | no | `true` | Auto-shorten long URLs in guild messages by replacing the originals. Requires the bot to have **Manage Messages** in each channel. See [Auto-shortener](#auto-shortener). |
+| `CHATTERBOX_AUTOSHORTEN_THRESHOLD` | no | `160` | Minimum URL length (characters) that triggers auto-shortening. |
 
 ## Building
 
@@ -390,6 +392,69 @@ Public endpoint exposed via Javalin. Outcomes:
 - **Unknown token** — `404 Not Found`.
 
 Token lookups are case-insensitive.
+
+#### Auto-shortener
+
+When `CHATTERBOX_AUTOSHORTEN_ENABLED=true` (the default), the bot watches
+guild messages and quietly replaces the user's message with one of its own
+when any URL in the body exceeds `CHATTERBOX_AUTOSHORTEN_THRESHOLD`
+characters (default `160`). Defaults err on the side of leaving URLs alone.
+
+Behaviour:
+
+- **Skip conditions**: bot/system/webhook/self messages, DMs, messages
+  with no URLs over the threshold, URLs already on the configured short
+  prefix, and any URLs found inside code spans / triple-backtick blocks /
+  spoilers / Markdown links — those formatting structures are intentional
+  and left intact.
+- **Per-message opt-out**: wrap a URL in angle brackets to keep it as-is —
+  e.g. `look at <https://really-long.example/path/...>`. Discord already
+  treats this syntax as "don't auto-embed", so it doubles as our
+  "don't auto-shorten" marker.
+- **Replacement format**: `<@author>: <original text with long URLs swapped>`.
+  Mentions in the rewritten body do not trigger pings — the user's mention
+  renders as their name, but no notification fires (also covers any other
+  mentions copied from the original message).
+- **Reply threading**: if the original was a reply to another message, the
+  replacement is too. With `failOnInvalidReply(false)` so a deleted
+  reply target doesn't block the post.
+- **Provenance**: rows minted by the auto-shortener are attributed to the
+  *original author's* user ID and the *original message's* timestamp, so
+  `/shorten delete` and audit lookups identify the right user.
+- **Failure ordering**: the replacement is posted *before* the original is
+  deleted. A failed post never erases the user's text; a failed delete
+  leaves both messages briefly with a logged warning so a moderator can
+  clean up.
+
+The bot needs **Manage Messages** in every channel where shortening
+should happen. Without it, the listener logs a warning and skips.
+
+##### Granting Manage Messages to the bot in your server
+
+If the bot is already in your server but doesn't have Manage Messages,
+the easiest fix is to grant the permission to the bot's role
+server-wide:
+
+1. Open your server's **Server Settings → Roles**.
+2. Find the bot's role (typically named after the bot, e.g. `Chatterbox`)
+   and click it.
+3. On the **Permissions** tab, scroll to **Text Channel Permissions** and
+   enable **Manage Messages**. Save.
+
+If you'd rather scope the permission to specific channels:
+
+1. Right-click the channel → **Edit Channel → Permissions**.
+2. Add the bot's role under **Roles/Members** (if not already present).
+3. Toggle **Manage Messages** to ✓ for that role. Save.
+
+If you're re-inviting the bot, append `&permissions=8192` (Manage Messages)
+to the existing permissions integer in your invite URL — or, easiest, use
+Discord's permissions calculator on the bot's developer-portal page to
+check the box and copy the new install URL.
+
+After the role gains the permission, no restart is needed — the bot
+checks per-message and starts auto-shortening on the next eligible
+message.
 
 ### Shout
 

--- a/src/main/java/ca/ryanmorrison/chatterbox/config/Config.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/config/Config.java
@@ -5,6 +5,7 @@ public record Config(
         boolean devMode,
         DatabaseConfig database,
         HttpConfig http,
+        ShortenerConfig shortener,
         String logLevel) {
 
     public record DatabaseConfig(String url, String user, String password) {
@@ -13,6 +14,18 @@ public record Config(
     }
 
     public record HttpConfig(int port) {}
+
+    /**
+     * URL shortener feature configuration.
+     *
+     * @param autoShortenEnabled  when true, the bot scans guild messages for
+     *                            HTTP(S) URLs and replaces overly long ones
+     *                            with short links.
+     * @param autoShortenThreshold a URL must exceed this many characters
+     *                             before auto-shortening kicks in. Defaults
+     *                             err on the side of leaving URLs alone.
+     */
+    public record ShortenerConfig(boolean autoShortenEnabled, int autoShortenThreshold) {}
 
     public static Config fromEnvironment() {
         return fromEnvironment(System::getenv);
@@ -30,7 +43,14 @@ public record Config(
                 envOrDefault(env, "CHATTERBOX_DB_USER", ""),
                 envOrDefault(env, "CHATTERBOX_DB_PASSWORD", ""));
 
-        return new Config(token, devMode, db, new HttpConfig(httpPort), logLevel);
+        boolean autoShortenEnabled = Boolean.parseBoolean(
+                envOrDefault(env, "CHATTERBOX_AUTOSHORTEN_ENABLED", "true"));
+        int autoShortenThreshold = parsePositiveInt(
+                envOrDefault(env, "CHATTERBOX_AUTOSHORTEN_THRESHOLD", "160"),
+                "CHATTERBOX_AUTOSHORTEN_THRESHOLD");
+        var shortener = new ShortenerConfig(autoShortenEnabled, autoShortenThreshold);
+
+        return new Config(token, devMode, db, new HttpConfig(httpPort), shortener, logLevel);
     }
 
     private static int parsePort(String raw) {
@@ -42,6 +62,18 @@ public record Config(
             return p;
         } catch (NumberFormatException e) {
             throw new IllegalStateException("CHATTERBOX_HTTP_PORT is not a valid integer: " + raw, e);
+        }
+    }
+
+    private static int parsePositiveInt(String raw, String key) {
+        try {
+            int v = Integer.parseInt(raw);
+            if (v <= 0) {
+                throw new IllegalStateException(key + " must be > 0, got " + v);
+            }
+            return v;
+        } catch (NumberFormatException e) {
+            throw new IllegalStateException(key + " is not a valid integer: " + raw, e);
         }
     }
 

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/shortener/AutoShortenListener.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/shortener/AutoShortenListener.java
@@ -1,0 +1,179 @@
+package ca.ryanmorrison.chatterbox.features.shortener;
+
+import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.channel.middleman.GuildMessageChannel;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.OffsetDateTime;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * Listens for guild messages and auto-shortens long HTTP(S) URLs.
+ *
+ * <h2>Pipeline</h2>
+ * <ol>
+ *   <li>Skip messages from bots, system events, DMs, and the bot itself.</li>
+ *   <li>Tokenise the content via {@link MessageRewriter}; this isolates
+ *       URLs that aren't inside code spans/blocks, spoilers, markdown
+ *       links, or angle-bracket opt-outs.</li>
+ *   <li>For each candidate URL, mint (or look up) a short token via the
+ *       shared {@link ShortenerRepository}, attributing it to the original
+ *       author and original message timestamp.</li>
+ *   <li>Post a replacement message (mention-suppressed) under the bot's
+ *       identity, then delete the original. Replacement is posted first so a
+ *       failed post never erases the user's text.</li>
+ * </ol>
+ *
+ * <h2>Skip conditions</h2>
+ * The listener is a no-op when:
+ * <ul>
+ *   <li>{@code CHATTERBOX_AUTOSHORTEN_ENABLED} is false (handled by
+ *       {@link ShortenerModule} not registering us).</li>
+ *   <li>{@code CHATTERBOX_SHORTENER_BASE_URL} is unset — without it we
+ *       can't construct the replacement URL.</li>
+ *   <li>The bot lacks {@link Permission#MESSAGE_MANAGE} in the channel.
+ *       Logged at WARN once per call.</li>
+ *   <li>The rewritten message would exceed Discord's 2000-character cap.</li>
+ *   <li>None of the URLs in the message are over the configured threshold.</li>
+ *   <li>The URL is already on the configured short-URL prefix (don't
+ *       re-shorten ourselves).</li>
+ * </ul>
+ *
+ * <h2>Failure ordering</h2>
+ * Replacement posted first, original deleted only if the post succeeded.
+ * If the delete subsequently fails, both messages exist briefly and a
+ * moderator can clean up — preferable to silently erasing the user's text.
+ */
+final class AutoShortenListener extends ListenerAdapter {
+
+    static final int MAX_TOKEN_ATTEMPTS = 10;
+    static final int DISCORD_MESSAGE_LIMIT = 2000;
+
+    private static final Logger log = LoggerFactory.getLogger(AutoShortenListener.class);
+
+    private final ShortenerRepository repository;
+    private final TokenGenerator tokenGenerator;
+    private final Supplier<String> baseUrlSupplier;
+    private final int threshold;
+
+    AutoShortenListener(ShortenerRepository repository, TokenGenerator tokenGenerator,
+                        Supplier<String> baseUrlSupplier, int threshold) {
+        this.repository = repository;
+        this.tokenGenerator = tokenGenerator;
+        this.baseUrlSupplier = baseUrlSupplier;
+        this.threshold = threshold;
+    }
+
+    @Override
+    public void onMessageReceived(MessageReceivedEvent event) {
+        if (!event.isFromGuild()) return;
+        if (event.getAuthor().isBot()) return;
+        if (event.isWebhookMessage()) return;
+        if (event.getAuthor().getIdLong() == event.getJDA().getSelfUser().getIdLong()) return;
+
+        Message message = event.getMessage();
+        String content = message.getContentRaw();
+        if (content.isBlank()) return;
+
+        String baseUrl = resolveBaseUrl();
+        if (baseUrl == null) return;
+
+        List<MessageRewriter.Span> spans = MessageRewriter.tokenize(content);
+
+        // Walk the spans, deciding which URLs to shorten. Same URL repeated in
+        // one message hits the shortener once and is replaced everywhere.
+        Map<String, String> substitutions = new LinkedHashMap<>();
+        for (MessageRewriter.Span span : spans) {
+            if (!(span instanceof MessageRewriter.Span.ShortenableUrl(String url))) continue;
+            if (substitutions.containsKey(url)) continue;
+            if (url.length() < threshold) continue;
+            if (isAlreadyShort(url, baseUrl)) continue;
+
+            Optional<String> token = mintToken(url, event.getAuthor().getIdLong(), message.getTimeCreated());
+            if (token.isEmpty()) continue;
+            substitutions.put(url, buildShortUrl(baseUrl, token.get()));
+        }
+
+        if (substitutions.isEmpty()) return;
+
+        String rewritten = MessageRewriter.rewrite(spans, url -> Optional.ofNullable(substitutions.get(url)));
+        if (rewritten.equals(content)) return;
+
+        String authorMention = event.getAuthor().getAsMention();
+        String fullMessage = authorMention + ": " + rewritten;
+        if (fullMessage.length() > DISCORD_MESSAGE_LIMIT) {
+            log.debug("Skipping auto-shorten — rewritten message would exceed Discord's {} char cap.",
+                    DISCORD_MESSAGE_LIMIT);
+            return;
+        }
+
+        GuildMessageChannel channel = event.getGuildChannel();
+        Member self = event.getGuild().getSelfMember();
+        if (!self.hasPermission(channel, Permission.MESSAGE_MANAGE)) {
+            log.warn("Lacking MESSAGE_MANAGE in channel {} (#{}); skipping auto-shorten. "
+                            + "Grant the bot Manage Messages to enable this feature.",
+                    channel.getId(), channel.getName());
+            return;
+        }
+
+        var post = channel.sendMessage(fullMessage)
+                .setAllowedMentions(EnumSet.noneOf(Message.MentionType.class));
+        Message reply = message.getReferencedMessage();
+        if (reply != null) {
+            post = post.setMessageReference(reply).failOnInvalidReply(false);
+        }
+        post.queue(
+                posted -> message.delete().queue(
+                        v -> {},
+                        err -> log.warn("Auto-shortened message {} but couldn't delete original {}: {}",
+                                posted.getId(), message.getId(), err.toString())),
+                err -> log.warn("Failed to post auto-shortened replacement for {}: {}",
+                        message.getId(), err.toString()));
+    }
+
+    private String resolveBaseUrl() {
+        try {
+            return baseUrlSupplier.get();
+        } catch (RuntimeException e) {
+            log.debug("Auto-shorten skipped: shortener base URL not configured.");
+            return null;
+        }
+    }
+
+    private Optional<String> mintToken(String url, long createdBy, OffsetDateTime createdAt) {
+        Optional<ShortenedUrl> existing = repository.findByUrl(url);
+        if (existing.isPresent()) return Optional.of(existing.get().token());
+
+        for (int attempt = 0; attempt < MAX_TOKEN_ATTEMPTS; attempt++) {
+            String token = tokenGenerator.next();
+            Optional<ShortenedUrl> inserted = repository.insert(token, url, createdBy, createdAt);
+            if (inserted.isPresent()) return Optional.of(inserted.get().token());
+            // Either token collision (retry) or url race (re-read & return).
+            Optional<ShortenedUrl> raced = repository.findByUrl(url);
+            if (raced.isPresent()) return Optional.of(raced.get().token());
+        }
+        log.error("Exhausted {} token attempts auto-shortening URL.", MAX_TOKEN_ATTEMPTS);
+        return Optional.empty();
+    }
+
+    static boolean isAlreadyShort(String url, String baseUrl) {
+        String normalisedBase = baseUrl.toLowerCase(Locale.ROOT);
+        if (!normalisedBase.endsWith("/")) normalisedBase = normalisedBase + "/";
+        return url.toLowerCase(Locale.ROOT).startsWith(normalisedBase);
+    }
+
+    private static String buildShortUrl(String baseUrl, String token) {
+        return baseUrl.endsWith("/") ? baseUrl + token : baseUrl + "/" + token;
+    }
+}

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/shortener/MessageRewriter.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/shortener/MessageRewriter.java
@@ -1,0 +1,187 @@
+package ca.ryanmorrison.chatterbox.features.shortener;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * Pure parser for the auto-shortener: walks a message body, splits it into
+ * literal text and bare-URL spans, and reassembles the body with chosen URLs
+ * substituted. No side effects — testable in isolation.
+ *
+ * <h2>What gets skipped</h2>
+ * URLs inside the following structures are emitted as part of a literal text
+ * span and never offered to the substitution function, so user-formatted
+ * content is left intact:
+ * <ul>
+ *   <li>Triple-backtick code blocks ({@code ```...```})</li>
+ *   <li>Single-backtick code spans ({@code `...`})</li>
+ *   <li>Spoiler tags ({@code ||...||})</li>
+ *   <li>Markdown links ({@code [text](url)}) — the URL is already labelled</li>
+ *   <li>Angle-bracket-wrapped URLs ({@code <https://...>}) — the user opted out
+ *       (mirrors Discord's "don't auto-embed" convention)</li>
+ * </ul>
+ *
+ * <h2>Bare URL boundaries</h2>
+ * A URL ends at the first whitespace or after trailing punctuation that
+ * couldn't reasonably be part of the URL. Trailing {@code )}/{@code ]}/{@code }}
+ * are kept only when a matching opener appears earlier in the URL (so
+ * Wikipedia-style {@code https://en.wikipedia.org/wiki/Foo_(bar)} works).
+ */
+final class MessageRewriter {
+
+    /** A piece of the message: either inert text or a candidate URL. */
+    sealed interface Span {
+        record Text(String text) implements Span {}
+        record ShortenableUrl(String url) implements Span {}
+    }
+
+    private MessageRewriter() {}
+
+    static List<Span> tokenize(String content) {
+        List<Span> spans = new ArrayList<>();
+        StringBuilder buf = new StringBuilder();
+        int i = 0;
+        int n = content.length();
+
+        while (i < n) {
+            // Triple-backtick code block — outermost so it wins over single backtick.
+            if (content.startsWith("```", i)) {
+                int end = content.indexOf("```", i + 3);
+                if (end >= 0) {
+                    flushBuffer(spans, buf);
+                    spans.add(new Span.Text(content.substring(i, end + 3)));
+                    i = end + 3;
+                    continue;
+                }
+            }
+            char c = content.charAt(i);
+
+            // Single-backtick code span.
+            if (c == '`') {
+                int end = content.indexOf('`', i + 1);
+                if (end >= 0) {
+                    flushBuffer(spans, buf);
+                    spans.add(new Span.Text(content.substring(i, end + 1)));
+                    i = end + 1;
+                    continue;
+                }
+            }
+
+            // Spoiler.
+            if (c == '|' && content.startsWith("||", i)) {
+                int end = content.indexOf("||", i + 2);
+                if (end >= 0) {
+                    flushBuffer(spans, buf);
+                    spans.add(new Span.Text(content.substring(i, end + 2)));
+                    i = end + 2;
+                    continue;
+                }
+            }
+
+            // Markdown link [text](url) — keep the whole structure as text.
+            if (c == '[') {
+                int closeBracket = content.indexOf(']', i + 1);
+                if (closeBracket >= 0
+                        && closeBracket + 1 < n
+                        && content.charAt(closeBracket + 1) == '(') {
+                    int closeParen = content.indexOf(')', closeBracket + 2);
+                    if (closeParen >= 0) {
+                        flushBuffer(spans, buf);
+                        spans.add(new Span.Text(content.substring(i, closeParen + 1)));
+                        i = closeParen + 1;
+                        continue;
+                    }
+                }
+            }
+
+            // Angle-bracket URL — opt-out wrapper.
+            if (c == '<') {
+                int closeAngle = content.indexOf('>', i + 1);
+                if (closeAngle >= 0) {
+                    String inside = content.substring(i + 1, closeAngle);
+                    if (looksLikeUrl(inside)) {
+                        flushBuffer(spans, buf);
+                        spans.add(new Span.Text(content.substring(i, closeAngle + 1)));
+                        i = closeAngle + 1;
+                        continue;
+                    }
+                }
+            }
+
+            // Bare HTTP(S) URL.
+            if ((c == 'h' || c == 'H')
+                    && (content.regionMatches(true, i, "http://", 0, 7)
+                            || content.regionMatches(true, i, "https://", 0, 8))) {
+                int urlEnd = findBareUrlEnd(content, i);
+                if (urlEnd > i) {
+                    flushBuffer(spans, buf);
+                    spans.add(new Span.ShortenableUrl(content.substring(i, urlEnd)));
+                    i = urlEnd;
+                    continue;
+                }
+            }
+
+            buf.append(c);
+            i++;
+        }
+        flushBuffer(spans, buf);
+        return spans;
+    }
+
+    /**
+     * Reassembles a tokenised message with each {@code ShortenableUrl} optionally
+     * rewritten via the supplied function. Returning {@link Optional#empty()}
+     * means "leave this URL alone".
+     */
+    static String rewrite(List<Span> spans, Function<String, Optional<String>> substitution) {
+        StringBuilder out = new StringBuilder();
+        for (Span span : spans) {
+            switch (span) {
+                case Span.Text(String text) -> out.append(text);
+                case Span.ShortenableUrl(String url) ->
+                        out.append(substitution.apply(url).orElse(url));
+            }
+        }
+        return out.toString();
+    }
+
+    private static void flushBuffer(List<Span> spans, StringBuilder buf) {
+        if (buf.isEmpty()) return;
+        spans.add(new Span.Text(buf.toString()));
+        buf.setLength(0);
+    }
+
+    private static boolean looksLikeUrl(String s) {
+        return s.regionMatches(true, 0, "http://", 0, 7)
+                || s.regionMatches(true, 0, "https://", 0, 8);
+    }
+
+    /**
+     * Finds the end of a bare URL starting at {@code start}. Consumes
+     * non-whitespace, then trims trailing punctuation that was almost
+     * certainly part of the surrounding sentence rather than the URL.
+     */
+    static int findBareUrlEnd(String content, int start) {
+        int i = start;
+        int n = content.length();
+        while (i < n && !Character.isWhitespace(content.charAt(i))) {
+            i++;
+        }
+        while (i > start && shouldTrim(content.charAt(i - 1), content.substring(start, i))) {
+            i--;
+        }
+        return i;
+    }
+
+    private static boolean shouldTrim(char c, String urlSoFar) {
+        return switch (c) {
+            case '.', ',', '!', '?', ';', ':', '"', '\'' -> true;
+            case ')' -> urlSoFar.indexOf('(') < 0;
+            case ']' -> urlSoFar.indexOf('[') < 0;
+            case '}' -> urlSoFar.indexOf('{') < 0;
+            default -> false;
+        };
+    }
+}

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/shortener/ShortenerModule.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/shortener/ShortenerModule.java
@@ -8,8 +8,11 @@ import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
+import net.dv8tion.jda.api.requests.GatewayIntent;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 /**
  * URL shortener feature.
@@ -28,10 +31,18 @@ import java.util.List;
  * 410 Gone if the token has been soft-deleted, 404 if unknown. The bot-wide
  * HTTP server only binds when this (or another) module registers a route.
  *
+ * <p>Auto-shortener: when {@code CHATTERBOX_AUTOSHORTEN_ENABLED} is true
+ * (default), the module also installs an {@link AutoShortenListener} that
+ * watches guild messages, replaces URLs longer than
+ * {@code CHATTERBOX_AUTOSHORTEN_THRESHOLD} characters with short links, and
+ * deletes the originals. Requires {@link net.dv8tion.jda.api.Permission#MESSAGE_MANAGE}
+ * in each channel; without it the listener is a no-op.
+ *
  * <p>Configuration: the public-facing prefix used to construct the link
  * returned to Discord users is read lazily from
  * {@code CHATTERBOX_SHORTENER_BASE_URL} when {@code /shorten} is first
- * invoked, so the bot can run without it set as long as the command isn't used.
+ * invoked, so the bot can run without it set as long as no shortening
+ * happens. The auto-shortener simply skips messages while it's unset.
  */
 public final class ShortenerModule implements Module {
 
@@ -39,8 +50,23 @@ public final class ShortenerModule implements Module {
 
     private ShortenerHandler handler;
     private ShortenerRedirectHandler redirectHandler;
+    private AutoShortenListener autoShortenListener;
 
     @Override public String name() { return "shortener"; }
+
+    /**
+     * The auto-shortener needs to read message bodies, which requires the
+     * privileged {@code MESSAGE_CONTENT} intent. We always request it (and
+     * {@code GUILD_MESSAGES}) so toggling {@code CHATTERBOX_AUTOSHORTEN_ENABLED}
+     * doesn't require a re-deploy with intent changes — those toggles are
+     * commonly used as a "kill switch" in production. When disabled, the
+     * listener isn't registered and any received message events are dropped
+     * without action.
+     */
+    @Override
+    public Set<GatewayIntent> intents() {
+        return Set.of(GatewayIntent.GUILD_MESSAGES, GatewayIntent.MESSAGE_CONTENT);
+    }
 
     @Override
     public List<String> migrationLocations() {
@@ -69,7 +95,12 @@ public final class ShortenerModule implements Module {
     @Override
     public List<EventListener> listeners(InitContext ctx) {
         ensureWired(ctx);
-        return List.of(handler);
+        List<EventListener> result = new ArrayList<>(2);
+        result.add(handler);
+        if (autoShortenListener != null) {
+            result.add(autoShortenListener);
+        }
+        return result;
     }
 
     @Override
@@ -81,8 +112,15 @@ public final class ShortenerModule implements Module {
     private void ensureWired(InitContext ctx) {
         if (handler != null) return;
         var repository = new ShortenerRepository(ctx.database());
-        this.handler = new ShortenerHandler(repository, new TokenGenerator(), ShortenerModule::resolveBaseUrl);
+        var tokenGenerator = new TokenGenerator();
+        this.handler = new ShortenerHandler(repository, tokenGenerator, ShortenerModule::resolveBaseUrl);
         this.redirectHandler = new ShortenerRedirectHandler(repository);
+
+        var cfg = ctx.config().shortener();
+        if (cfg.autoShortenEnabled()) {
+            this.autoShortenListener = new AutoShortenListener(
+                    repository, tokenGenerator, ShortenerModule::resolveBaseUrl, cfg.autoShortenThreshold());
+        }
     }
 
     private static String resolveBaseUrl() {

--- a/src/test/java/ca/ryanmorrison/chatterbox/config/ConfigTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/config/ConfigTest.java
@@ -54,4 +54,54 @@ class ConfigTest {
                         "CHATTERBOX_DISCORD_TOKEN", "abc"
                 )::get));
     }
+
+    @Test
+    void autoShortenDefaultsToEnabledAt160() {
+        Config cfg = Config.fromEnvironment(Map.of(
+                "CHATTERBOX_DISCORD_TOKEN", "abc",
+                "CHATTERBOX_DB_URL", "jdbc:sqlite:./x.db"
+        )::get);
+        assertTrue(cfg.shortener().autoShortenEnabled());
+        assertEquals(160, cfg.shortener().autoShortenThreshold());
+    }
+
+    @Test
+    void autoShortenCanBeDisabled() {
+        Config cfg = Config.fromEnvironment(Map.of(
+                "CHATTERBOX_DISCORD_TOKEN", "abc",
+                "CHATTERBOX_DB_URL", "jdbc:sqlite:./x.db",
+                "CHATTERBOX_AUTOSHORTEN_ENABLED", "false"
+        )::get);
+        assertFalse(cfg.shortener().autoShortenEnabled());
+    }
+
+    @Test
+    void autoShortenThresholdIsParsed() {
+        Config cfg = Config.fromEnvironment(Map.of(
+                "CHATTERBOX_DISCORD_TOKEN", "abc",
+                "CHATTERBOX_DB_URL", "jdbc:sqlite:./x.db",
+                "CHATTERBOX_AUTOSHORTEN_THRESHOLD", "200"
+        )::get);
+        assertEquals(200, cfg.shortener().autoShortenThreshold());
+    }
+
+    @Test
+    void autoShortenThresholdMustBePositive() {
+        assertThrows(IllegalStateException.class,
+                () -> Config.fromEnvironment(Map.of(
+                        "CHATTERBOX_DISCORD_TOKEN", "abc",
+                        "CHATTERBOX_DB_URL", "jdbc:sqlite:./x.db",
+                        "CHATTERBOX_AUTOSHORTEN_THRESHOLD", "0"
+                )::get));
+    }
+
+    @Test
+    void autoShortenThresholdMustBeAnInteger() {
+        assertThrows(IllegalStateException.class,
+                () -> Config.fromEnvironment(Map.of(
+                        "CHATTERBOX_DISCORD_TOKEN", "abc",
+                        "CHATTERBOX_DB_URL", "jdbc:sqlite:./x.db",
+                        "CHATTERBOX_AUTOSHORTEN_THRESHOLD", "not-a-number"
+                )::get));
+    }
 }

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/shortener/AutoShortenListenerTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/shortener/AutoShortenListenerTest.java
@@ -1,0 +1,43 @@
+package ca.ryanmorrison.chatterbox.features.shortener;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Listener-side coverage is limited to the pure helpers — JDA's event
+ * surface isn't worth mocking for the side-effecting bits, which are
+ * exercised on staging.
+ */
+class AutoShortenListenerTest {
+
+    @Test
+    void recognisesUrlsAlreadyOnConfiguredBase() {
+        assertTrue(AutoShortenListener.isAlreadyShort(
+                "https://example.com/abc123", "https://example.com"));
+        assertTrue(AutoShortenListener.isAlreadyShort(
+                "https://example.com/abc123", "https://example.com/"));
+    }
+
+    @Test
+    void caseInsensitiveOnHostAndScheme() {
+        assertTrue(AutoShortenListener.isAlreadyShort(
+                "HTTPS://EXAMPLE.COM/AbC123", "https://example.com"));
+    }
+
+    @Test
+    void rejectsUrlsOnDifferentHost() {
+        assertFalse(AutoShortenListener.isAlreadyShort(
+                "https://other.example/abc123", "https://example.com"));
+    }
+
+    @Test
+    void rejectsHostnameSubstringMatches() {
+        // "https://example.com.attacker.test/..." starts with "https://example.com"
+        // textually but is on a different host. The trailing slash on the
+        // normalised base prevents a false positive.
+        assertFalse(AutoShortenListener.isAlreadyShort(
+                "https://example.com.attacker.test/abc123", "https://example.com"));
+    }
+}

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/shortener/MessageRewriterTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/shortener/MessageRewriterTest.java
@@ -1,0 +1,193 @@
+package ca.ryanmorrison.chatterbox.features.shortener;
+
+import ca.ryanmorrison.chatterbox.features.shortener.MessageRewriter.Span;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MessageRewriterTest {
+
+    /** A substitution that replaces every shortenable URL with a fixed short URL. */
+    private static final Function<String, Optional<String>> SHORTEN_ALL =
+            url -> Optional.of("https://x.test/abc123");
+
+    /** A substitution that leaves every URL alone. */
+    private static final Function<String, Optional<String>> SHORTEN_NONE = url -> Optional.empty();
+
+    @Test
+    void emptyContentProducesNoSpans() {
+        assertTrue(MessageRewriter.tokenize("").isEmpty());
+    }
+
+    @Test
+    void plainTextProducesSingleTextSpan() {
+        var spans = MessageRewriter.tokenize("hello world, no url here");
+        assertEquals(1, spans.size());
+        assertInstanceOf(Span.Text.class, spans.get(0));
+        assertEquals("hello world, no url here", ((Span.Text) spans.get(0)).text());
+    }
+
+    @Test
+    void bareUrlIsExtractedAsItsOwnSpan() {
+        var spans = MessageRewriter.tokenize("hey check https://example.com/foo cool");
+        assertEquals(3, spans.size());
+        assertEquals("hey check ", textOf(spans.get(0)));
+        assertEquals("https://example.com/foo", urlOf(spans.get(1)));
+        assertEquals(" cool", textOf(spans.get(2)));
+    }
+
+    @Test
+    void httpAndHttpsBothMatch() {
+        assertEquals("http://example.com",
+                urlOf(MessageRewriter.tokenize("see http://example.com").get(1)));
+        assertEquals("https://example.com",
+                urlOf(MessageRewriter.tokenize("see https://example.com").get(1)));
+    }
+
+    @Test
+    void schemeMatchIsCaseInsensitive() {
+        assertEquals("HTTPS://EXAMPLE.COM/X",
+                urlOf(MessageRewriter.tokenize("see HTTPS://EXAMPLE.COM/X here").get(1)));
+    }
+
+    @Test
+    void trailingSentencePunctuationIsTrimmed() {
+        var spans = MessageRewriter.tokenize("look at https://example.com/foo.");
+        assertEquals("https://example.com/foo", urlOf(spans.get(1)));
+        assertEquals(".", textOf(spans.get(2)));
+    }
+
+    @Test
+    void wikipediaParensAreKeptWhenMatched() {
+        var spans = MessageRewriter.tokenize("https://en.wikipedia.org/wiki/Example_(song)");
+        assertEquals(1, spans.size());
+        assertEquals("https://en.wikipedia.org/wiki/Example_(song)", urlOf(spans.get(0)));
+    }
+
+    @Test
+    void unmatchedTrailingClosingParenIsTrimmed() {
+        var spans = MessageRewriter.tokenize("(see https://example.com/foo)");
+        assertEquals("https://example.com/foo", urlOf(spans.get(1)));
+        assertEquals(")", textOf(spans.get(2)));
+    }
+
+    @Test
+    void angleBracketUrlIsOptOut() {
+        var spans = MessageRewriter.tokenize("don't shorten <https://really-long.example/path> please");
+        // Angle-wrapped URL must be a single text span, not a ShortenableUrl.
+        for (Span s : spans) {
+            assertTrue(!(s instanceof Span.ShortenableUrl),
+                    "angle-bracket URL should not be eligible for shortening");
+        }
+        assertEquals("don't shorten <https://really-long.example/path> please",
+                MessageRewriter.rewrite(spans, SHORTEN_ALL));
+    }
+
+    @Test
+    void angleBracketWithoutUrlIsNotConsumed() {
+        // <foo> is not a URL opt-out — should not swallow surrounding URLs.
+        var spans = MessageRewriter.tokenize("<foo> https://example.com/bar");
+        // Find the URL span.
+        boolean found = spans.stream().anyMatch(s -> s instanceof Span.ShortenableUrl);
+        assertTrue(found, "bare URL after non-URL angle brackets should still be eligible");
+    }
+
+    @Test
+    void inlineCodeSpanProtectsUrls() {
+        var spans = MessageRewriter.tokenize("compare `https://example.com/inline` with regular");
+        for (Span s : spans) {
+            assertTrue(!(s instanceof Span.ShortenableUrl),
+                    "URL inside backticks should not be eligible");
+        }
+    }
+
+    @Test
+    void tripleBacktickBlockProtectsUrls() {
+        String body = "before ```\nhttps://example.com/inblock\n``` after https://example.com/outside";
+        var spans = MessageRewriter.tokenize(body);
+        long urlCount = spans.stream().filter(s -> s instanceof Span.ShortenableUrl).count();
+        assertEquals(1, urlCount, "only the URL outside the code block should be eligible");
+    }
+
+    @Test
+    void spoilerProtectsUrls() {
+        var spans = MessageRewriter.tokenize("warn ||https://example.com/spoiler|| hidden");
+        for (Span s : spans) {
+            assertTrue(!(s instanceof Span.ShortenableUrl),
+                    "URL inside spoiler should not be eligible");
+        }
+    }
+
+    @Test
+    void markdownLinkIsLeftAlone() {
+        var spans = MessageRewriter.tokenize("see [the docs](https://example.com/docs) please");
+        for (Span s : spans) {
+            assertTrue(!(s instanceof Span.ShortenableUrl),
+                    "URL inside markdown link should not be eligible");
+        }
+    }
+
+    @Test
+    void rewriteSubstitutesEachShortenableUrl() {
+        var spans = MessageRewriter.tokenize("a https://x.example/aaaa b https://y.example/bbbb c");
+        String out = MessageRewriter.rewrite(spans,
+                url -> Optional.of(url.contains("x.example") ? "https://s/1" : "https://s/2"));
+        assertEquals("a https://s/1 b https://s/2 c", out);
+    }
+
+    @Test
+    void rewritePassesThroughUrlsWhenSubstitutionEmpty() {
+        String body = "a https://x.example/aaaa b https://y.example/bbbb c";
+        var spans = MessageRewriter.tokenize(body);
+        assertEquals(body, MessageRewriter.rewrite(spans, SHORTEN_NONE));
+    }
+
+    @Test
+    void multipleStructuresInOneMessageAreTokenizedCorrectly() {
+        String body = "outer `code` and ||spoiler|| then [link](https://md.example/x) "
+                + "and <https://opt.example/y> and finally https://bare.example/z!";
+        var spans = MessageRewriter.tokenize(body);
+        long urlCount = spans.stream().filter(s -> s instanceof Span.ShortenableUrl).count();
+        assertEquals(1, urlCount, "only the trailing bare URL should be eligible");
+        // Confirm the lone shortenable URL has its trailing ! trimmed off.
+        spans.stream().filter(s -> s instanceof Span.ShortenableUrl)
+                .forEach(s -> assertEquals("https://bare.example/z", urlOf(s)));
+    }
+
+    @Test
+    void unterminatedCodeBlockFallsBackToTextScanning() {
+        // Triple backtick without closer — the URL after it should still be eligible.
+        var spans = MessageRewriter.tokenize("```partial https://example.com/bare");
+        long urlCount = spans.stream().filter(s -> s instanceof Span.ShortenableUrl).count();
+        assertEquals(1, urlCount,
+                "unterminated code block shouldn't swallow URLs that follow");
+    }
+
+    @Test
+    void rewriteRoundTripsUnchangedContent() {
+        String body = "no urls here, just text";
+        assertEquals(body, MessageRewriter.rewrite(MessageRewriter.tokenize(body), SHORTEN_ALL));
+    }
+
+    @Test
+    void sameUrlTwiceIsExtractedTwiceForRewriting() {
+        var spans = MessageRewriter.tokenize("a https://example.com/x b https://example.com/x c");
+        long urlCount = spans.stream().filter(s -> s instanceof Span.ShortenableUrl).count();
+        assertEquals(2, urlCount);
+    }
+
+    @Test
+    void findBareUrlEndStopsAtWhitespace() {
+        String body = "https://example.com/foo bar";
+        assertEquals(body.indexOf(' '), MessageRewriter.findBareUrlEnd(body, 0));
+    }
+
+    private static String textOf(Span s) { return ((Span.Text) s).text(); }
+    private static String urlOf(Span s) { return ((Span.ShortenableUrl) s).url(); }
+}


### PR DESCRIPTION
## Summary

Implements an auto-shortener feature that watches guild messages and automatically replaces long HTTP(S) URLs with short links, then deletes the original message. This is controlled by new configuration flags and respects user intent by skipping URLs in code blocks, spoilers, markdown links, and angle-bracket-wrapped opt-outs.

## Key Changes

- **MessageRewriter** (`MessageRewriter.java`): Pure parser that tokenizes message content into text and shortenable URL spans. Intelligently skips URLs inside:
  - Triple-backtick code blocks
  - Single-backtick code spans
  - Spoiler tags (`||...||`)
  - Markdown links (`[text](url)`)
  - Angle-bracket-wrapped URLs (`<https://...>`) as user opt-out
  
  Handles URL boundary detection with smart trailing punctuation trimming (e.g., Wikipedia URLs with parentheses).

- **AutoShortenListener** (`AutoShortenListener.java`): JDA event listener that:
  - Monitors guild messages and tokenizes them via `MessageRewriter`
  - Mints short tokens for URLs exceeding the configured threshold
  - Posts a replacement message (with suppressed mentions) before deleting the original
  - Attributes shortened URLs to the original author and message timestamp
  - Requires `MESSAGE_MANAGE` permission; logs warning and skips if absent

- **Configuration**: Added two new environment variables:
  - `CHATTERBOX_AUTOSHORTEN_ENABLED` (default: `true`) — toggle the feature
  - `CHATTERBOX_AUTOSHORTEN_THRESHOLD` (default: `160`) — minimum URL length to shorten
  
  Updated `Config` and `ShortenerConfig` records to parse and validate these settings.

- **ShortenerModule**: Registers the `AutoShortenListener` when enabled and declares required gateway intents (`GUILD_MESSAGES`, `MESSAGE_CONTENT`).

- **Comprehensive tests**:
  - `MessageRewriterTest`: 20 tests covering tokenization, URL extraction, protected structures, and rewriting logic
  - `AutoShortenListenerTest`: Tests for the `isAlreadyShort` helper (prevents re-shortening)
  - `ConfigTest`: Tests for parsing and validation of new config flags

## Notable Implementation Details

- **Failure ordering**: Replacement posted before original deletion to ensure user text is never silently erased
- **Reply threading**: Replacement preserves reply context with `failOnInvalidReply(false)` for robustness
- **Deduplication**: Same URL repeated in one message is shortened once and substituted everywhere
- **Mention suppression**: Replacement message uses `setAllowedMentions(EnumSet.noneOf(...))` so copied mentions don't ping
- **Graceful degradation**: Feature skips when base URL is unset, lacks permissions, or would exceed Discord's 2000-char limit

https://claude.ai/code/session_0132oNuqJjJkwHKVF5dhq1gX