### PR TITLE
Refactor shout commands to use subcommands under /shout

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,10 +467,10 @@ for the classifier rules.
 Requires the **`MESSAGE_CONTENT`** privileged intent — enable it on the bot's
 application page in the Discord Developer Portal.
 
-#### `/shout-history`
+#### `/shout history`
 
 Each successful emission is recorded against the channel. Users can run the
-ephemeral, guild-only `/shout-history` slash command to browse the bot's
+ephemeral, guild-only `/shout history` slash command to browse the bot's
 emissions for the current channel, paginating with **← Older** / **Newer →**
 buttons. The embed shows the original author's server display name, the time
 the shout was first written, and a position indicator (e.g. `Entry 2 of 17`).
@@ -501,7 +501,7 @@ non-moderator's in the same channel.
 The permission is re-checked on every interaction (slash and button), so
 losing the role mid-pagination immediately removes the moderation buttons.
 
-#### `/shout-stats`
+#### `/shout stats`
 
 Ephemeral, guild-only stats snapshot for the current channel. Shows:
 
@@ -517,7 +517,7 @@ Ephemeral, guild-only stats snapshot for the current channel. Shows:
   (joined through `shout_history`), with replay count and jump link.
 
 All counts and lookups exclude soft-deleted shouts so the figures match
-what's browseable via `/shout-history`. There is no moderator-only view.
+what's browseable via `/shout history`. There is no moderator-only view.
 
 ### Autoreply
 

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/shout/ShoutHistoryHandler.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/shout/ShoutHistoryHandler.java
@@ -19,7 +19,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
 /**
- * Slash command and button glue for {@code /shout-history}. Looks up the
+ * Slash command and button glue for {@code /shout history}. Looks up the
  * latest history entry on slash invocation, then steps older / newer / soft-
  * deletes / restores in response to button clicks. Replies are ephemeral, so
  * cross-user button spoofing isn't a concern.
@@ -45,7 +45,8 @@ final class ShoutHistoryHandler extends ListenerAdapter {
 
     @Override
     public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
-        if (!ShoutHistoryView.CMD_NAME.equals(event.getName())) return;
+        if (!ShoutModule.COMMAND.equals(event.getName())) return;
+        if (!ShoutHistoryView.SUBCOMMAND.equals(event.getSubcommandName())) return;
 
         Guild guild = event.getGuild();
         Member member = event.getMember();

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/shout/ShoutHistoryView.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/shout/ShoutHistoryView.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * Pure rendering for the {@code /shout-history} response. Given an entry, the
+ * Pure rendering for the {@code /shout history} response. Given an entry, the
  * resolved author display name, the deleter display name (only relevant when
  * the entry is deleted and the viewer is a moderator), the position info, and
  * a {@code viewerCanModerate} flag, produces the embed and button row.
@@ -21,8 +21,13 @@ import java.util.Optional;
  */
 final class ShoutHistoryView {
 
-    static final String CMD_NAME = "shout-history";
-    static final String BUTTON_PREFIX = CMD_NAME + ":";
+    static final String SUBCOMMAND = "history";
+    /**
+     * Stable namespace for the button component IDs; deliberately distinct
+     * from the slash command path so future {@code /shout} subcommands can't
+     * accidentally collide with active button interactions.
+     */
+    static final String BUTTON_PREFIX = "shout-history:";
     static final String OLDER   = BUTTON_PREFIX + "older:";
     static final String NEWER   = BUTTON_PREFIX + "newer:";
     static final String DELETE  = BUTTON_PREFIX + "delete:";

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/shout/ShoutModule.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/shout/ShoutModule.java
@@ -6,6 +6,7 @@ import net.dv8tion.jda.api.hooks.EventListener;
 import net.dv8tion.jda.api.interactions.InteractionContextType;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
+import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
 import net.dv8tion.jda.api.requests.GatewayIntent;
 
 import java.util.List;
@@ -16,14 +17,16 @@ import java.util.Set;
  * channel, the bot stores it (per channel) and replies with a random
  * previously-stored shout from the same channel.
  *
- * <p>Also exposes {@code /shout-history} (ephemeral, guild-only) so users can
- * page back through emissions in the channel, and {@code /shout-stats}
+ * <p>Also exposes {@code /shout history} (ephemeral, guild-only) so users can
+ * page back through emissions in the channel, and {@code /shout stats}
  * (ephemeral, guild-only) for a per-channel stats snapshot.
  *
  * <p>Requires the {@code MESSAGE_CONTENT} privileged intent. Enable it on the
  * bot's application page in the Discord Developer Portal.
  */
 public final class ShoutModule implements Module {
+
+    static final String COMMAND = "shout";
 
     @Override public String name() { return "shout"; }
 
@@ -50,10 +53,12 @@ public final class ShoutModule implements Module {
 
     @Override
     public List<SlashCommandData> slashCommands(InitContext ctx) {
-        return List.of(
-                Commands.slash(ShoutHistoryView.CMD_NAME, "Browse the bot's shout history for this channel.")
-                        .setContexts(InteractionContextType.GUILD),
-                Commands.slash(ShoutStatsView.CMD_NAME, "Show fun stats about shouts in this channel.")
-                        .setContexts(InteractionContextType.GUILD));
+        return List.of(Commands.slash(COMMAND, "Tools for the shout feature.")
+                .setContexts(InteractionContextType.GUILD)
+                .addSubcommands(
+                        new SubcommandData(ShoutHistoryView.SUBCOMMAND,
+                                "Browse the bot's shout history for this channel."),
+                        new SubcommandData(ShoutStatsView.SUBCOMMAND,
+                                "Show fun stats about shouts in this channel.")));
     }
 }

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/shout/ShoutStats.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/shout/ShoutStats.java
@@ -6,8 +6,8 @@ import java.util.Optional;
 
 /**
  * Aggregated stats for a single channel, computed once and rendered into the
- * {@code /shout-stats} embed. All counts and lookups exclude soft-deleted
- * shouts so the figures match what users can browse via {@code /shout-history}.
+ * {@code /shout stats} embed. All counts and lookups exclude soft-deleted
+ * shouts so the figures match what users can browse via {@code /shout history}.
  *
  * @param totalShouts        live shouts in the channel
  * @param distinctShouters   unique authors with at least one live shout

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/shout/ShoutStatsHandler.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/shout/ShoutStatsHandler.java
@@ -22,12 +22,12 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
 /**
- * Slash handler for {@code /shout-stats}. Loads the channel's stat snapshot,
+ * Slash handler for {@code /shout stats}. Loads the channel's stat snapshot,
  * resolves all referenced user IDs to Discord mentions in parallel, and
  * renders a single embed via {@link ShoutStatsView}.
  *
  * <p>All counts and lookups exclude soft-deleted shouts so the figures
- * always match what's browseable via {@code /shout-history}.
+ * always match what's browseable via {@code /shout history}.
  */
 final class ShoutStatsHandler extends ListenerAdapter {
 
@@ -44,7 +44,8 @@ final class ShoutStatsHandler extends ListenerAdapter {
 
     @Override
     public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
-        if (!ShoutStatsView.CMD_NAME.equals(event.getName())) return;
+        if (!ShoutModule.COMMAND.equals(event.getName())) return;
+        if (!ShoutStatsView.SUBCOMMAND.equals(event.getSubcommandName())) return;
 
         Guild guild = event.getGuild();
         Member member = event.getMember();

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/shout/ShoutStatsRepository.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/shout/ShoutStatsRepository.java
@@ -15,7 +15,7 @@ import static ca.ryanmorrison.chatterbox.db.generated.Tables.SHOUTS;
 import static ca.ryanmorrison.chatterbox.db.generated.Tables.SHOUT_HISTORY;
 
 /**
- * jOOQ-backed read-only access for the {@code /shout-stats} command. All
+ * jOOQ-backed read-only access for the {@code /shout stats} command. All
  * queries filter soft-deleted shouts ({@code deleted_at IS NOT NULL}) so the
  * stats reflect what's actually browseable.
  *

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/shout/ShoutStatsView.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/shout/ShoutStatsView.java
@@ -9,14 +9,14 @@ import net.dv8tion.jda.api.entities.MessageEmbed;
 import java.util.List;
 
 /**
- * Pure rendering for the {@code /shout-stats} response. The handler resolves
+ * Pure rendering for the {@code /shout stats} response. The handler resolves
  * raw shouts to their public-facing references (Discord mentions, jump-to-
  * message links, truncated content previews) and passes everything in via
  * value records, so this class makes no DB or REST calls and is unit-testable.
  */
 final class ShoutStatsView {
 
-    static final String CMD_NAME = "shout-stats";
+    static final String SUBCOMMAND = "stats";
 
     /** Cap on content shown inline so a 2000-char shout doesn't blow the embed field. */
     static final int CONTENT_PREVIEW_LIMIT = 200;


### PR DESCRIPTION
## Summary
Restructured the shout feature's slash commands from two separate top-level commands (`/shout-history` and `/shout-stats`) into subcommands under a single `/shout` parent command (`/shout history` and `/shout stats`).

## Key Changes
- **Command structure**: Consolidated `ShoutHistoryView.CMD_NAME` and `ShoutStatsView.CMD_NAME` into a single `ShoutModule.COMMAND` constant, with separate `SUBCOMMAND` constants in each view class
- **Slash command registration**: Updated `ShoutModule.slashCommands()` to register a single `/shout` command with two subcommands instead of two separate commands
- **Handler updates**: Modified `ShoutHistoryHandler` and `ShoutStatsHandler` to check both the parent command name and subcommand name when filtering events
- **Button namespace**: Explicitly separated button component IDs (`shout-history:`) from the slash command path to prevent future collisions with new `/shout` subcommands
- **Documentation**: Updated all references in comments, docstrings, and README.md to reflect the new command structure

## Implementation Details
- The button prefix for history pagination remains `shout-history:` (distinct from the command path) to maintain stability for active button interactions and avoid collisions with future subcommands
- Event handlers now use a two-step filter: first checking `event.getName()` matches the parent command, then checking `event.getSubcommandName()` matches the specific subcommand
- All internal references and documentation consistently use the new `/shout history` and `/shout stats` syntax

https://claude.ai/code/session_0132oNuqJjJkwHKVF5dhq1gX