### PR TITLE
Add Magic 8 Ball feature with `/8ball` slash command

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,3 +644,22 @@ Public by default since decisions are usually shared; pass `private:true`
 to keep the result to yourself. Mentions in the rendered options are
 suppressed so a `/decide options:"@everyone or no"` can't ping the
 channel.
+
+### Magic 8 Ball
+
+`/8ball question:<text> [private:<bool>]` — ask the bot a question,
+get one of the 20 canonical Magic 8 Ball answers chosen uniformly at
+random (10 affirmative, 5 non-committal, 5 negative — same split as
+the physical toy, which slightly favours "yes").
+
+Reply echoes the question and renders the answer in bold:
+
+```
+🎱 *"will it rain tomorrow?"*
+**It is decidedly so.**
+```
+
+Public by default; pass `private:true` to keep the answer ephemeral.
+Mentions in the question text are suppressed so
+`/8ball question:should @everyone get pinged?` can't actually ping
+anyone.

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/eightball/EightBallAnswers.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/eightball/EightBallAnswers.java
@@ -1,0 +1,54 @@
+package ca.ryanmorrison.chatterbox.features.eightball;
+
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * The 20 canonical Magic 8 Ball answers, in the same 10 / 5 / 5 split as
+ * the physical toy (affirmative / non-committal / negative). Picks are
+ * uniform — every answer has equal probability — which (slightly) skews
+ * outcomes toward "yes" because the bowl itself does.
+ */
+final class EightBallAnswers {
+
+    static final List<String> AFFIRMATIVE = List.of(
+            "It is certain.",
+            "It is decidedly so.",
+            "Without a doubt.",
+            "Yes definitely.",
+            "You may rely on it.",
+            "As I see it, yes.",
+            "Most likely.",
+            "Outlook good.",
+            "Yes.",
+            "Signs point to yes.");
+
+    static final List<String> NON_COMMITTAL = List.of(
+            "Reply hazy, try again.",
+            "Ask again later.",
+            "Better not tell you now.",
+            "Cannot predict now.",
+            "Concentrate and ask again.");
+
+    static final List<String> NEGATIVE = List.of(
+            "Don't count on it.",
+            "My reply is no.",
+            "My sources say no.",
+            "Outlook not so good.",
+            "Very doubtful.");
+
+    static final List<String> ALL;
+    static {
+        var combined = new java.util.ArrayList<String>(20);
+        combined.addAll(AFFIRMATIVE);
+        combined.addAll(NON_COMMITTAL);
+        combined.addAll(NEGATIVE);
+        ALL = List.copyOf(combined);
+    }
+
+    private EightBallAnswers() {}
+
+    static String pick() {
+        return ALL.get(ThreadLocalRandom.current().nextInt(ALL.size()));
+    }
+}

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/eightball/EightBallModule.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/eightball/EightBallModule.java
@@ -1,0 +1,82 @@
+package ca.ryanmorrison.chatterbox.features.eightball;
+
+import ca.ryanmorrison.chatterbox.module.InitContext;
+import ca.ryanmorrison.chatterbox.module.Module;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.hooks.EventListener;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.Commands;
+import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
+
+import java.util.EnumSet;
+import java.util.List;
+
+/**
+ * {@code /8ball} — ask the bot a question, get one of the 20 classic Magic 8
+ * Ball answers chosen at random.
+ *
+ * <p>Public reply by default since the joke wants an audience; pass
+ * {@code private:true} to keep it ephemeral. Mentions in the question text
+ * are suppressed so {@code /8ball question:should @everyone get pinged?}
+ * can't actually ping anyone.
+ */
+public final class EightBallModule extends ListenerAdapter implements Module {
+
+    static final String COMMAND     = "8ball";
+    static final String OPT_QUESTION = "question";
+    static final String OPT_PRIVATE  = "private";
+
+    /**
+     * Trim the echoed question if it'd push the rendered reply past Discord's
+     * 2000-char message cap. Generous; real questions are short.
+     */
+    static final int MAX_QUESTION_LENGTH = 1500;
+
+    @Override public String name() { return "eightball"; }
+
+    @Override
+    public List<SlashCommandData> slashCommands(InitContext ctx) {
+        return List.of(Commands.slash(COMMAND, "Ask the Magic 8 Ball a question.")
+                .addOption(OptionType.STRING, OPT_QUESTION,
+                        "What do you want to know?", true)
+                .addOption(OptionType.BOOLEAN, OPT_PRIVATE,
+                        "Show the answer only to you instead of the channel.", false));
+    }
+
+    @Override
+    public List<EventListener> listeners(InitContext ctx) {
+        return List.of(this);
+    }
+
+    @Override
+    public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
+        if (!COMMAND.equals(event.getName())) return;
+
+        OptionMapping questionOption = event.getOption(OPT_QUESTION);
+        String question = questionOption == null ? "" : questionOption.getAsString().trim();
+        if (question.isEmpty()) {
+            event.reply("Give the 8 ball a question to ponder.")
+                    .setEphemeral(true).queue();
+            return;
+        }
+
+        OptionMapping privateOption = event.getOption(OPT_PRIVATE);
+        boolean ephemeral = privateOption != null && privateOption.getAsBoolean();
+
+        String body = renderResult(question, EightBallAnswers.pick());
+        event.reply(body)
+                .setEphemeral(ephemeral)
+                .setAllowedMentions(EnumSet.noneOf(Message.MentionType.class))
+                .queue();
+    }
+
+    static String renderResult(String question, String answer) {
+        String echoed = question.length() > MAX_QUESTION_LENGTH
+                ? question.substring(0, MAX_QUESTION_LENGTH - 1) + "…"
+                : question;
+        return "🎱 *\"" + echoed + "\"*\n**" + answer + "**";
+    }
+}

--- a/src/main/resources/META-INF/services/ca.ryanmorrison.chatterbox.module.Module
+++ b/src/main/resources/META-INF/services/ca.ryanmorrison.chatterbox.module.Module
@@ -5,3 +5,4 @@ ca.ryanmorrison.chatterbox.features.rss.RssModule
 ca.ryanmorrison.chatterbox.features.nhl.NhlModule
 ca.ryanmorrison.chatterbox.features.shortener.ShortenerModule
 ca.ryanmorrison.chatterbox.features.decide.DecideModule
+ca.ryanmorrison.chatterbox.features.eightball.EightBallModule

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/eightball/EightBallAnswersTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/eightball/EightBallAnswersTest.java
@@ -1,0 +1,58 @@
+package ca.ryanmorrison.chatterbox.features.eightball;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EightBallAnswersTest {
+
+    @Test
+    void canonicalSplitMatchesThePhysicalToy() {
+        // 10 affirmative, 5 non-committal, 5 negative — total 20.
+        assertEquals(10, EightBallAnswers.AFFIRMATIVE.size());
+        assertEquals(5, EightBallAnswers.NON_COMMITTAL.size());
+        assertEquals(5, EightBallAnswers.NEGATIVE.size());
+        assertEquals(20, EightBallAnswers.ALL.size());
+    }
+
+    @Test
+    void allAnswersAreDistinct() {
+        Set<String> deduped = new HashSet<>(EightBallAnswers.ALL);
+        assertEquals(EightBallAnswers.ALL.size(), deduped.size(),
+                "no duplicate answers in the bowl");
+    }
+
+    @Test
+    void allAnswersAreNonBlankAndPunctuated() {
+        for (String a : EightBallAnswers.ALL) {
+            assertTrue(a != null && !a.isBlank(), "blank answer: " + a);
+            char last = a.charAt(a.length() - 1);
+            assertTrue(last == '.' || last == '?' || last == '!',
+                    "answer should end with sentence punctuation: " + a);
+        }
+    }
+
+    @Test
+    void pickAlwaysReturnsAnAnswerFromTheBowl() {
+        // Sample enough to exercise the random source meaningfully.
+        for (int i = 0; i < 200; i++) {
+            String picked = EightBallAnswers.pick();
+            assertTrue(EightBallAnswers.ALL.contains(picked),
+                    "pick returned something not in the bowl: " + picked);
+        }
+    }
+
+    @Test
+    void repeatedPicksHitMultipleAnswers() {
+        Set<String> seen = new HashSet<>();
+        for (int i = 0; i < 500; i++) seen.add(EightBallAnswers.pick());
+        // 500 samples from a 20-element pool — collisions for fewer than ~10 unique
+        // would be vanishingly improbable even with a heavy bias.
+        assertTrue(seen.size() >= 15,
+                "expected most of the pool to be sampled across 500 draws, got " + seen.size());
+    }
+}

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/eightball/EightBallModuleTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/eightball/EightBallModuleTest.java
@@ -1,0 +1,34 @@
+package ca.ryanmorrison.chatterbox.features.eightball;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Slash-handler glue is exercised on staging; this covers the pure renderer. */
+class EightBallModuleTest {
+
+    @Test
+    void rendersQuestionAndAnswer() {
+        String body = EightBallModule.renderResult("will it rain?", "Yes definitely.");
+        assertTrue(body.contains("🎱"));
+        assertTrue(body.contains("\"will it rain?\""));
+        assertTrue(body.contains("**Yes definitely.**"));
+    }
+
+    @Test
+    void truncatesOverlongQuestions() {
+        String huge = "x".repeat(EightBallModule.MAX_QUESTION_LENGTH + 50);
+        String body = EightBallModule.renderResult(huge, "Yes.");
+        assertTrue(body.contains("…"), "should ellipsise an overlong question");
+        assertFalse(body.length() > 2000,
+                "rendered message must remain under Discord's 2000 char cap");
+    }
+
+    @Test
+    void preservesShortQuestionsExactly() {
+        String body = EightBallModule.renderResult("hello?", "Most likely.");
+        assertTrue(body.contains("\"hello?\""));
+        assertFalse(body.contains("…"));
+    }
+}


### PR DESCRIPTION
## Summary
Adds a new Magic 8 Ball feature that allows users to ask the bot questions and receive one of the 20 canonical Magic 8 Ball answers chosen at random.

## Key Changes
- **EightBallModule**: New module implementing the `/8ball` slash command
  - Accepts a required `question` parameter and optional `private` boolean flag
  - Renders responses with the question echoed and answer in bold
  - Suppresses mentions in question text to prevent accidental pings
  - Truncates overly long questions to stay within Discord's 2000-character message limit
  
- **EightBallAnswers**: Utility class managing the 20 canonical Magic 8 Ball answers
  - Maintains the authentic 10/5/5 split: 10 affirmative, 5 non-committal, 5 negative
  - Provides uniform random selection via `pick()`
  
- **Comprehensive test coverage**:
  - `EightBallAnswersTest`: Validates answer pool integrity, distribution, and randomness
  - `EightBallModuleTest`: Tests message rendering and question truncation logic
  
- **Documentation**: Updated README with usage examples and behavior details

## Notable Implementation Details
- Uses `ThreadLocalRandom` for efficient thread-safe random selection
- Replies are public by default (for audience effect) but can be made ephemeral with `private:true`
- Question truncation preserves ellipsis indicator while ensuring final message stays under Discord's 2000-character limit
- All answers end with proper sentence punctuation (`.`, `?`, or `!`)

https://claude.ai/code/session_0132oNuqJjJkwHKVF5dhq1gX