### PR TITLE
Add weather module with wttr.in integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -832,3 +832,32 @@ Autocomplete on `tz:` shares the curated list with `/when`'s `in:`
 option (typing a city name like `tor` surfaces `America/Toronto`); any
 IANA name or offset is accepted. Replies are ephemeral throughout —
 no need to clutter the channel with someone's preference setting.
+
+### Weather
+
+`/weather location:<text> [units:<metric|imperial>] [private:<bool>]` —
+current conditions plus a 3-day forecast for any location
+[wttr.in](https://wttr.in) recognises (city, country, postal code,
+`lat,long`, etc.).
+
+Output is a Discord embed:
+
+- Title: "Weather in {city}, {region}, {country}" (resolved by wttr.in's
+  geocoder; if that comes back empty the embed falls back to the
+  caller's literal location string).
+- Description: condition emoji + temperature + feels-like, plus a
+  one-line summary of wind, humidity, UV.
+- Field: 3-day forecast as one line per day (emoji, weekday, high/low,
+  noon-ish description).
+- Footer: "via wttr.in".
+
+Units default to **metric** (°C, km/h); pass `units:imperial` for °F /
+mph. wttr.in returns both, so it's a render-time switch.
+
+No API key, no DB, no SSRF concerns (hostname is hard-coded). Ten-second
+timeout, response-size cap, and a small failure-mapping layer that
+distinguishes unknown locations (HTTP 500 with a "location not found"
+body — wttr.in's odd convention for typos) from rate-limit (HTTP 429,
+~30 req/hour per IP on the free tier) from generic upstream errors.
+Every failure mode produces a deterministic ephemeral message; raw
+exceptions are never surfaced.

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/weather/WeatherClient.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/weather/WeatherClient.java
@@ -1,0 +1,138 @@
+package ca.ryanmorrison.chatterbox.features.weather;
+
+import ca.ryanmorrison.chatterbox.features.weather.dto.WeatherResponse;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpTimeoutException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Locale;
+
+/**
+ * Talks to {@code wttr.in}.
+ *
+ * <p>Posture mirrors {@code NhlClient} / {@code FrinkiacClient}: 10s
+ * timeout, response-size cap, all failures funnelled into
+ * {@link WeatherException} with messages safe to surface in a Discord
+ * reply. wttr.in defaults its response format to ANSI text or HTML
+ * depending on UA, so we always pin {@code ?format=j1} to get JSON.
+ *
+ * <p>Failure mapping follows the live-probed behaviour:
+ * <ul>
+ *   <li>Unknown location → upstream replies HTTP 500 with the plaintext
+ *       body {@code "location not found: …"}. We sniff that body shape
+ *       and surface a "location not found" message rather than a generic
+ *       "HTTP 500" — that's the difference between a retryable hint and
+ *       a typo correction.</li>
+ *   <li>HTTP 429 → friendly "rate limited" message (wttr.in caps free
+ *       usage at ~30 req/hour per IP).</li>
+ *   <li>Other non-2xx → generic "HTTP N" error.</li>
+ * </ul>
+ */
+final class WeatherClient {
+
+    static final String BASE_URL = "https://wttr.in";
+    static final int MAX_RESPONSE_BYTES = 256 * 1024;
+    static final Duration HTTP_TIMEOUT = Duration.ofSeconds(10);
+    static final String USER_AGENT = "Chatterbox/0.1 (+/weather; via wttr.in)";
+
+    private final HttpClient http;
+    private final String baseUrl;
+    private final ObjectMapper mapper;
+
+    WeatherClient() {
+        this(HttpClient.newBuilder()
+                        .connectTimeout(HTTP_TIMEOUT)
+                        .followRedirects(HttpClient.Redirect.NORMAL)
+                        .build(),
+                BASE_URL);
+    }
+
+    /** Test seam — lets tests point at a local {@code HttpServer}. */
+    WeatherClient(HttpClient http, String baseUrl) {
+        this.http = http;
+        this.baseUrl = baseUrl;
+        this.mapper = JsonMapper.builder()
+                .findAndAddModules()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .build();
+    }
+
+    /**
+     * Fetch parsed weather for {@code location}. Empty / blank input is
+     * rejected client-side because wttr.in interprets it as "use my IP",
+     * which from the bot's perspective would silently return the
+     * datacentre's location instead of the user's intent.
+     */
+    WeatherResponse fetch(String location) throws WeatherException {
+        if (location == null || location.isBlank()) {
+            throw new WeatherException("Tell me a location.");
+        }
+        // URLEncoder uses form-encoding (+ for space); paths need %20.
+        String encoded = URLEncoder.encode(location.trim(), StandardCharsets.UTF_8).replace("+", "%20");
+        URI uri;
+        try {
+            uri = URI.create(baseUrl + "/" + encoded + "?format=j1");
+        } catch (IllegalArgumentException e) {
+            throw new WeatherException("That doesn't look like a valid location.");
+        }
+        HttpRequest req = HttpRequest.newBuilder(uri)
+                .timeout(HTTP_TIMEOUT)
+                .header("User-Agent", USER_AGENT)
+                .header("Accept", "application/json")
+                .GET()
+                .build();
+        HttpResponse<byte[]> resp;
+        try {
+            resp = http.send(req, HttpResponse.BodyHandlers.ofByteArray());
+        } catch (HttpTimeoutException e) {
+            throw new WeatherException("wttr.in didn't respond within "
+                    + HTTP_TIMEOUT.toSeconds() + " seconds.");
+        } catch (IOException e) {
+            throw new WeatherException("Couldn't reach wttr.in.");
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new WeatherException("Request was interrupted.");
+        }
+        int status = resp.statusCode();
+        byte[] body = resp.body() == null ? new byte[0] : resp.body();
+        if (body.length > MAX_RESPONSE_BYTES) {
+            throw new WeatherException("wttr.in response was too large.");
+        }
+
+        if (status == 429) {
+            throw new WeatherException("wttr.in is rate-limiting us. Try again in a minute.");
+        }
+        if (status / 100 != 2) {
+            // Sniff the unknown-location body before falling back to a generic
+            // "HTTP N" — the upstream returns 500 (not 404) for typos.
+            String text = new String(body, StandardCharsets.UTF_8).toLowerCase(Locale.ROOT);
+            if (text.contains("location not found") || text.contains("unknown location")) {
+                throw new WeatherException("Couldn't find a place called `" + location.trim() + "`. "
+                        + "Try a city name, country, postal code, or `lat,long`.");
+            }
+            throw new WeatherException("wttr.in returned HTTP " + status + ".");
+        }
+        if (body.length == 0) {
+            throw new WeatherException("wttr.in returned an empty response.");
+        }
+        try {
+            return mapper.readValue(body, WeatherResponse.class);
+        } catch (IOException e) {
+            throw new WeatherException("wttr.in returned an unexpected response.");
+        }
+    }
+
+    /** User-safe checked exception for any fetch/parse failure. */
+    static final class WeatherException extends Exception {
+        WeatherException(String message) { super(message); }
+    }
+}

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/weather/WeatherEmbedBuilder.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/weather/WeatherEmbedBuilder.java
@@ -1,0 +1,145 @@
+package ca.ryanmorrison.chatterbox.features.weather;
+
+import ca.ryanmorrison.chatterbox.features.weather.dto.CurrentCondition;
+import ca.ryanmorrison.chatterbox.features.weather.dto.DailyForecast;
+import ca.ryanmorrison.chatterbox.features.weather.dto.HourlyForecast;
+import ca.ryanmorrison.chatterbox.features.weather.dto.NearestArea;
+import ca.ryanmorrison.chatterbox.features.weather.dto.WeatherResponse;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+
+import java.awt.Color;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+/**
+ * Renders a {@link WeatherResponse} as a Discord embed.
+ *
+ * <p>Layout:
+ * <ul>
+ *   <li>Title: "Weather in {city}, {region}, {country}"</li>
+ *   <li>Description: current condition emoji + temp + feels-like + a one-line
+ *       summary of wind / humidity / UV.</li>
+ *   <li>Three-day forecast as a single field (one line per day with emoji,
+ *       weekday name, high/low, and the day's representative description).</li>
+ *   <li>Footer: "via wttr.in"</li>
+ * </ul>
+ *
+ * <p>{@link Units#METRIC} renders °C and km/h; {@link Units#IMPERIAL} renders
+ * °F and mph. wttr.in returns both, so it's a render-time switch.
+ */
+final class WeatherEmbedBuilder {
+
+    /** wttr.in's date format (the {@code "date"} field on each forecast day). */
+    private static final DateTimeFormatter SOURCE_DATE = DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.ENGLISH);
+    private static final DateTimeFormatter WEEKDAY = DateTimeFormatter.ofPattern("EEEE", Locale.ENGLISH);
+    private static final Color EMBED_COLOR = new Color(0x4F8DDC);
+
+    enum Units { METRIC, IMPERIAL }
+
+    private WeatherEmbedBuilder() {}
+
+    static MessageEmbed build(WeatherResponse response, String requestedLocation, Units units) {
+        EmbedBuilder eb = new EmbedBuilder().setColor(EMBED_COLOR);
+        eb.setTitle("Weather in " + locationLine(response.nearest(), requestedLocation));
+
+        Optional<CurrentCondition> currentOpt = response.current();
+        if (currentOpt.isEmpty()) {
+            eb.setDescription("_No current observation available._");
+        } else {
+            eb.setDescription(currentDescription(currentOpt.get(), units));
+        }
+
+        List<DailyForecast> forecast = response.forecast();
+        if (!forecast.isEmpty()) {
+            eb.addField("3-day forecast", forecastBlock(forecast, units), false);
+        }
+
+        eb.setFooter("via wttr.in");
+        return eb.build();
+    }
+
+    /** "Toronto, Ontario, Canada" or "Toronto, Canada" or just the requested string. */
+    static String locationLine(Optional<NearestArea> nearestOpt, String requestedLocation) {
+        if (nearestOpt.isEmpty()) return requestedLocation;
+        NearestArea n = nearestOpt.get();
+        StringBuilder sb = new StringBuilder();
+        n.city().ifPresent(sb::append);
+        n.regionName().ifPresent(r -> {
+            if (sb.length() > 0) sb.append(", ");
+            sb.append(r);
+        });
+        n.countryName().ifPresent(c -> {
+            if (sb.length() > 0) sb.append(", ");
+            sb.append(c);
+        });
+        return sb.length() == 0 ? requestedLocation : sb.toString();
+    }
+
+    private static String currentDescription(CurrentCondition c, Units units) {
+        String emoji = WeatherEmoji.forCode(c.weatherCode());
+        String temp = formatTemp(c.tempC(), c.tempF(), units);
+        String feels = formatTemp(c.feelsLikeC(), c.feelsLikeF(), units);
+        String wind = formatWind(c.windSpeedKmph(), c.windSpeedMiles(), c.windDir(), units);
+        StringBuilder sb = new StringBuilder();
+        sb.append(emoji).append(" **").append(c.description().trim()).append("** · ");
+        sb.append(temp).append(" (feels like ").append(feels).append(")\n");
+        sb.append("💨 Wind ").append(wind);
+        if (notBlank(c.humidity()))   sb.append(" · 💧 Humidity ").append(c.humidity()).append("%");
+        if (notBlank(c.uvIndex()))    sb.append(" · 🌅 UV ").append(c.uvIndex());
+        return sb.toString();
+    }
+
+    private static String forecastBlock(List<DailyForecast> forecast, Units units) {
+        StringBuilder sb = new StringBuilder();
+        for (DailyForecast d : forecast) {
+            String weekday = formatWeekday(d.date());
+            String high = formatTemp(d.maxTempC(), d.maxTempF(), units);
+            String low  = formatTemp(d.minTempC(), d.minTempF(), units);
+            Optional<HourlyForecast> noon = d.noonish();
+            String emoji = noon.map(h -> WeatherEmoji.forCode(h.weatherCode())).orElse("🌡️");
+            String desc  = noon.map(HourlyForecast::description).orElse("");
+            sb.append(emoji).append(" **").append(weekday).append("** ");
+            sb.append("↑ ").append(high).append(" / ↓ ").append(low);
+            if (!desc.isBlank()) sb.append(" — ").append(desc.trim());
+            sb.append('\n');
+        }
+        return sb.toString().stripTrailing();
+    }
+
+    private static String formatWeekday(String date) {
+        if (date == null) return "";
+        try {
+            return WEEKDAY.format(LocalDate.parse(date, SOURCE_DATE));
+        } catch (DateTimeParseException e) {
+            return date;
+        }
+    }
+
+    private static String formatTemp(String celsius, String fahrenheit, Units units) {
+        return units == Units.METRIC
+                ? formatNumber(celsius) + "°C"
+                : formatNumber(fahrenheit) + "°F";
+    }
+
+    private static String formatWind(String kmph, String mph, String direction, Units units) {
+        String speed = units == Units.METRIC
+                ? formatNumber(kmph) + " km/h"
+                : formatNumber(mph) + " mph";
+        return notBlank(direction) ? speed + " " + direction : speed;
+    }
+
+    /** Strips any trailing ".0" wttr.in might emit and falls back to "?" for missing values. */
+    private static String formatNumber(String s) {
+        if (s == null || s.isBlank()) return "?";
+        String t = s.trim();
+        if (t.endsWith(".0")) t = t.substring(0, t.length() - 2);
+        return t;
+    }
+
+    private static boolean notBlank(String s) { return s != null && !s.isBlank(); }
+}

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/weather/WeatherEmoji.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/weather/WeatherEmoji.java
@@ -1,0 +1,81 @@
+package ca.ryanmorrison.chatterbox.features.weather;
+
+import java.util.Map;
+
+/**
+ * Maps wttr.in's {@code weatherCode} (a 3-digit string from the
+ * world-weather-online code list) to a Discord-renderable emoji.
+ *
+ * <p>The full list has ~50 codes; we collapse them into ~10 visual
+ * groups (sun, partly cloudy, cloudy, fog, rain, heavy rain, snow,
+ * sleet, thunder, ice). Anything we don't recognise falls back to the
+ * thermometer so the embed still renders coherently.
+ */
+final class WeatherEmoji {
+
+    private WeatherEmoji() {}
+
+    private static final String DEFAULT = "🌡️";
+
+    private static final Map<String, String> CODES = Map.<String, String>ofEntries(
+            // Clear / sunny
+            Map.entry("113", "☀️"),
+            // Partly / mostly cloudy
+            Map.entry("116", "🌤️"),
+            Map.entry("119", "☁️"),
+            Map.entry("122", "☁️"),
+            // Mist / fog
+            Map.entry("143", "🌫️"),
+            Map.entry("248", "🌫️"),
+            Map.entry("260", "🌫️"),
+            // Patchy / light rain
+            Map.entry("176", "🌦️"),
+            Map.entry("263", "🌦️"),
+            Map.entry("266", "🌦️"),
+            Map.entry("293", "🌦️"),
+            Map.entry("296", "🌦️"),
+            Map.entry("353", "🌦️"),
+            // Moderate / heavy rain
+            Map.entry("299", "🌧️"),
+            Map.entry("302", "🌧️"),
+            Map.entry("305", "🌧️"),
+            Map.entry("308", "🌧️"),
+            Map.entry("356", "🌧️"),
+            Map.entry("359", "🌧️"),
+            // Freezing rain / sleet
+            Map.entry("281", "🌨️"),
+            Map.entry("284", "🌨️"),
+            Map.entry("311", "🌨️"),
+            Map.entry("314", "🌨️"),
+            Map.entry("317", "🌨️"),
+            Map.entry("320", "🌨️"),
+            Map.entry("362", "🌨️"),
+            Map.entry("365", "🌨️"),
+            // Snow
+            Map.entry("179", "🌨️"),
+            Map.entry("227", "❄️"),
+            Map.entry("230", "❄️"),
+            Map.entry("323", "🌨️"),
+            Map.entry("326", "🌨️"),
+            Map.entry("329", "❄️"),
+            Map.entry("332", "❄️"),
+            Map.entry("335", "❄️"),
+            Map.entry("338", "❄️"),
+            Map.entry("368", "🌨️"),
+            Map.entry("371", "❄️"),
+            // Ice pellets / hail
+            Map.entry("350", "🌨️"),
+            Map.entry("374", "🌨️"),
+            Map.entry("377", "🌨️"),
+            // Thunder
+            Map.entry("200", "⛈️"),
+            Map.entry("386", "⛈️"),
+            Map.entry("389", "⛈️"),
+            Map.entry("392", "⛈️"),
+            Map.entry("395", "⛈️"));
+
+    static String forCode(String weatherCode) {
+        if (weatherCode == null) return DEFAULT;
+        return CODES.getOrDefault(weatherCode.trim(), DEFAULT);
+    }
+}

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/weather/WeatherHandler.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/weather/WeatherHandler.java
@@ -1,0 +1,78 @@
+package ca.ryanmorrison.chatterbox.features.weather;
+
+import ca.ryanmorrison.chatterbox.features.weather.dto.WeatherResponse;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Handles {@code /weather location:<text> [units:<choice>] [private:<bool>]}.
+ *
+ * <p>Defers the reply (the network call can take a few seconds), fetches via
+ * {@link WeatherClient}, and renders a 3-day-forecast embed via
+ * {@link WeatherEmbedBuilder}. Failures map to ephemeral text replies with
+ * the user-safe message stored in {@link WeatherClient.WeatherException} —
+ * the underlying exception is never surfaced.
+ */
+final class WeatherHandler extends ListenerAdapter {
+
+    private static final Logger log = LoggerFactory.getLogger(WeatherHandler.class);
+
+    private final WeatherClient client;
+
+    WeatherHandler(WeatherClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
+        if (!WeatherModule.COMMAND.equals(event.getName())) return;
+
+        String location = stringOption(event, WeatherModule.OPT_LOCATION);
+        if (location == null || location.isBlank()) {
+            event.reply("Tell me a location.").setEphemeral(true).queue();
+            return;
+        }
+
+        WeatherEmbedBuilder.Units units = parseUnits(stringOption(event, WeatherModule.OPT_UNITS));
+        boolean ephemeral = booleanOption(event, WeatherModule.OPT_PRIVATE);
+
+        event.deferReply(ephemeral).queue();
+
+        WeatherResponse response;
+        try {
+            response = client.fetch(location);
+        } catch (WeatherClient.WeatherException e) {
+            event.getHook().sendMessage(e.getMessage()).queue();
+            return;
+        } catch (RuntimeException e) {
+            log.warn("Unexpected error fetching weather for {}", location, e);
+            event.getHook().sendMessage("Something went wrong fetching the weather.").queue();
+            return;
+        }
+
+        MessageEmbed embed = WeatherEmbedBuilder.build(response, location.trim(), units);
+        event.getHook().sendMessageEmbeds(embed).queue();
+    }
+
+    private static WeatherEmbedBuilder.Units parseUnits(String raw) {
+        if (raw == null) return WeatherEmbedBuilder.Units.METRIC;
+        return switch (raw.trim().toLowerCase(java.util.Locale.ROOT)) {
+            case "imperial" -> WeatherEmbedBuilder.Units.IMPERIAL;
+            default         -> WeatherEmbedBuilder.Units.METRIC;
+        };
+    }
+
+    private static String stringOption(SlashCommandInteractionEvent event, String name) {
+        OptionMapping opt = event.getOption(name);
+        return opt == null ? null : opt.getAsString();
+    }
+
+    private static boolean booleanOption(SlashCommandInteractionEvent event, String name) {
+        OptionMapping opt = event.getOption(name);
+        return opt != null && opt.getAsBoolean();
+    }
+}

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/weather/WeatherModule.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/weather/WeatherModule.java
@@ -1,0 +1,56 @@
+package ca.ryanmorrison.chatterbox.features.weather;
+
+import ca.ryanmorrison.chatterbox.module.InitContext;
+import ca.ryanmorrison.chatterbox.module.Module;
+import net.dv8tion.jda.api.hooks.EventListener;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.Commands;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
+
+import java.util.List;
+
+/**
+ * {@code /weather location:<text> [units:<metric|imperial>] [private:<bool>]} —
+ * current conditions plus a 3-day forecast for any location wttr.in
+ * recognises (city, country, postal code, {@code lat,long}, etc.).
+ *
+ * <p>No API key, no DB, no SSRF concerns: hostname is hard-coded
+ * {@code wttr.in} and user input is just a location string passed to
+ * its open lookup. Ten-second timeout, response-size cap, and a small
+ * {@link WeatherClient.WeatherException} mapping for the failure modes
+ * we've observed in the wild — see {@link WeatherClient}.
+ */
+public final class WeatherModule implements Module {
+
+    static final String COMMAND      = "weather";
+    static final String OPT_LOCATION = "location";
+    static final String OPT_UNITS    = "units";
+    static final String OPT_PRIVATE  = "private";
+
+    static final String UNITS_METRIC   = "metric";
+    static final String UNITS_IMPERIAL = "imperial";
+
+    @Override public String name() { return "weather"; }
+
+    @Override
+    public List<SlashCommandData> slashCommands(InitContext ctx) {
+        OptionData location = new OptionData(OptionType.STRING, OPT_LOCATION,
+                "City, country, postal code, or `lat,long`.", true, false);
+        OptionData units = new OptionData(OptionType.STRING, OPT_UNITS,
+                "Temperature units (default metric).", false, false)
+                .addChoice("Metric (°C, km/h)",   UNITS_METRIC)
+                .addChoice("Imperial (°F, mph)",  UNITS_IMPERIAL);
+        OptionData priv = new OptionData(OptionType.BOOLEAN, OPT_PRIVATE,
+                "Show the result only to you instead of the channel.",
+                false, false);
+        return List.of(Commands.slash(COMMAND,
+                        "Show current conditions and a 3-day forecast for any location.")
+                .addOptions(location, units, priv));
+    }
+
+    @Override
+    public List<EventListener> listeners(InitContext ctx) {
+        return List.of(new WeatherHandler(new WeatherClient()));
+    }
+}

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/weather/dto/CurrentCondition.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/weather/dto/CurrentCondition.java
@@ -1,0 +1,38 @@
+package ca.ryanmorrison.chatterbox.features.weather.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * Snapshot of the current observation at the queried location.
+ *
+ * <p>Numbers come back as strings (wttr.in's quirk); we keep them as
+ * strings here and parse on render to avoid losing fidelity for the
+ * occasional missing field. Only the subset we render is exposed.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record CurrentCondition(
+        @JsonProperty("temp_C") String tempC,
+        @JsonProperty("temp_F") String tempF,
+        @JsonProperty("FeelsLikeC") String feelsLikeC,
+        @JsonProperty("FeelsLikeF") String feelsLikeF,
+        @JsonProperty("humidity") String humidity,
+        @JsonProperty("weatherCode") String weatherCode,
+        @JsonProperty("weatherDesc") List<ValueWrapper> weatherDesc,
+        @JsonProperty("windspeedKmph") String windSpeedKmph,
+        @JsonProperty("windspeedMiles") String windSpeedMiles,
+        @JsonProperty("winddir16Point") String windDir,
+        @JsonProperty("uvIndex") String uvIndex,
+        @JsonProperty("visibility") String visibilityKm,
+        @JsonProperty("visibilityMiles") String visibilityMiles,
+        @JsonProperty("pressure") String pressureMb,
+        @JsonProperty("cloudcover") String cloudCover) {
+
+    public String description() {
+        return weatherDesc == null || weatherDesc.isEmpty() || weatherDesc.get(0) == null
+                ? ""
+                : weatherDesc.get(0).value();
+    }
+}

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/weather/dto/DailyForecast.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/weather/dto/DailyForecast.java
@@ -1,0 +1,37 @@
+package ca.ryanmorrison.chatterbox.features.weather.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * One day in wttr.in's forecast array. The first entry is "today" (its
+ * {@code maxtempC} / {@code mintempC} are based on the full day, including
+ * already-passed hours), the next two are the upcoming days.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record DailyForecast(
+        @JsonProperty("date") String date,
+        @JsonProperty("maxtempC") String maxTempC,
+        @JsonProperty("maxtempF") String maxTempF,
+        @JsonProperty("mintempC") String minTempC,
+        @JsonProperty("mintempF") String minTempF,
+        @JsonProperty("avgtempC") String avgTempC,
+        @JsonProperty("avgtempF") String avgTempF,
+        @JsonProperty("uvIndex") String uvIndex,
+        @JsonProperty("hourly") List<HourlyForecast> hourly) {
+
+    /**
+     * Pick the hour-bucket closest to noon as the day's "representative"
+     * condition. wttr.in returns 8 buckets per day at 3-hour spacing; the
+     * 12:00 entry sits at index 4 of a well-formed list, but we look up
+     * by {@code time == "1200"} so a sparse list still works.
+     */
+    public Optional<HourlyForecast> noonish() {
+        if (hourly == null) return Optional.empty();
+        return hourly.stream().filter(h -> "1200".equals(h.time())).findFirst()
+                .or(() -> hourly.size() > 4 ? Optional.ofNullable(hourly.get(4)) : Optional.empty());
+    }
+}

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/weather/dto/HourlyForecast.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/weather/dto/HourlyForecast.java
@@ -1,0 +1,31 @@
+package ca.ryanmorrison.chatterbox.features.weather.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * One hour-bucket inside a forecast day. wttr.in returns 8 of these per
+ * day at 3-hour intervals: {@code time} is the hour-of-day as
+ * {@code "0"}, {@code "300"}, {@code "600"}, …, {@code "2100"}.
+ *
+ * <p>We pull the noon-ish bucket out and use its weather code + description
+ * as the day's representative condition.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record HourlyForecast(
+        @JsonProperty("time") String time,
+        @JsonProperty("tempC") String tempC,
+        @JsonProperty("tempF") String tempF,
+        @JsonProperty("weatherCode") String weatherCode,
+        @JsonProperty("weatherDesc") List<ValueWrapper> weatherDesc,
+        @JsonProperty("chanceofrain") String chanceOfRain,
+        @JsonProperty("chanceofsnow") String chanceOfSnow) {
+
+    public String description() {
+        return weatherDesc == null || weatherDesc.isEmpty() || weatherDesc.get(0) == null
+                ? ""
+                : weatherDesc.get(0).value();
+    }
+}

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/weather/dto/NearestArea.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/weather/dto/NearestArea.java
@@ -1,0 +1,27 @@
+package ca.ryanmorrison.chatterbox.features.weather.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Optional;
+
+/** Reverse-geocoded location wttr.in resolved the query to. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record NearestArea(
+        @JsonProperty("areaName") List<ValueWrapper> areaName,
+        @JsonProperty("region") List<ValueWrapper> region,
+        @JsonProperty("country") List<ValueWrapper> country,
+        @JsonProperty("latitude") String latitude,
+        @JsonProperty("longitude") String longitude) {
+
+    public Optional<String> city()    { return firstValue(areaName); }
+    public Optional<String> regionName() { return firstValue(region); }
+    public Optional<String> countryName() { return firstValue(country); }
+
+    private static Optional<String> firstValue(List<ValueWrapper> list) {
+        if (list == null || list.isEmpty() || list.get(0) == null) return Optional.empty();
+        String v = list.get(0).value();
+        return v == null || v.isBlank() ? Optional.empty() : Optional.of(v);
+    }
+}

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/weather/dto/ValueWrapper.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/weather/dto/ValueWrapper.java
@@ -1,0 +1,12 @@
+package ca.ryanmorrison.chatterbox.features.weather.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * wttr.in wraps every scalar inside {@code [{"value": "X"}]}. This record
+ * is the {@code .value} unwrapper, used wherever a label like
+ * {@code areaName}, {@code country}, {@code weatherDesc} appears.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ValueWrapper(String value) {
+}

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/weather/dto/WeatherResponse.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/weather/dto/WeatherResponse.java
@@ -1,0 +1,31 @@
+package ca.ryanmorrison.chatterbox.features.weather.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Optional;
+
+/** Top-level wttr.in {@code ?format=j1} response. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record WeatherResponse(
+        @JsonProperty("current_condition") List<CurrentCondition> currentCondition,
+        @JsonProperty("nearest_area") List<NearestArea> nearestArea,
+        @JsonProperty("weather") List<DailyForecast> weather) {
+
+    public Optional<CurrentCondition> current() {
+        return currentCondition == null || currentCondition.isEmpty()
+                ? Optional.empty()
+                : Optional.ofNullable(currentCondition.get(0));
+    }
+
+    public Optional<NearestArea> nearest() {
+        return nearestArea == null || nearestArea.isEmpty()
+                ? Optional.empty()
+                : Optional.ofNullable(nearestArea.get(0));
+    }
+
+    public List<DailyForecast> forecast() {
+        return weather == null ? List.of() : weather;
+    }
+}

--- a/src/main/resources/META-INF/services/ca.ryanmorrison.chatterbox.module.Module
+++ b/src/main/resources/META-INF/services/ca.ryanmorrison.chatterbox.module.Module
@@ -13,3 +13,4 @@ ca.ryanmorrison.chatterbox.features.frinkiac.FrinkiacModule
 ca.ryanmorrison.chatterbox.features.isitdown.IsItDownModule
 ca.ryanmorrison.chatterbox.features.when.WhenModule
 ca.ryanmorrison.chatterbox.features.timezone.TimezoneModule
+ca.ryanmorrison.chatterbox.features.weather.WeatherModule

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/weather/WeatherClientTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/weather/WeatherClientTest.java
@@ -1,0 +1,207 @@
+package ca.ryanmorrison.chatterbox.features.weather;
+
+import ca.ryanmorrison.chatterbox.features.weather.dto.WeatherResponse;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WeatherClientTest {
+
+    private HttpServer server;
+    private WeatherClient client;
+    private String baseUrl;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.start();
+        baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
+        HttpClient http = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(2)).build();
+        client = new WeatherClient(http, baseUrl);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) server.stop(0);
+    }
+
+    private void serve(String path, int status, String contentType, String body) {
+        server.createContext(path, ex -> {
+            byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+            ex.getResponseHeaders().add("Content-Type", contentType);
+            ex.sendResponseHeaders(status, bytes.length);
+            try (var os = ex.getResponseBody()) { os.write(bytes); }
+        });
+    }
+
+    /** Trimmed real-shape wttr.in response — verbatim shape, minimal data. */
+    private static final String SAMPLE = """
+            {
+              "current_condition": [{
+                "temp_C": "8", "temp_F": "47",
+                "FeelsLikeC": "7", "FeelsLikeF": "44",
+                "humidity": "81",
+                "weatherCode": "116",
+                "weatherDesc": [{"value": "Partly cloudy"}],
+                "winddir16Point": "SSW",
+                "windspeedKmph": "9", "windspeedMiles": "6",
+                "uvIndex": "1",
+                "pressure": "1006",
+                "cloudcover": "75",
+                "visibility": "14", "visibilityMiles": "8"
+              }],
+              "nearest_area": [{
+                "areaName": [{"value": "Toronto"}],
+                "region":   [{"value": "Ontario"}],
+                "country":  [{"value": "Canada"}],
+                "latitude": "43.667", "longitude": "-79.417"
+              }],
+              "weather": [
+                {
+                  "date": "2026-05-09",
+                  "maxtempC": "12", "maxtempF": "54",
+                  "mintempC": "5",  "mintempF": "41",
+                  "avgtempC": "9",  "avgtempF": "48",
+                  "uvIndex": "5",
+                  "hourly": [
+                    {"time": "1200", "tempC": "10", "tempF": "50",
+                     "weatherCode": "116",
+                     "weatherDesc": [{"value": "Partly cloudy"}]}
+                  ]
+                },
+                {
+                  "date": "2026-05-10",
+                  "maxtempC": "15", "maxtempF": "59",
+                  "mintempC": "7",  "mintempF": "45",
+                  "hourly": [
+                    {"time": "1200", "weatherCode": "308",
+                     "weatherDesc": [{"value": "Heavy rain"}]}
+                  ]
+                },
+                {
+                  "date": "2026-05-11",
+                  "maxtempC": "18", "maxtempF": "64",
+                  "mintempC": "10", "mintempF": "50",
+                  "hourly": [
+                    {"time": "1200", "weatherCode": "113",
+                     "weatherDesc": [{"value": "Sunny"}]}
+                  ]
+                }
+              ]
+            }
+            """;
+
+    // ---- happy path ----
+
+    @Test
+    void successParsesNestedShape() throws Exception {
+        serve("/Toronto", 200, "application/json", SAMPLE);
+        WeatherResponse resp = client.fetch("Toronto");
+
+        assertTrue(resp.current().isPresent());
+        assertEquals("8",  resp.current().get().tempC());
+        assertEquals("Partly cloudy", resp.current().get().description());
+
+        assertTrue(resp.nearest().isPresent());
+        assertEquals("Toronto", resp.nearest().get().city().orElseThrow());
+        assertEquals("Ontario", resp.nearest().get().regionName().orElseThrow());
+        assertEquals("Canada",  resp.nearest().get().countryName().orElseThrow());
+
+        assertEquals(3, resp.forecast().size());
+        assertEquals("2026-05-09", resp.forecast().get(0).date());
+        assertEquals("Heavy rain", resp.forecast().get(1).noonish().orElseThrow().description());
+    }
+
+    @Test
+    void formatJ1QueryAndUserAgentAreSent() throws Exception {
+        // Capture the actual request-line+headers wttr.in sees.
+        java.util.concurrent.atomic.AtomicReference<String> rawQuery = new java.util.concurrent.atomic.AtomicReference<>();
+        java.util.concurrent.atomic.AtomicReference<String> userAgent = new java.util.concurrent.atomic.AtomicReference<>();
+        server.createContext("/Toronto", ex -> {
+            rawQuery.set(ex.getRequestURI().getRawQuery());
+            userAgent.set(ex.getRequestHeaders().getFirst("User-Agent"));
+            byte[] bytes = SAMPLE.getBytes(StandardCharsets.UTF_8);
+            ex.getResponseHeaders().add("Content-Type", "application/json");
+            ex.sendResponseHeaders(200, bytes.length);
+            try (var os = ex.getResponseBody()) { os.write(bytes); }
+        });
+        client.fetch("Toronto");
+        assertEquals("format=j1", rawQuery.get(),
+                "wttr.in returns ANSI/HTML by default; we must pin format=j1 to get JSON.");
+        assertNotNull(userAgent.get());
+    }
+
+    @Test
+    void locationWithSpacesIsUrlEncodedAsPath() throws Exception {
+        // Capture what path the client actually sends so we can assert %20 not +.
+        java.util.concurrent.atomic.AtomicReference<String> rawPath = new java.util.concurrent.atomic.AtomicReference<>();
+        // Catch-all context at root: HttpServer routes longest-prefix-first.
+        server.createContext("/", ex -> {
+            rawPath.set(ex.getRequestURI().getRawPath());
+            byte[] bytes = SAMPLE.getBytes(StandardCharsets.UTF_8);
+            ex.getResponseHeaders().add("Content-Type", "application/json");
+            ex.sendResponseHeaders(200, bytes.length);
+            try (var os = ex.getResponseBody()) { os.write(bytes); }
+        });
+        WeatherResponse resp = client.fetch("London UK");
+        assertTrue(resp.current().isPresent());
+        // %20, not + (which would be form-encoding, wrong for path components).
+        assertEquals("/London%20UK", rawPath.get());
+    }
+
+    // ---- failure paths ----
+
+    @Test
+    void blankLocationRejectedClientSide() {
+        // We never let an empty path through — wttr.in would interpret it as
+        // "use my IP" and return weather for the bot's datacentre.
+        var ex = assertThrows(WeatherClient.WeatherException.class, () -> client.fetch(""));
+        assertTrue(ex.getMessage().toLowerCase().contains("location"), () -> ex.getMessage());
+        assertThrows(WeatherClient.WeatherException.class, () -> client.fetch(null));
+        assertThrows(WeatherClient.WeatherException.class, () -> client.fetch("   "));
+    }
+
+    @Test
+    void unknownLocationDetectedFromBodySniff() {
+        // wttr.in returns 500 with this body for typos; we surface a friendly
+        // "couldn't find" rather than the noisy "HTTP 500".
+        serve("/asdfqwer", 500, "text/plain",
+                "location not found: upstream error: opencage: invalid response\n");
+        var ex = assertThrows(WeatherClient.WeatherException.class, () -> client.fetch("asdfqwer"));
+        assertTrue(ex.getMessage().toLowerCase().contains("couldn't find"),
+                () -> ex.getMessage());
+    }
+
+    @Test
+    void rateLimitedReturnsFriendlyMessage() {
+        serve("/Toronto", 429, "text/plain", "rate limited");
+        var ex = assertThrows(WeatherClient.WeatherException.class, () -> client.fetch("Toronto"));
+        assertTrue(ex.getMessage().toLowerCase().contains("rate"), () -> ex.getMessage());
+    }
+
+    @Test
+    void otherServerErrorBubblesGenericHttpStatus() {
+        serve("/Toronto", 503, "text/plain", "service unavailable");
+        var ex = assertThrows(WeatherClient.WeatherException.class, () -> client.fetch("Toronto"));
+        assertTrue(ex.getMessage().contains("503"), () -> ex.getMessage());
+    }
+
+    @Test
+    void unparseableBodySurfacedAsUnexpected() {
+        serve("/Toronto", 200, "application/json", "{not json");
+        var ex = assertThrows(WeatherClient.WeatherException.class, () -> client.fetch("Toronto"));
+        assertTrue(ex.getMessage().toLowerCase().contains("unexpected"), () -> ex.getMessage());
+    }
+}

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/weather/WeatherEmbedBuilderTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/weather/WeatherEmbedBuilderTest.java
@@ -1,0 +1,172 @@
+package ca.ryanmorrison.chatterbox.features.weather;
+
+import ca.ryanmorrison.chatterbox.features.weather.dto.CurrentCondition;
+import ca.ryanmorrison.chatterbox.features.weather.dto.DailyForecast;
+import ca.ryanmorrison.chatterbox.features.weather.dto.HourlyForecast;
+import ca.ryanmorrison.chatterbox.features.weather.dto.NearestArea;
+import ca.ryanmorrison.chatterbox.features.weather.dto.ValueWrapper;
+import ca.ryanmorrison.chatterbox.features.weather.dto.WeatherResponse;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WeatherEmbedBuilderTest {
+
+    private static List<ValueWrapper> wrap(String value) {
+        return List.of(new ValueWrapper(value));
+    }
+
+    private static CurrentCondition torontoCurrent() {
+        return new CurrentCondition(
+                "8", "47",      // temp C/F
+                "7", "44",      // feels-like C/F
+                "81",           // humidity
+                "116",          // weatherCode (Partly cloudy)
+                wrap("Partly cloudy"),
+                "9", "6",       // wind kmph/mph
+                "SSW",
+                "1",            // uv
+                "14", "8",      // visibility
+                "1006",         // pressure
+                "75");          // cloud cover
+    }
+
+    private static NearestArea torontoArea() {
+        return new NearestArea(wrap("Toronto"), wrap("Ontario"), wrap("Canada"),
+                "43.667", "-79.417");
+    }
+
+    private static HourlyForecast noon(String code, String desc) {
+        return new HourlyForecast("1200", "10", "50", code, wrap(desc), "0", "0");
+    }
+
+    private static DailyForecast day(String date, String maxC, String minC, String code, String desc) {
+        return new DailyForecast(date,
+                maxC, String.valueOf(Integer.parseInt(maxC) * 9 / 5 + 32),
+                minC, String.valueOf(Integer.parseInt(minC) * 9 / 5 + 32),
+                "?", "?",
+                "5",
+                List.of(noon(code, desc)));
+    }
+
+    private static WeatherResponse sampleResponse() {
+        return new WeatherResponse(
+                List.of(torontoCurrent()),
+                List.of(torontoArea()),
+                List.of(
+                        day("2026-05-09", "12", "5",  "116", "Partly cloudy"),
+                        day("2026-05-10", "15", "7",  "308", "Heavy rain"),
+                        day("2026-05-11", "18", "10", "113", "Sunny")));
+    }
+
+    // ---- title / location ----
+
+    @Test
+    void titleUsesNearestAreaWhenAvailable() {
+        MessageEmbed embed = WeatherEmbedBuilder.build(sampleResponse(), "Toronto",
+                WeatherEmbedBuilder.Units.METRIC);
+        assertEquals("Weather in Toronto, Ontario, Canada", embed.getTitle());
+    }
+
+    @Test
+    void titleFallsBackToRequestedWhenNoArea() {
+        WeatherResponse resp = new WeatherResponse(
+                List.of(torontoCurrent()), List.of(), List.of());
+        MessageEmbed embed = WeatherEmbedBuilder.build(resp, "Some place",
+                WeatherEmbedBuilder.Units.METRIC);
+        assertEquals("Weather in Some place", embed.getTitle());
+    }
+
+    @Test
+    void locationLineHandlesPartialFields() {
+        // City + country, no region.
+        NearestArea area = new NearestArea(wrap("Tokyo"), List.of(), wrap("Japan"), "0", "0");
+        assertEquals("Tokyo, Japan",
+                WeatherEmbedBuilder.locationLine(Optional.of(area), "fallback"));
+    }
+
+    // ---- current description ----
+
+    @Test
+    void currentDescriptionMentionsTempFeelsAndWind_metric() {
+        MessageEmbed embed = WeatherEmbedBuilder.build(sampleResponse(), "Toronto",
+                WeatherEmbedBuilder.Units.METRIC);
+        String desc = embed.getDescription();
+        assertTrue(desc.contains("Partly cloudy"), desc);
+        assertTrue(desc.contains("8°C"),  () -> desc);
+        assertTrue(desc.contains("7°C"),  () -> desc);
+        assertTrue(desc.contains("9 km/h"), () -> desc);
+        assertTrue(desc.contains("SSW"),  () -> desc);
+        assertTrue(desc.contains("81%"),  () -> desc);
+        // The condition emoji (Partly cloudy → 🌤️).
+        assertTrue(desc.startsWith("🌤️"), () -> desc);
+    }
+
+    @Test
+    void currentDescriptionUsesImperialWhenRequested() {
+        MessageEmbed embed = WeatherEmbedBuilder.build(sampleResponse(), "Toronto",
+                WeatherEmbedBuilder.Units.IMPERIAL);
+        String desc = embed.getDescription();
+        assertTrue(desc.contains("47°F"), desc);
+        assertTrue(desc.contains("44°F"), desc);
+        assertTrue(desc.contains("6 mph"), desc);
+        assertTrue(!desc.contains("°C"), () -> desc);
+        assertTrue(!desc.contains("km/h"), () -> desc);
+    }
+
+    // ---- forecast block ----
+
+    @Test
+    void forecastFieldRenders3DaysWithWeekdayAndHighLow() {
+        MessageEmbed embed = WeatherEmbedBuilder.build(sampleResponse(), "Toronto",
+                WeatherEmbedBuilder.Units.METRIC);
+        MessageEmbed.Field forecast = embed.getFields().get(0);
+        assertEquals("3-day forecast", forecast.getName());
+        String body = forecast.getValue();
+        // 2026-05-09 is a Saturday; 2026-05-10 Sunday; 2026-05-11 Monday.
+        assertTrue(body.contains("Saturday"),  () -> body);
+        assertTrue(body.contains("Sunday"),    () -> body);
+        assertTrue(body.contains("Monday"),    () -> body);
+        assertTrue(body.contains("↑ 12°C / ↓ 5°C"),  () -> body);
+        assertTrue(body.contains("↑ 15°C / ↓ 7°C"),  () -> body);
+        assertTrue(body.contains("↑ 18°C / ↓ 10°C"), () -> body);
+        assertTrue(body.contains("Heavy rain"), () -> body);
+        assertTrue(body.contains("Sunny"),      () -> body);
+    }
+
+    @Test
+    void forecastImperialUnits() {
+        MessageEmbed embed = WeatherEmbedBuilder.build(sampleResponse(), "Toronto",
+                WeatherEmbedBuilder.Units.IMPERIAL);
+        String body = embed.getFields().get(0).getValue();
+        assertTrue(body.contains("°F"), body);
+        assertTrue(!body.contains("°C"), () -> body);
+    }
+
+    // ---- footer ----
+
+    @Test
+    void footerCreditsWttrIn() {
+        MessageEmbed embed = WeatherEmbedBuilder.build(sampleResponse(), "Toronto",
+                WeatherEmbedBuilder.Units.METRIC);
+        assertEquals("via wttr.in", embed.getFooter().getText());
+    }
+
+    // ---- defensive paths ----
+
+    @Test
+    void emptyResponseStillProducesEmbedWithoutThrowing() {
+        WeatherResponse empty = new WeatherResponse(List.of(), List.of(), List.of());
+        MessageEmbed embed = WeatherEmbedBuilder.build(empty, "Mars",
+                WeatherEmbedBuilder.Units.METRIC);
+        assertEquals("Weather in Mars", embed.getTitle());
+        assertTrue(embed.getDescription().toLowerCase().contains("no current"),
+                () -> embed.getDescription());
+        assertEquals(0, embed.getFields().size());
+    }
+}

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/weather/WeatherEmojiTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/weather/WeatherEmojiTest.java
@@ -1,0 +1,54 @@
+package ca.ryanmorrison.chatterbox.features.weather;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class WeatherEmojiTest {
+
+    @Test
+    void clearAndSunnyMapToSun() {
+        assertEquals("☀️", WeatherEmoji.forCode("113"));
+    }
+
+    @Test
+    void partlyCloudyAndCloudy() {
+        assertEquals("🌤️", WeatherEmoji.forCode("116"));
+        assertEquals("☁️", WeatherEmoji.forCode("119"));
+        assertEquals("☁️", WeatherEmoji.forCode("122"));
+    }
+
+    @Test
+    void rainCodes() {
+        assertEquals("🌦️", WeatherEmoji.forCode("176"));
+        assertEquals("🌧️", WeatherEmoji.forCode("308"));
+    }
+
+    @Test
+    void snowCodes() {
+        assertEquals("❄️", WeatherEmoji.forCode("338"));
+    }
+
+    @Test
+    void thunderCodes() {
+        assertEquals("⛈️", WeatherEmoji.forCode("200"));
+        assertEquals("⛈️", WeatherEmoji.forCode("389"));
+    }
+
+    @Test
+    void unknownCodeFallsBackToThermometer() {
+        assertEquals("🌡️", WeatherEmoji.forCode("999"));
+        assertEquals("🌡️", WeatherEmoji.forCode(""));
+        assertEquals("🌡️", WeatherEmoji.forCode(null));
+    }
+
+    @Test
+    void differentCategoriesProduceDifferentEmoji() {
+        // Loose sanity: sun, cloud, rain, snow, thunder shouldn't collapse.
+        assertNotEquals(WeatherEmoji.forCode("113"), WeatherEmoji.forCode("119"));
+        assertNotEquals(WeatherEmoji.forCode("119"), WeatherEmoji.forCode("308"));
+        assertNotEquals(WeatherEmoji.forCode("308"), WeatherEmoji.forCode("338"));
+        assertNotEquals(WeatherEmoji.forCode("338"), WeatherEmoji.forCode("200"));
+    }
+}


### PR DESCRIPTION
## Summary
Adds a new `/weather` slash command that fetches current conditions and a 3-day forecast from wttr.in for any location (city, country, postal code, lat/long, etc.). Results are rendered as a Discord embed with temperature, wind, humidity, UV index, and daily high/low forecasts.

## Key Changes

- **WeatherClient**: HTTP client for wttr.in's `?format=j1` JSON API
  - 10-second timeout with response-size cap (256 KB)
  - Robust error handling: sniffs "location not found" responses, maps HTTP 429 to rate-limit message, surfaces user-safe exceptions
  - Rejects blank/null locations client-side (wttr.in would interpret as "use my IP")
  - URL-encodes location with `%20` for spaces (not form-encoding `+`)

- **WeatherEmbedBuilder**: Renders WeatherResponse as a Discord MessageEmbed
  - Title: "Weather in {city}, {region}, {country}" (falls back to requested location if geocoding unavailable)
  - Description: condition emoji + current temp/feels-like + wind/humidity/UV summary
  - Field: 3-day forecast with weekday names, high/low temps, noon-ish condition description
  - Supports metric (°C, km/h) and imperial (°F, mph) units as render-time switch

- **WeatherEmoji**: Maps wttr.in's 3-digit weather codes to Discord emojis
  - ~50 codes collapsed into ~10 visual groups (sun, clouds, rain, snow, thunder, etc.)
  - Falls back to thermometer emoji for unknown codes

- **WeatherHandler**: Slash command listener
  - Defers reply (network call can take seconds)
  - Parses `location` (required), `units` (metric/imperial), and `private` (ephemeral) options
  - Surfaces WeatherException messages directly to user; logs unexpected errors

- **WeatherModule**: Module registration
  - Defines `/weather location:<text> [units:<choice>] [private:<bool>]` command
  - Integrates with existing module system

- **DTOs**: Jackson records for wttr.in's nested JSON shape
  - CurrentCondition, DailyForecast, HourlyForecast, NearestArea, ValueWrapper, WeatherResponse
  - Keeps numeric fields as strings to avoid precision loss on missing values
  - Extracts only rendered fields; ignores unknown properties

## Notable Implementation Details

- **No API key required**: wttr.in is a free, open service; hostname is hard-coded
- **Defensive parsing**: All numeric fields kept as strings; render-time formatting handles missing/malformed data gracefully
- **Comprehensive test coverage**: 
  - WeatherClientTest: happy path (nested shape parsing, query params, URL encoding), failure modes (blank location, unknown location, rate limit, HTTP errors, unparseable body)
  - WeatherEmbedBuilderTest: title/location rendering, current description (metric/imperial), forecast block, footer, empty response handling
  - WeatherEmojiTest: code-to-emoji mapping, fallback behavior
- **README updated** with feature documentation and usage examples

https://claude.ai/code/session_01Sx89PCe12XmPkoe5HiaQsV