### PR TITLE
Add Format and Emote modules with text transformation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -663,3 +663,36 @@ Public by default; pass `private:true` to keep the answer ephemeral.
 Mentions in the question text are suppressed so
 `/8ball question:should @everyone get pinged?` can't actually ping
 anyone.
+
+### Format
+
+`/format style:<choice> text:<text> [private:<bool>]` — apply a fun
+text transform and post the result. Available styles:
+
+- **Clap 👏** — inserts 👏 between whitespace-separated words.
+  `make it stop` → `make 👏 it 👏 stop`. Runs of whitespace collapse
+  to a single clap.
+- **SpongeCase** — alternates letter case across the whole string,
+  starting lowercase. The cursor advances only on letters, so spaces,
+  digits, punctuation, and emoji pass through without disturbing the
+  rhythm. `alternating caps` → `aLtErNaTiNg CaPs`.
+
+Public by default; pass `private:true` to keep it ephemeral. Input is
+truncated above 1500 characters (so the formatted output stays under
+Discord's 2000-char message cap), and mentions in the input are
+suppressed so a hostile `/format text:"@everyone hi"` can't ping
+anyone. Adding a new style is one enum line — see
+[`TextStyle.java`](src/main/java/ca/ryanmorrison/chatterbox/features/format/TextStyle.java).
+
+### Emote
+
+`/emote name:<choice> [private:<bool>]` — post one of a small roster
+of canned text emotes. Roster includes **Flip table**
+(`(╯°□°)╯︵ ┻━┻`), **Put table back** (`┬─┬ノ( º _ ºノ)`),
+**Rage-flip table** (`(ノಠ益ಠ)ノ彡┻━┻`), **Double-flip**
+(`┻━┻ ︵ ヽ(°□°ヽ)`), **Shrug** (`¯\_(ツ)_/¯`), **Lenny face**
+(`( ͡° ͜ʖ ͡°)`), and **Look of disapproval** (`ಠ_ಠ`).
+
+Public by default; pass `private:true` to keep it ephemeral. Adding a
+new emote is one enum line — see
+[`Emote.java`](src/main/java/ca/ryanmorrison/chatterbox/features/emote/Emote.java).

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/emote/Emote.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/emote/Emote.java
@@ -1,0 +1,44 @@
+package ca.ryanmorrison.chatterbox.features.emote;
+
+/**
+ * The roster of canned text emotes. Each carries:
+ * <ul>
+ *   <li>{@code value} — the slash-command choice value the user picks,</li>
+ *   <li>{@code label} — the human-readable picker label,</li>
+ *   <li>{@code text}  — the literal characters posted to the channel.</li>
+ * </ul>
+ *
+ * <p>Adding a new emote is one enum line; {@code EmoteModule} reflects
+ * the values into Discord choices automatically.
+ */
+enum Emote {
+
+    FLIP("flip",       "Flip table",        "(╯°□°)╯︵ ┻━┻"),
+    UNFLIP("unflip",   "Put table back",    "┬─┬ノ( º _ ºノ)"),
+    RAGEFLIP("rageflip", "Rage-flip table", "(ノಠ益ಠ)ノ彡┻━┻"),
+    DOUBLEFLIP("doubleflip", "Double-flip", "┻━┻ ︵ ヽ(°□°ヽ)"),
+    SHRUG("shrug",     "Shrug",             "¯\\_(ツ)_/¯"),
+    LENNY("lenny",     "Lenny face",        "( ͡° ͜ʖ ͡°)"),
+    DISAPPROVE("disapprove", "Look of disapproval", "ಠ_ಠ");
+
+    private final String value;
+    private final String label;
+    private final String text;
+
+    Emote(String value, String label, String text) {
+        this.value = value;
+        this.label = label;
+        this.text = text;
+    }
+
+    String value() { return value; }
+    String label() { return label; }
+    String text()  { return text; }
+
+    static Emote fromValue(String value) {
+        for (Emote e : values()) {
+            if (e.value.equals(value)) return e;
+        }
+        throw new IllegalArgumentException("Unknown emote: " + value);
+    }
+}

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/emote/EmoteModule.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/emote/EmoteModule.java
@@ -1,0 +1,68 @@
+package ca.ryanmorrison.chatterbox.features.emote;
+
+import ca.ryanmorrison.chatterbox.module.InitContext;
+import ca.ryanmorrison.chatterbox.module.Module;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.hooks.EventListener;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.Commands;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
+
+import java.util.List;
+
+/**
+ * {@code /emote name:<choice> [private:<bool>]} — post one of a small roster
+ * of canned text emotes (flipped tables, shrugs, etc.). Public by default;
+ * pass {@code private:true} to keep it ephemeral.
+ */
+public final class EmoteModule extends ListenerAdapter implements Module {
+
+    static final String COMMAND     = "emote";
+    static final String OPT_NAME    = "name";
+    static final String OPT_PRIVATE = "private";
+
+    @Override public String name() { return "emote"; }
+
+    @Override
+    public List<SlashCommandData> slashCommands(InitContext ctx) {
+        OptionData name = new OptionData(OptionType.STRING, OPT_NAME,
+                "Which emote to post.", true);
+        for (Emote e : Emote.values()) {
+            name.addChoice(e.label(), e.value());
+        }
+        return List.of(Commands.slash(COMMAND, "Post a canned text emote.")
+                .addOptions(
+                        name,
+                        new OptionData(OptionType.BOOLEAN, OPT_PRIVATE,
+                                "Show the emote only to you instead of the channel.", false)));
+    }
+
+    @Override
+    public List<EventListener> listeners(InitContext ctx) {
+        return List.of(this);
+    }
+
+    @Override
+    public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
+        if (!COMMAND.equals(event.getName())) return;
+
+        OptionMapping nameOption = event.getOption(OPT_NAME);
+        if (nameOption == null) return;
+
+        Emote emote;
+        try {
+            emote = Emote.fromValue(nameOption.getAsString());
+        } catch (IllegalArgumentException e) {
+            event.reply("Unknown emote.").setEphemeral(true).queue();
+            return;
+        }
+
+        OptionMapping privateOption = event.getOption(OPT_PRIVATE);
+        boolean ephemeral = privateOption != null && privateOption.getAsBoolean();
+
+        event.reply(emote.text()).setEphemeral(ephemeral).queue();
+    }
+}

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/format/FormatModule.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/format/FormatModule.java
@@ -1,0 +1,97 @@
+package ca.ryanmorrison.chatterbox.features.format;
+
+import ca.ryanmorrison.chatterbox.module.InitContext;
+import ca.ryanmorrison.chatterbox.module.Module;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.hooks.EventListener;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.Commands;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
+
+import java.util.EnumSet;
+import java.util.List;
+
+/**
+ * {@code /format style:<choice> text:<text> [private:<bool>]} — apply a
+ * fun text transform and post the result. Public by default; pass
+ * {@code private:true} to keep it ephemeral.
+ *
+ * <p>Mentions in the input text are suppressed so a hostile
+ * {@code /format text:"@everyone hi"} can't actually ping anyone.
+ */
+public final class FormatModule extends ListenerAdapter implements Module {
+
+    static final String COMMAND     = "format";
+    static final String OPT_STYLE   = "style";
+    static final String OPT_TEXT    = "text";
+    static final String OPT_PRIVATE = "private";
+
+    /** Discord caps message bodies at 2000 chars; cap the input to leave headroom. */
+    static final int MAX_INPUT_LENGTH = 1500;
+
+    @Override public String name() { return "format"; }
+
+    @Override
+    public List<SlashCommandData> slashCommands(InitContext ctx) {
+        OptionData style = new OptionData(OptionType.STRING, OPT_STYLE,
+                "How to transform the text.", true);
+        for (TextStyle s : TextStyle.values()) {
+            style.addChoice(s.label(), s.value());
+        }
+        return List.of(Commands.slash(COMMAND, "Transform some text in a fun way.")
+                .addOptions(
+                        style,
+                        new OptionData(OptionType.STRING, OPT_TEXT,
+                                "The text to format.", true),
+                        new OptionData(OptionType.BOOLEAN, OPT_PRIVATE,
+                                "Show the result only to you instead of the channel.", false)));
+    }
+
+    @Override
+    public List<EventListener> listeners(InitContext ctx) {
+        return List.of(this);
+    }
+
+    @Override
+    public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
+        if (!COMMAND.equals(event.getName())) return;
+
+        OptionMapping styleOption = event.getOption(OPT_STYLE);
+        OptionMapping textOption  = event.getOption(OPT_TEXT);
+        if (styleOption == null || textOption == null) {
+            event.reply("Pick a style and give me some text.").setEphemeral(true).queue();
+            return;
+        }
+
+        TextStyle style;
+        try {
+            style = TextStyle.fromValue(styleOption.getAsString());
+        } catch (IllegalArgumentException e) {
+            event.reply("Unknown style.").setEphemeral(true).queue();
+            return;
+        }
+
+        String text = textOption.getAsString();
+        if (text.length() > MAX_INPUT_LENGTH) {
+            text = text.substring(0, MAX_INPUT_LENGTH);
+        }
+        String formatted = style.apply(text);
+        if (formatted.isEmpty()) {
+            event.reply("Give me something with at least one character to work with.")
+                    .setEphemeral(true).queue();
+            return;
+        }
+
+        OptionMapping privateOption = event.getOption(OPT_PRIVATE);
+        boolean ephemeral = privateOption != null && privateOption.getAsBoolean();
+
+        event.reply(formatted)
+                .setEphemeral(ephemeral)
+                .setAllowedMentions(EnumSet.noneOf(Message.MentionType.class))
+                .queue();
+    }
+}

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/format/TextStyle.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/format/TextStyle.java
@@ -1,0 +1,92 @@
+package ca.ryanmorrison.chatterbox.features.format;
+
+import java.util.regex.Pattern;
+
+/**
+ * Available text styles for {@code /format}. Each carries:
+ * <ul>
+ *   <li>a slash-command choice value (lowercase identifier the user picks),</li>
+ *   <li>a human-readable label shown in the choice picker,</li>
+ *   <li>the transform itself.</li>
+ * </ul>
+ *
+ * <p>Adding a new style is a one-liner: append an enum value with its
+ * transform. {@code FormatModule} reflects the enum into Discord choices
+ * automatically.
+ */
+enum TextStyle {
+
+    CLAP("clap", "Clap 👏", TextStyle::clap),
+    SPONGECASE("spongecase", "SpOnGeCaSe", TextStyle::spongecase);
+
+    private final String value;
+    private final String label;
+    private final java.util.function.UnaryOperator<String> transform;
+
+    TextStyle(String value, String label, java.util.function.UnaryOperator<String> transform) {
+        this.value = value;
+        this.label = label;
+        this.transform = transform;
+    }
+
+    String value() { return value; }
+    String label() { return label; }
+
+    String apply(String text) {
+        return transform.apply(text);
+    }
+
+    static TextStyle fromValue(String value) {
+        for (TextStyle s : values()) {
+            if (s.value.equals(value)) return s;
+        }
+        throw new IllegalArgumentException("Unknown style: " + value);
+    }
+
+    // -- transforms ---------------------------------------------------------
+
+    /**
+     * Inserts {@code 👏} between whitespace-separated words. Collapses runs
+     * of whitespace to a single clap so {@code "make  it stop"} doesn't
+     * yield doubled punctuation.
+     */
+    static String clap(String text) {
+        if (text == null) return "";
+        String trimmed = text.trim();
+        if (trimmed.isEmpty()) return "";
+        return WHITESPACE.matcher(trimmed).replaceAll(" 👏 ");
+    }
+
+    private static final Pattern WHITESPACE = Pattern.compile("\\s+");
+
+    /**
+     * Alternates letter case across the whole string, advancing only on
+     * letters so non-letter characters (spaces, punctuation, digits, emoji)
+     * pass through without disturbing the rhythm:
+     *
+     * <pre>
+     *   "alternating caps" → "aLtErNaTiNg CaPs"
+     * </pre>
+     *
+     * Starts lowercase, matching the canonical Wikipedia example.
+     */
+    static String spongecase(String text) {
+        if (text == null || text.isEmpty()) return "";
+        StringBuilder out = new StringBuilder(text.length());
+        int letterIndex = 0;
+        for (int i = 0; i < text.length(); ) {
+            int cp = text.codePointAt(i);
+            if (Character.isLetter(cp)) {
+                int transformed = (letterIndex % 2 == 0)
+                        ? Character.toLowerCase(cp)
+                        : Character.toUpperCase(cp);
+                out.appendCodePoint(transformed);
+                letterIndex++;
+            } else {
+                out.appendCodePoint(cp);
+            }
+            i += Character.charCount(cp);
+        }
+        return out.toString();
+    }
+}

--- a/src/main/resources/META-INF/services/ca.ryanmorrison.chatterbox.module.Module
+++ b/src/main/resources/META-INF/services/ca.ryanmorrison.chatterbox.module.Module
@@ -6,3 +6,5 @@ ca.ryanmorrison.chatterbox.features.nhl.NhlModule
 ca.ryanmorrison.chatterbox.features.shortener.ShortenerModule
 ca.ryanmorrison.chatterbox.features.decide.DecideModule
 ca.ryanmorrison.chatterbox.features.eightball.EightBallModule
+ca.ryanmorrison.chatterbox.features.format.FormatModule
+ca.ryanmorrison.chatterbox.features.emote.EmoteModule

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/emote/EmoteTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/emote/EmoteTest.java
@@ -1,0 +1,65 @@
+package ca.ryanmorrison.chatterbox.features.emote;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EmoteTest {
+
+    @Test
+    void everyEmoteHasNonBlankFields() {
+        for (Emote e : Emote.values()) {
+            assertTrue(e.value() != null && !e.value().isBlank(),
+                    "emote " + e.name() + " missing value");
+            assertTrue(e.label() != null && !e.label().isBlank(),
+                    "emote " + e.name() + " missing label");
+            assertTrue(e.text() != null && !e.text().isBlank(),
+                    "emote " + e.name() + " missing text");
+        }
+    }
+
+    @Test
+    void valuesAreUnique() {
+        Set<String> values = java.util.Arrays.stream(Emote.values())
+                .map(Emote::value)
+                .collect(Collectors.toSet());
+        assertEquals(Emote.values().length, values.size(),
+                "duplicate value among emotes");
+    }
+
+    @Test
+    void textsAreUnique() {
+        Set<String> texts = new HashSet<>();
+        for (Emote e : Emote.values()) texts.add(e.text());
+        assertEquals(Emote.values().length, texts.size(),
+                "two emotes share the same text");
+    }
+
+    @Test
+    void fromValueLooksUpKnown() {
+        assertEquals(Emote.FLIP,  Emote.fromValue("flip"));
+        assertEquals(Emote.SHRUG, Emote.fromValue("shrug"));
+        assertEquals(Emote.LENNY, Emote.fromValue("lenny"));
+    }
+
+    @Test
+    void fromValueRejectsUnknown() {
+        assertThrows(IllegalArgumentException.class,
+                () -> Emote.fromValue("bogus"));
+    }
+
+    @Test
+    void everyEmoteFitsInADiscordMessage() {
+        // 2000-char cap; sanity check none of the canned strings get carried away.
+        for (Emote e : Emote.values()) {
+            assertTrue(e.text().length() < 2000,
+                    "emote " + e.name() + " too long for a Discord message");
+        }
+    }
+}

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/format/TextStyleTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/format/TextStyleTest.java
@@ -1,0 +1,108 @@
+package ca.ryanmorrison.chatterbox.features.format;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TextStyleTest {
+
+    // -- clap ---------------------------------------------------------------
+
+    @Test
+    void clapInsertsClapsBetweenWords() {
+        assertEquals("make 👏 it 👏 stop", TextStyle.clap("make it stop"));
+    }
+
+    @Test
+    void clapHandlesSingleWord() {
+        assertEquals("hello", TextStyle.clap("hello"));
+    }
+
+    @Test
+    void clapCollapsesRunsOfWhitespace() {
+        assertEquals("a 👏 b 👏 c", TextStyle.clap("a   b\tc"));
+    }
+
+    @Test
+    void clapTrimsEdges() {
+        assertEquals("hello 👏 world", TextStyle.clap("   hello world   "));
+    }
+
+    @Test
+    void clapHandlesEmptyAndWhitespaceOnly() {
+        assertEquals("", TextStyle.clap(""));
+        assertEquals("", TextStyle.clap("   "));
+        assertEquals("", TextStyle.clap(null));
+    }
+
+    @Test
+    void clapPreservesPunctuationAttachedToWords() {
+        assertEquals("hello, 👏 world!", TextStyle.clap("hello, world!"));
+    }
+
+    // -- spongecase ---------------------------------------------------------
+
+    @Test
+    void spongecaseMatchesWikipediaExample() {
+        assertEquals("aLtErNaTiNg CaPs", TextStyle.spongecase("alternating caps"));
+    }
+
+    @Test
+    void spongecaseStartsLowercase() {
+        assertEquals("hElLo", TextStyle.spongecase("hello"));
+        assertEquals("hElLo", TextStyle.spongecase("HELLO"));
+    }
+
+    @Test
+    void spongecaseAdvancesOnlyOnLetters() {
+        // Non-letters don't bump the alternation cursor, so "ab cd" reads
+        // a-LOWER, b-UPPER, [space], c-LOWER, d-UPPER.
+        assertEquals("aB cD", TextStyle.spongecase("ab cd"));
+    }
+
+    @Test
+    void spongecasePreservesDigitsAndPunctuation() {
+        assertEquals("h1 W0rLd!", TextStyle.spongecase("H1 w0RlD!"));
+    }
+
+    @Test
+    void spongecaseHandlesEmpty() {
+        assertEquals("", TextStyle.spongecase(""));
+        assertEquals("", TextStyle.spongecase(null));
+    }
+
+    @Test
+    void spongecasePassesEmojiThroughUnchanged() {
+        // Emoji aren't letters; they pass through and don't disturb the
+        // alternation. Letters [h, e, l, l, o] cycle lower/upper from index 0,
+        // yielding h(lower), 👋(skip), E(upper), l(lower), L(upper), o(lower).
+        assertEquals("h👋ElLo", TextStyle.spongecase("h👋ello"));
+    }
+
+    // -- enum bookkeeping ---------------------------------------------------
+
+    @Test
+    void fromValueLooksUpKnownStyles() {
+        assertEquals(TextStyle.CLAP,       TextStyle.fromValue("clap"));
+        assertEquals(TextStyle.SPONGECASE, TextStyle.fromValue("spongecase"));
+    }
+
+    @Test
+    void fromValueRejectsUnknown() {
+        assertThrows(IllegalArgumentException.class,
+                () -> TextStyle.fromValue("bogus"));
+    }
+
+    @Test
+    void everyStyleHasNonBlankLabel() {
+        for (TextStyle s : TextStyle.values()) {
+            org.junit.jupiter.api.Assertions.assertTrue(
+                    s.label() != null && !s.label().isBlank(),
+                    "style " + s.name() + " missing a label");
+            org.junit.jupiter.api.Assertions.assertTrue(
+                    s.value() != null && !s.value().isBlank(),
+                    "style " + s.name() + " missing a value");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds two new Discord bot modules: **Format** for applying fun text transformations, and **Emote** for posting canned ASCII art emotes.

## Key Changes

### Format Module
- New `/format style:<choice> text:<text> [private:<bool>]` command
- Implements two text transformation styles:
  - **Clap**: Inserts 👏 between whitespace-separated words, collapsing runs of whitespace
  - **SpongeCaseCase**: Alternates letter case across the string, advancing only on letters so non-letter characters (spaces, punctuation, digits, emoji) pass through unchanged
- Input truncated to 1500 characters to stay under Discord's 2000-char message limit
- Suppresses mentions in input to prevent abuse
- Extensible enum-based design: adding new styles requires only one enum line
- Comprehensive test coverage for both transformations including edge cases (empty strings, emoji, punctuation, etc.)

### Emote Module
- New `/emote name:<choice> [private:<bool>]` command
- Provides 7 canned ASCII art emotes: flip table, put table back, rage-flip, double-flip, shrug, Lenny face, and look of disapproval
- Extensible enum-based design: adding new emotes requires only one enum line
- Full test coverage validating uniqueness of values/texts and Discord message length constraints

### General
- Both modules follow the existing `Module` interface pattern with slash command registration and event listener integration
- Both support optional `private:true` flag to make responses ephemeral
- Updated README with documentation and examples for both new modules
- Registered both modules in the service loader configuration

## Implementation Details
- `TextStyle` enum uses `UnaryOperator<String>` for transform functions, allowing clean separation of concerns
- `spongecase()` uses code point iteration to properly handle emoji and multi-byte characters
- `clap()` uses regex pattern matching for whitespace normalization
- Both modules validate input and provide user-friendly error messages
- Enum-based design enables automatic Discord choice picker population via reflection

https://claude.ai/code/session_0132oNuqJjJkwHKVF5dhq1gX