### PR TITLE
Add /decide command for random option selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,3 +626,21 @@ Anyone in a guild can `/rss add`. `/rss remove` is restricted to the
 adder of each feed; users with `MESSAGE_MANAGE` in the channel can
 remove any feed. The check is re-applied on the select and confirm
 buttons too, so losing the role mid-flow denies the deletion.
+
+### Decide
+
+`/decide options:<text> [private:<bool>]` — picks one option at random
+and posts it. Two ways to phrase the options string:
+
+- **Whitespace-separated** — `pizza tacos sushi` → three options.
+- **`or`-separated** — when the input contains the standalone word `or`
+  (case-insensitive, surrounded by whitespace), it splits on that
+  instead. Lets multi-word choices read naturally:
+  `say hello or be silent` → `["say hello", "be silent"]`.
+
+Reply renders the chosen option in bold with a "from:" line listing all
+the alternatives, e.g. `🎲 **say hello`\n_(from: say hello · be silent)_`.
+Public by default since decisions are usually shared; pass `private:true`
+to keep the result to yourself. Mentions in the rendered options are
+suppressed so a `/decide options:"@everyone or no"` can't ping the
+channel.

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/decide/DecideModule.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/decide/DecideModule.java
@@ -1,0 +1,93 @@
+package ca.ryanmorrison.chatterbox.features.decide;
+
+import ca.ryanmorrison.chatterbox.module.InitContext;
+import ca.ryanmorrison.chatterbox.module.Module;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.hooks.EventListener;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.Commands;
+import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * {@code /decide} — pick a random option from a free-form list. Public by
+ * default since decisions are usually shared; pass {@code private:true} to
+ * keep the result to yourself.
+ *
+ * <p>Splits via {@link DecideOptionsParser} so users can phrase choices
+ * either as {@code "pizza tacos sushi"} (whitespace) or
+ * {@code "say hello or be silent"} (the word "or").
+ *
+ * <p>Mentions in the rendered options are suppressed so a malicious
+ * {@code /decide options:"@everyone or nope"} can't ping the channel.
+ */
+public final class DecideModule extends ListenerAdapter implements Module {
+
+    static final String COMMAND  = "decide";
+    static final String OPT_OPTIONS = "options";
+    static final String OPT_PRIVATE = "private";
+
+    private static final int MAX_FROM_LINE_LENGTH = 1500;
+
+    @Override public String name() { return "decide"; }
+
+    @Override
+    public List<SlashCommandData> slashCommands(InitContext ctx) {
+        return List.of(Commands.slash(COMMAND, "Pick one of several options at random.")
+                .addOption(OptionType.STRING, OPT_OPTIONS,
+                        "Options separated by whitespace, or use the word \"or\" between them.", true)
+                .addOption(OptionType.BOOLEAN, OPT_PRIVATE,
+                        "Show the result only to you instead of the channel.", false));
+    }
+
+    @Override
+    public List<EventListener> listeners(InitContext ctx) {
+        return List.of(this);
+    }
+
+    @Override
+    public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
+        if (!COMMAND.equals(event.getName())) return;
+
+        OptionMapping optionsOption = event.getOption(OPT_OPTIONS);
+        String raw = optionsOption == null ? null : optionsOption.getAsString();
+        List<String> options = DecideOptionsParser.parse(raw);
+
+        OptionMapping privateOption = event.getOption(OPT_PRIVATE);
+        boolean ephemeral = privateOption != null && privateOption.getAsBoolean();
+
+        if (options.isEmpty()) {
+            event.reply("Give me at least one option to choose from. "
+                    + "Separate them with whitespace, or use the word `or` between them.")
+                    .setEphemeral(true).queue();
+            return;
+        }
+
+        String pick = options.get(ThreadLocalRandom.current().nextInt(options.size()));
+        String body = renderResult(pick, options);
+
+        event.reply(body)
+                .setEphemeral(ephemeral)
+                .setAllowedMentions(EnumSet.noneOf(Message.MentionType.class))
+                .queue();
+    }
+
+    static String renderResult(String pick, List<String> options) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("🎲 **").append(pick).append("**");
+        if (options.size() > 1) {
+            String joined = String.join(" · ", options);
+            if (joined.length() > MAX_FROM_LINE_LENGTH) {
+                joined = joined.substring(0, MAX_FROM_LINE_LENGTH - 1) + "…";
+            }
+            sb.append("\n_(from: ").append(joined).append(")_");
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/decide/DecideOptionsParser.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/decide/DecideOptionsParser.java
@@ -1,0 +1,52 @@
+package ca.ryanmorrison.chatterbox.features.decide;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Splits a free-form {@code /decide} options string into a list of
+ * choices. Two flavours, picked automatically:
+ *
+ * <ul>
+ *   <li><b>"or"-separated</b> — when the input contains the standalone
+ *       word {@code or} (case-insensitive) bracketed by whitespace,
+ *       split on it. Lets users phrase complex choices naturally:
+ *       {@code "say hello or be silent"} → {@code ["say hello", "be silent"]}.</li>
+ *   <li><b>Whitespace-separated</b> — fallback for the bare
+ *       {@code "pizza tacos sushi"} form.</li>
+ * </ul>
+ *
+ * <p>Each option is trimmed; surrounding punctuation
+ * ({@code , . ; : ! ?}) is stripped so {@code "say hello, or be silent"}
+ * parses cleanly. Empty options are dropped.
+ */
+final class DecideOptionsParser {
+
+    /** Matches " or " (any case) bracketed by whitespace, including line breaks. */
+    private static final Pattern OR_SEPARATOR = Pattern.compile("(?i)\\s+or\\s+");
+    private static final Pattern WHITESPACE = Pattern.compile("\\s+");
+    private static final Pattern TRIM_PUNCTUATION = Pattern.compile("^[\\s,.;:!?]+|[\\s,.;:!?]+$");
+
+    private DecideOptionsParser() {}
+
+    /**
+     * @return the parsed options, possibly empty if the input was blank or
+     *         all-punctuation.
+     */
+    static List<String> parse(String raw) {
+        if (raw == null) return List.of();
+        String trimmed = raw.trim();
+        if (trimmed.isEmpty()) return List.of();
+
+        Pattern splitter = OR_SEPARATOR.matcher(trimmed).find()
+                ? OR_SEPARATOR
+                : WHITESPACE;
+
+        return Arrays.stream(splitter.split(trimmed))
+                .map(s -> TRIM_PUNCTUATION.matcher(s).replaceAll(""))
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/resources/META-INF/services/ca.ryanmorrison.chatterbox.module.Module
+++ b/src/main/resources/META-INF/services/ca.ryanmorrison.chatterbox.module.Module
@@ -4,3 +4,4 @@ ca.ryanmorrison.chatterbox.features.autoreply.AutoReplyModule
 ca.ryanmorrison.chatterbox.features.rss.RssModule
 ca.ryanmorrison.chatterbox.features.nhl.NhlModule
 ca.ryanmorrison.chatterbox.features.shortener.ShortenerModule
+ca.ryanmorrison.chatterbox.features.decide.DecideModule

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/decide/DecideModuleTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/decide/DecideModuleTest.java
@@ -1,0 +1,38 @@
+package ca.ryanmorrison.chatterbox.features.decide;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** The slash-handling glue is exercised on staging; this covers the pure renderer. */
+class DecideModuleTest {
+
+    @Test
+    void singleOptionOmitsFromLine() {
+        String rendered = DecideModule.renderResult("yes", List.of("yes"));
+        assertEquals("🎲 **yes**", rendered);
+    }
+
+    @Test
+    void multipleOptionsIncludeFromLine() {
+        String rendered = DecideModule.renderResult("tacos", List.of("pizza", "tacos", "sushi"));
+        assertTrue(rendered.startsWith("🎲 **tacos**"));
+        assertTrue(rendered.contains("\n_(from: pizza · tacos · sushi)_"));
+    }
+
+    @Test
+    void hugeFromLineIsTruncated() {
+        // 200 options of ~10 chars each → ~2000 char joined line, well over the cap.
+        List<String> options = java.util.stream.IntStream.range(0, 200)
+                .mapToObj(i -> "option" + i)
+                .toList();
+        String rendered = DecideModule.renderResult("option0", options);
+        assertTrue(rendered.contains("…"), "should ellipsise an overlong from-line");
+        assertFalse(rendered.length() > 2000,
+                "rendered message must remain under Discord's 2000 char cap");
+    }
+}

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/decide/DecideOptionsParserTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/decide/DecideOptionsParserTest.java
@@ -1,0 +1,107 @@
+package ca.ryanmorrison.chatterbox.features.decide;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DecideOptionsParserTest {
+
+    @Test
+    void splitsOnWhitespaceWhenNoOrPresent() {
+        assertEquals(List.of("pizza", "tacos", "sushi"),
+                DecideOptionsParser.parse("pizza tacos sushi"));
+    }
+
+    @Test
+    void splitsOnOrWhenPresent() {
+        assertEquals(List.of("say hello", "be silent"),
+                DecideOptionsParser.parse("say hello or be silent"));
+    }
+
+    @Test
+    void orMatchIsCaseInsensitive() {
+        assertEquals(List.of("yes", "no"),
+                DecideOptionsParser.parse("yes OR no"));
+        assertEquals(List.of("yes", "no"),
+                DecideOptionsParser.parse("yes Or no"));
+    }
+
+    @Test
+    void multipleOrSeparatedOptions() {
+        assertEquals(List.of("rock", "paper", "scissors"),
+                DecideOptionsParser.parse("rock or paper or scissors"));
+    }
+
+    @Test
+    void orPreemptsWhitespaceWhenBothPresent() {
+        // "say hello or be silent" — whitespace alone would give 5 tokens; the
+        // " or " split is the user-friendly interpretation.
+        List<String> parsed = DecideOptionsParser.parse("say hello or be silent");
+        assertEquals(2, parsed.size());
+    }
+
+    @Test
+    void trimsTrailingPunctuation() {
+        // Common natural phrasing: "say hello, or be silent."
+        assertEquals(List.of("say hello", "be silent"),
+                DecideOptionsParser.parse("say hello, or be silent."));
+    }
+
+    @Test
+    void trimsLeadingPunctuation() {
+        assertEquals(List.of("hi", "bye"), DecideOptionsParser.parse(",hi or ,bye"));
+    }
+
+    @Test
+    void collapsesRunsOfWhitespace() {
+        assertEquals(List.of("a", "b", "c"),
+                DecideOptionsParser.parse("a   b\tc"));
+    }
+
+    @Test
+    void blankInputProducesNoOptions() {
+        assertTrue(DecideOptionsParser.parse("").isEmpty());
+        assertTrue(DecideOptionsParser.parse("   ").isEmpty());
+        assertTrue(DecideOptionsParser.parse(null).isEmpty());
+    }
+
+    @Test
+    void allPunctuationProducesNoOptions() {
+        assertTrue(DecideOptionsParser.parse(",,,...!!!").isEmpty());
+    }
+
+    @Test
+    void singleOptionPassesThrough() {
+        assertEquals(List.of("yes"), DecideOptionsParser.parse("yes"));
+    }
+
+    @Test
+    void wordContainingOrIsNotSplit() {
+        // "morning" contains the substring "or" but the regex requires
+        // whitespace boundaries on both sides.
+        assertEquals(List.of("morning", "evening"),
+                DecideOptionsParser.parse("morning evening"));
+    }
+
+    @Test
+    void unboundedOrAtStartOrEndStaysWithItsToken() {
+        // The separator regex requires whitespace on BOTH sides of "or", so a
+        // leading or trailing "or" without surrounding whitespace is preserved
+        // as part of the adjacent option rather than silently dropped.
+        assertEquals(List.of("or a", "b"), DecideOptionsParser.parse("or a or b"));
+        assertEquals(List.of("a", "b or"), DecideOptionsParser.parse("a or b or"));
+    }
+
+    @Test
+    void rendersOptionsWithMultiwordChoicesIntact() {
+        List<String> parsed = DecideOptionsParser.parse(
+                "drive to the store or order delivery or skip the meal entirely");
+        assertEquals(3, parsed.size());
+        assertEquals("drive to the store", parsed.get(0));
+        assertEquals("order delivery", parsed.get(1));
+        assertEquals("skip the meal entirely", parsed.get(2));
+    }
+}


### PR DESCRIPTION
## Summary
Adds a new `/decide` slash command that picks a random option from a user-provided list. The command supports two input formats for flexibility: whitespace-separated options or options separated by the word "or".

## Changes
- **DecideOptionsParser** — Parses free-form option strings with intelligent splitting:
  - Detects and splits on standalone "or" (case-insensitive, whitespace-bounded) for natural multi-word phrases like "say hello or be silent"
  - Falls back to whitespace splitting for simple lists like "pizza tacos sushi"
  - Trims surrounding punctuation (`,`, `.`, `;`, `:`, `!`, `?`) to handle natural phrasing
  - Collapses whitespace runs and filters empty options

- **DecideModule** — Implements the slash command handler:
  - Registers `/decide options:<text> [private:<bool>]` command
  - Picks a random option and renders it with a "from:" line listing all alternatives
  - Suppresses mentions in output to prevent abuse (e.g., `@everyone` injection)
  - Supports ephemeral replies via the `private` flag
  - Truncates overly long "from:" lines to stay under Discord's 2000 character message limit

- **Tests** — Comprehensive test coverage for both parser and renderer:
  - Parser handles edge cases: unbounded "or", words containing "or", punctuation, whitespace collapse, null/blank input
  - Renderer validates single vs. multi-option formatting and message length constraints

- **Documentation** — Updated README with usage examples and behavior notes

## Notable Details
- The "or" separator requires whitespace on both sides, so words like "morning" are never split
- Unbound "or" at string boundaries (e.g., "or a or b") stays attached to adjacent tokens rather than being silently dropped
- Mention suppression uses `EnumSet.noneOf()` to block all mention types, preventing potential abuse vectors

https://claude.ai/code/session_0132oNuqJjJkwHKVF5dhq1gX