### PR TITLE
Add Wikipedia lookup feature with /wiki command

### DIFF
--- a/README.md
+++ b/README.md
@@ -861,3 +861,37 @@ body — wttr.in's odd convention for typos) from rate-limit (HTTP 429,
 ~30 req/hour per IP on the free tier) from generic upstream errors.
 Every failure mode produces a deterministic ephemeral message; raw
 exceptions are never surfaced.
+
+### Wiki
+
+`/wiki query:<text> [private:<bool>]` — Wikipedia summary lookup. English
+Wikipedia only; no API key required.
+
+Resolution: tries
+[`/api/rest_v1/page/summary/{title}`](https://en.wikipedia.org/api/rest_v1/)
+first (Wikipedia normalises common variants like capitalisation and
+redirects in-flight). On 404, falls back to
+[`/w/rest.php/v1/search/page?q=...&limit=1`](https://en.wikipedia.org/w/rest.php/v1/)
+and re-fetches the summary for the top hit, so typos like "torono"
+still find Toronto.
+
+Output is a Discord embed:
+
+- Title: page title, hyperlinked to the article.
+- Description: short Wikipedia description (italicised) + lead paragraph,
+  capped at ~1500 chars on a word boundary so the message stays
+  scrollable rather than wall-of-text.
+- Thumbnail: page image if Wikipedia provides one.
+- Footer: "Wikipedia".
+
+**Disambiguation pages** (`type == "disambiguation"`) get an italic hint
+at the top of the description so readers refine their query rather than
+treat the list of meanings as the answer.
+
+Failure modes map to ephemeral text replies: rate limit (HTTP 429),
+generic upstream errors (other non-2xx), timeouts, and "couldn't find
+anything" when both summary and search come up empty. Mentions in the
+extract are suppressed so a Wikipedia article that happens to contain
+`@everyone` can't ping the channel.
+
+Hostname is hard-coded `en.wikipedia.org`, so no SSRF surface to defend.

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/wiki/WikiClient.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/wiki/WikiClient.java
@@ -1,0 +1,160 @@
+package ca.ryanmorrison.chatterbox.features.wiki;
+
+import ca.ryanmorrison.chatterbox.features.wiki.dto.PageSummary;
+import ca.ryanmorrison.chatterbox.features.wiki.dto.SearchHit;
+import ca.ryanmorrison.chatterbox.features.wiki.dto.SearchResponse;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpTimeoutException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Talks to Wikipedia's REST API.
+ *
+ * <p>Two endpoints used:
+ * <ul>
+ *   <li>{@code GET /api/rest_v1/page/summary/{title}} — page summary (lead
+ *       paragraph + description + thumbnail).</li>
+ *   <li>{@code GET /w/rest.php/v1/search/page?q=...&limit=N} — fallback
+ *       full-text search when the direct title lookup 404s.</li>
+ * </ul>
+ *
+ * <p>Both follow the project's standard posture: 10s timeout, response-size
+ * cap, all failures funnelled into {@link WikiException} with messages safe
+ * to surface in a Discord reply.
+ */
+final class WikiClient {
+
+    static final String BASE_URL = "https://en.wikipedia.org";
+    static final int MAX_RESPONSE_BYTES = 1024 * 1024;
+    static final Duration HTTP_TIMEOUT = Duration.ofSeconds(10);
+    static final String USER_AGENT = "Chatterbox/0.1 (+/wiki Discord bot)";
+
+    private final HttpClient http;
+    private final String baseUrl;
+    private final ObjectMapper mapper;
+
+    WikiClient() {
+        this(HttpClient.newBuilder()
+                        .connectTimeout(HTTP_TIMEOUT)
+                        .followRedirects(HttpClient.Redirect.NORMAL)
+                        .build(),
+                BASE_URL);
+    }
+
+    /** Test seam — lets tests point at a local {@code HttpServer}. */
+    WikiClient(HttpClient http, String baseUrl) {
+        this.http = http;
+        this.baseUrl = baseUrl;
+        this.mapper = JsonMapper.builder()
+                .findAndAddModules()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .build();
+    }
+
+    /**
+     * Direct page summary lookup. Returns {@link Optional#empty()} on 404
+     * (so callers can chain into {@link #search}); other non-2xx surface
+     * as {@link WikiException}.
+     */
+    Optional<PageSummary> summary(String title) throws WikiException {
+        if (title == null || title.isBlank()) {
+            throw new WikiException("Tell me what to look up.");
+        }
+        // URLEncoder uses form-encoding (+ for space); paths need %20.
+        String encoded = URLEncoder.encode(title.trim(), StandardCharsets.UTF_8).replace("+", "%20");
+        byte[] body;
+        int status;
+        try {
+            HttpResponse<byte[]> resp = send("/api/rest_v1/page/summary/" + encoded);
+            body = resp.body() == null ? new byte[0] : resp.body();
+            status = resp.statusCode();
+        } catch (WikiException e) {
+            throw e;
+        }
+
+        if (status == 404) return Optional.empty();
+        if (status == 429) throw new WikiException("Wikipedia is rate-limiting us. Try again in a minute.");
+        if (status / 100 != 2) throw new WikiException("Wikipedia returned HTTP " + status + ".");
+        if (body.length == 0) throw new WikiException("Wikipedia returned an empty response.");
+        try {
+            return Optional.of(mapper.readValue(body, PageSummary.class));
+        } catch (IOException e) {
+            throw new WikiException("Wikipedia returned an unexpected response.");
+        }
+    }
+
+    /**
+     * Full-text search. Used as a fallback when {@link #summary} 404s, so we
+     * can convert "torono" → "Toronto". Returns at most {@code limit} hits.
+     */
+    List<SearchHit> search(String query, int limit) throws WikiException {
+        if (query == null || query.isBlank()) return List.of();
+        String encoded = URLEncoder.encode(query.trim(), StandardCharsets.UTF_8);
+        byte[] body;
+        int status;
+        try {
+            HttpResponse<byte[]> resp =
+                    send("/w/rest.php/v1/search/page?q=" + encoded + "&limit=" + limit);
+            body = resp.body() == null ? new byte[0] : resp.body();
+            status = resp.statusCode();
+        } catch (WikiException e) {
+            throw e;
+        }
+
+        if (status == 429) throw new WikiException("Wikipedia is rate-limiting us. Try again in a minute.");
+        if (status / 100 != 2) throw new WikiException("Wikipedia returned HTTP " + status + ".");
+        if (body.length == 0) return List.of();
+        try {
+            return mapper.readValue(body, SearchResponse.class).hits();
+        } catch (IOException e) {
+            throw new WikiException("Wikipedia returned an unexpected response.");
+        }
+    }
+
+    private HttpResponse<byte[]> send(String path) throws WikiException {
+        URI uri;
+        try {
+            uri = URI.create(baseUrl + path);
+        } catch (IllegalArgumentException e) {
+            throw new WikiException("Couldn't build the request URL.");
+        }
+        HttpRequest req = HttpRequest.newBuilder(uri)
+                .timeout(HTTP_TIMEOUT)
+                .header("User-Agent", USER_AGENT)
+                .header("Accept", "application/json")
+                .GET()
+                .build();
+        try {
+            HttpResponse<byte[]> resp = http.send(req, HttpResponse.BodyHandlers.ofByteArray());
+            byte[] body = resp.body();
+            if (body != null && body.length > MAX_RESPONSE_BYTES) {
+                throw new WikiException("Wikipedia response was too large.");
+            }
+            return resp;
+        } catch (HttpTimeoutException e) {
+            throw new WikiException("Wikipedia didn't respond within " + HTTP_TIMEOUT.toSeconds() + " seconds.");
+        } catch (IOException e) {
+            throw new WikiException("Couldn't reach Wikipedia.");
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new WikiException("Request was interrupted.");
+        }
+    }
+
+    /** User-safe checked exception for any fetch/parse failure. */
+    static final class WikiException extends Exception {
+        WikiException(String message) { super(message); }
+    }
+}

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/wiki/WikiEmbedBuilder.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/wiki/WikiEmbedBuilder.java
@@ -1,0 +1,76 @@
+package ca.ryanmorrison.chatterbox.features.wiki;
+
+import ca.ryanmorrison.chatterbox.features.wiki.dto.PageSummary;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+
+import java.awt.Color;
+import java.util.Optional;
+
+/**
+ * Renders a {@link PageSummary} as a Discord embed.
+ *
+ * <p>Layout:
+ * <ul>
+ *   <li>Title: page title, hyperlinked to the article URL.</li>
+ *   <li>Description: optional short Wikipedia description on the first line,
+ *       a blank line, then the lead paragraph (capped at
+ *       {@link #MAX_EXTRACT_LENGTH} chars on a word boundary).</li>
+ *   <li>Thumbnail: {@code thumbnail.source} if present.</li>
+ *   <li>Footer: "Wikipedia".</li>
+ * </ul>
+ *
+ * <p>For disambiguation pages a small italic hint precedes the extract so
+ * readers know to refine the query rather than treat the list as the answer.
+ */
+final class WikiEmbedBuilder {
+
+    /**
+     * Discord's embed-description max is 4096 chars; we keep the extract under
+     * 1500 to leave room for the description-line + disambiguation hint and
+     * to keep the message scrollable rather than wall-of-text.
+     */
+    static final int MAX_EXTRACT_LENGTH = 1500;
+    static final String DISAMBIGUATION_HINT =
+            "_This is a disambiguation page — try a more specific query._";
+    private static final Color EMBED_COLOR = new Color(0xCDD2D6); // Wikipedia grey
+
+    private WikiEmbedBuilder() {}
+
+    static MessageEmbed build(PageSummary summary) {
+        EmbedBuilder eb = new EmbedBuilder().setColor(EMBED_COLOR);
+        eb.setTitle(summary.title(), summary.articleUrl().orElse(null));
+
+        StringBuilder body = new StringBuilder();
+        if (summary.isDisambiguation()) {
+            body.append(DISAMBIGUATION_HINT).append("\n\n");
+        }
+        Optional.ofNullable(summary.description())
+                .filter(s -> !s.isBlank())
+                .ifPresent(d -> body.append("*").append(d.trim()).append("*\n\n"));
+        Optional.ofNullable(summary.extract())
+                .filter(s -> !s.isBlank())
+                .ifPresent(e -> body.append(truncate(e.trim(), MAX_EXTRACT_LENGTH)));
+        if (body.length() > 0) eb.setDescription(body.toString());
+
+        if (summary.thumbnail() != null && summary.thumbnail().source() != null
+                && !summary.thumbnail().source().isBlank()) {
+            eb.setThumbnail(summary.thumbnail().source());
+        }
+
+        eb.setFooter("Wikipedia");
+        return eb.build();
+    }
+
+    /**
+     * Truncate to {@code max} chars on a word boundary, appending an ellipsis.
+     * Falls back to a hard cut if no whitespace is found in the last quarter
+     * of the window — pathological case but covers it cleanly.
+     */
+    static String truncate(String s, int max) {
+        if (s.length() <= max) return s;
+        int cut = s.lastIndexOf(' ', max);
+        if (cut < max * 3 / 4) cut = max;
+        return s.substring(0, cut).stripTrailing() + "…";
+    }
+}

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/wiki/WikiHandler.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/wiki/WikiHandler.java
@@ -1,0 +1,96 @@
+package ca.ryanmorrison.chatterbox.features.wiki;
+
+import ca.ryanmorrison.chatterbox.features.wiki.dto.PageSummary;
+import ca.ryanmorrison.chatterbox.features.wiki.dto.SearchHit;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Handles {@code /wiki query:<text> [private:<bool>]}.
+ *
+ * <p>Resolution: tries a direct {@code page/summary/{title}} lookup first.
+ * On 404, falls back to {@code search/page?q=...} and re-fetches the
+ * summary for the top hit. Any successful path renders the result as an
+ * embed via {@link WikiEmbedBuilder}; failures map to ephemeral text
+ * replies via {@link WikiClient.WikiException}.
+ *
+ * <p>Mentions in the reply are suppressed: a Wikipedia extract that
+ * happens to contain {@code @everyone} or a real user-id-shaped string
+ * shouldn't ping the channel.
+ */
+final class WikiHandler extends ListenerAdapter {
+
+    private static final Logger log = LoggerFactory.getLogger(WikiHandler.class);
+
+    private final WikiClient client;
+
+    WikiHandler(WikiClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
+        if (!WikiModule.COMMAND.equals(event.getName())) return;
+
+        String query = stringOption(event, WikiModule.OPT_QUERY);
+        if (query == null || query.isBlank()) {
+            event.reply("Tell me what to look up.").setEphemeral(true).queue();
+            return;
+        }
+        boolean ephemeral = booleanOption(event, WikiModule.OPT_PRIVATE);
+
+        event.deferReply(ephemeral).queue();
+
+        Optional<PageSummary> summary;
+        try {
+            summary = client.summary(query);
+            if (summary.isEmpty()) {
+                List<SearchHit> hits = client.search(query, 1);
+                if (hits.isEmpty()) {
+                    event.getHook().sendMessage("Couldn't find anything for `" + query.trim() + "`. "
+                                    + "Try different wording or a more specific name.")
+                            .queue();
+                    return;
+                }
+                summary = client.summary(hits.get(0).title());
+            }
+        } catch (WikiClient.WikiException e) {
+            event.getHook().sendMessage(e.getMessage()).queue();
+            return;
+        } catch (RuntimeException e) {
+            log.warn("Unexpected error for /wiki query={}", query, e);
+            event.getHook().sendMessage("Something went wrong looking that up.").queue();
+            return;
+        }
+
+        if (summary.isEmpty()) {
+            // Search returned a hit but the follow-up summary 404'd — rare race.
+            event.getHook().sendMessage("Couldn't find anything for `" + query.trim() + "`.").queue();
+            return;
+        }
+
+        MessageEmbed embed = WikiEmbedBuilder.build(summary.get());
+        event.getHook().sendMessageEmbeds(embed)
+                .setAllowedMentions(EnumSet.noneOf(Message.MentionType.class))
+                .queue();
+    }
+
+    private static String stringOption(SlashCommandInteractionEvent event, String name) {
+        OptionMapping opt = event.getOption(name);
+        return opt == null ? null : opt.getAsString();
+    }
+
+    private static boolean booleanOption(SlashCommandInteractionEvent event, String name) {
+        OptionMapping opt = event.getOption(name);
+        return opt != null && opt.getAsBoolean();
+    }
+}

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/wiki/WikiModule.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/wiki/WikiModule.java
@@ -1,0 +1,44 @@
+package ca.ryanmorrison.chatterbox.features.wiki;
+
+import ca.ryanmorrison.chatterbox.module.InitContext;
+import ca.ryanmorrison.chatterbox.module.Module;
+import net.dv8tion.jda.api.hooks.EventListener;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.Commands;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
+
+import java.util.List;
+
+/**
+ * {@code /wiki query:<text> [private:<bool>]} — Wikipedia summary lookup.
+ *
+ * <p>Direct title lookup with a search-on-404 fallback so typos and
+ * partial matches still resolve. English Wikipedia only; no API key
+ * required. Hostname is hard-coded {@code en.wikipedia.org} so there's
+ * no SSRF surface to defend.
+ */
+public final class WikiModule implements Module {
+
+    static final String COMMAND     = "wiki";
+    static final String OPT_QUERY   = "query";
+    static final String OPT_PRIVATE = "private";
+
+    @Override public String name() { return "wiki"; }
+
+    @Override
+    public List<SlashCommandData> slashCommands(InitContext ctx) {
+        OptionData query = new OptionData(OptionType.STRING, OPT_QUERY,
+                "What to look up on Wikipedia.", true, false);
+        OptionData priv = new OptionData(OptionType.BOOLEAN, OPT_PRIVATE,
+                "Show the result only to you instead of the channel.",
+                false, false);
+        return List.of(Commands.slash(COMMAND, "Look up a topic on Wikipedia.")
+                .addOptions(query, priv));
+    }
+
+    @Override
+    public List<EventListener> listeners(InitContext ctx) {
+        return List.of(new WikiHandler(new WikiClient()));
+    }
+}

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/wiki/dto/ContentUrlSet.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/wiki/dto/ContentUrlSet.java
@@ -1,0 +1,11 @@
+package ca.ryanmorrison.chatterbox.features.wiki.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * One of the entries in {@code content_urls} (keyed by {@code desktop} or
+ * {@code mobile}). Only {@code page} is used.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ContentUrlSet(String page) {
+}

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/wiki/dto/PageSummary.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/wiki/dto/PageSummary.java
@@ -1,0 +1,42 @@
+package ca.ryanmorrison.chatterbox.features.wiki.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Response shape from {@code /api/rest_v1/page/summary/{title}}.
+ *
+ * <p>Field selection: only what the embed renders. The API returns much more
+ * (revision, timestamp, namespace, languagelinks, …) but we ignore unknown
+ * fields so the bot doesn't break when Wikipedia adds something.
+ *
+ * <p>{@link #type()} drives the disambiguation branch — values are
+ * {@code "standard"}, {@code "disambiguation"}, {@code "no-extract"}, and
+ * a handful of error-shaped strings on 404 (e.g.
+ * {@code "https://mediawiki.org/wiki/HyperSwitch/errors/not_found"}).
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record PageSummary(
+        String type,
+        String title,
+        String description,
+        String extract,
+        Thumbnail thumbnail,
+        @JsonProperty("content_urls") Map<String, ContentUrlSet> contentUrls) {
+
+    public static final String TYPE_DISAMBIGUATION = "disambiguation";
+
+    public Optional<String> articleUrl() {
+        if (contentUrls == null) return Optional.empty();
+        ContentUrlSet desktop = contentUrls.get("desktop");
+        if (desktop == null || desktop.page() == null) return Optional.empty();
+        return Optional.of(desktop.page());
+    }
+
+    public boolean isDisambiguation() {
+        return TYPE_DISAMBIGUATION.equalsIgnoreCase(type);
+    }
+}

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/wiki/dto/SearchHit.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/wiki/dto/SearchHit.java
@@ -1,0 +1,14 @@
+package ca.ryanmorrison.chatterbox.features.wiki.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * One hit from {@code /w/rest.php/v1/search/page}.
+ *
+ * <p>{@code key} is the URL slug (used to fetch the summary), {@code title}
+ * is the display title. Other fields (excerpt, thumbnail, description) exist
+ * on the response but we only need the title to chain into a summary call.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record SearchHit(String key, String title) {
+}

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/wiki/dto/SearchResponse.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/wiki/dto/SearchResponse.java
@@ -1,0 +1,14 @@
+package ca.ryanmorrison.chatterbox.features.wiki.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+/** Top-level shape of {@code /w/rest.php/v1/search/page}: just {@code pages}. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record SearchResponse(List<SearchHit> pages) {
+
+    public List<SearchHit> hits() {
+        return pages == null ? List.of() : pages;
+    }
+}

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/wiki/dto/Thumbnail.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/wiki/dto/Thumbnail.java
@@ -1,0 +1,10 @@
+package ca.ryanmorrison.chatterbox.features.wiki.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record Thumbnail(
+        String source,
+        Integer width,
+        Integer height) {
+}

--- a/src/main/resources/META-INF/services/ca.ryanmorrison.chatterbox.module.Module
+++ b/src/main/resources/META-INF/services/ca.ryanmorrison.chatterbox.module.Module
@@ -14,3 +14,4 @@ ca.ryanmorrison.chatterbox.features.isitdown.IsItDownModule
 ca.ryanmorrison.chatterbox.features.when.WhenModule
 ca.ryanmorrison.chatterbox.features.timezone.TimezoneModule
 ca.ryanmorrison.chatterbox.features.weather.WeatherModule
+ca.ryanmorrison.chatterbox.features.wiki.WikiModule

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/wiki/WikiClientTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/wiki/WikiClientTest.java
@@ -1,0 +1,220 @@
+package ca.ryanmorrison.chatterbox.features.wiki;
+
+import ca.ryanmorrison.chatterbox.features.wiki.dto.PageSummary;
+import ca.ryanmorrison.chatterbox.features.wiki.dto.SearchHit;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WikiClientTest {
+
+    private HttpServer server;
+    private WikiClient client;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.start();
+        String baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
+        HttpClient http = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(2)).build();
+        client = new WikiClient(http, baseUrl);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) server.stop(0);
+    }
+
+    private void serve(String path, int status, String body) {
+        server.createContext(path, ex -> {
+            byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+            ex.getResponseHeaders().add("Content-Type", "application/json");
+            ex.sendResponseHeaders(status, bytes.length);
+            try (var os = ex.getResponseBody()) { os.write(bytes); }
+        });
+    }
+
+    /** Trimmed real-shape Wikipedia summary response. */
+    private static final String TORONTO_SUMMARY = """
+            {
+              "type": "standard",
+              "title": "Toronto",
+              "displaytitle": "Toronto",
+              "description": "Capital city of Ontario, Canada",
+              "extract": "Toronto is the capital city of the Canadian province of Ontario.",
+              "thumbnail": {
+                "source": "https://upload.wikimedia.org/wikipedia/commons/thumb/toronto.jpg",
+                "width": 320, "height": 213
+              },
+              "content_urls": {
+                "desktop": {
+                  "page": "https://en.wikipedia.org/wiki/Toronto",
+                  "revisions": "https://en.wikipedia.org/wiki/Toronto?action=history"
+                },
+                "mobile": {
+                  "page": "https://en.m.wikipedia.org/wiki/Toronto"
+                }
+              }
+            }
+            """;
+
+    private static final String DISAMBIGUATION_SUMMARY = """
+            {
+              "type": "disambiguation",
+              "title": "Java",
+              "extract": "Java may refer to:",
+              "content_urls": {
+                "desktop": {"page": "https://en.wikipedia.org/wiki/Java"}
+              }
+            }
+            """;
+
+    private static final String SEARCH_RESPONSE = """
+            {
+              "pages": [
+                {"id": 64646, "key": "Toronto", "title": "Toronto",
+                 "excerpt": "<span class=\\"searchmatch\\">Toronto</span> is..."},
+                {"id": 1, "key": "Toronto_FC", "title": "Toronto FC"}
+              ]
+            }
+            """;
+
+    // ---- summary happy path ----
+
+    @Test
+    void summaryParsesStandardPage() throws Exception {
+        serve("/api/rest_v1/page/summary/Toronto", 200, TORONTO_SUMMARY);
+        Optional<PageSummary> got = client.summary("Toronto");
+        assertTrue(got.isPresent());
+        PageSummary p = got.get();
+        assertEquals("Toronto", p.title());
+        assertEquals("Capital city of Ontario, Canada", p.description());
+        assertTrue(p.extract().startsWith("Toronto is the capital city"));
+        assertEquals("https://en.wikipedia.org/wiki/Toronto", p.articleUrl().orElseThrow());
+        assertEquals("https://upload.wikimedia.org/wikipedia/commons/thumb/toronto.jpg",
+                p.thumbnail().source());
+        assertEquals(false, p.isDisambiguation());
+    }
+
+    @Test
+    void summaryDetectsDisambiguation() throws Exception {
+        serve("/api/rest_v1/page/summary/Java", 200, DISAMBIGUATION_SUMMARY);
+        PageSummary p = client.summary("Java").orElseThrow();
+        assertTrue(p.isDisambiguation());
+        assertEquals("Java may refer to:", p.extract());
+    }
+
+    @Test
+    void summaryWithSpacesIsPathEncoded() throws Exception {
+        AtomicReference<String> rawPath = new AtomicReference<>();
+        // Catch-all so we can capture the actual path.
+        server.createContext("/api/rest_v1/page/summary/", ex -> {
+            rawPath.set(ex.getRequestURI().getRawPath());
+            byte[] bytes = TORONTO_SUMMARY.getBytes(StandardCharsets.UTF_8);
+            ex.getResponseHeaders().add("Content-Type", "application/json");
+            ex.sendResponseHeaders(200, bytes.length);
+            try (var os = ex.getResponseBody()) { os.write(bytes); }
+        });
+        client.summary("Java (programming language)");
+        assertEquals("/api/rest_v1/page/summary/Java%20%28programming%20language%29", rawPath.get(),
+                "URL spaces must be %20 (paths), not + (form-encoding).");
+    }
+
+    // ---- summary failure paths ----
+
+    @Test
+    void summary404ReturnsEmpty() throws Exception {
+        serve("/api/rest_v1/page/summary/Asdfqwer", 404,
+                """
+                {"type":"https://mediawiki.org/wiki/HyperSwitch/errors/not_found",
+                 "title":"Not found.","detail":"Page or revision not found."}
+                """);
+        // 404 is the chain-into-search signal — must not throw.
+        assertTrue(client.summary("Asdfqwer").isEmpty());
+    }
+
+    @Test
+    void summary429SurfacesRateLimit() {
+        serve("/api/rest_v1/page/summary/Toronto", 429, "rate limited");
+        var ex = assertThrows(WikiClient.WikiException.class, () -> client.summary("Toronto"));
+        assertTrue(ex.getMessage().toLowerCase().contains("rate"), () -> ex.getMessage());
+    }
+
+    @Test
+    void summary500SurfacesGenericHttpStatus() {
+        serve("/api/rest_v1/page/summary/Toronto", 500, "internal error");
+        var ex = assertThrows(WikiClient.WikiException.class, () -> client.summary("Toronto"));
+        assertTrue(ex.getMessage().contains("500"), () -> ex.getMessage());
+    }
+
+    @Test
+    void summaryUnparseableBodySurfacedAsUnexpected() {
+        serve("/api/rest_v1/page/summary/Toronto", 200, "{not json");
+        var ex = assertThrows(WikiClient.WikiException.class, () -> client.summary("Toronto"));
+        assertTrue(ex.getMessage().toLowerCase().contains("unexpected"), () -> ex.getMessage());
+    }
+
+    @Test
+    void blankTitleRejectedClientSide() {
+        assertThrows(WikiClient.WikiException.class, () -> client.summary(""));
+        assertThrows(WikiClient.WikiException.class, () -> client.summary("   "));
+        assertThrows(WikiClient.WikiException.class, () -> client.summary(null));
+    }
+
+    // ---- search ----
+
+    @Test
+    void searchHappyPathReturnsHits() throws Exception {
+        serve("/w/rest.php/v1/search/page", 200, SEARCH_RESPONSE);
+        List<SearchHit> hits = client.search("torono", 2);
+        assertEquals(2, hits.size());
+        assertEquals("Toronto", hits.get(0).title());
+        assertEquals("Toronto", hits.get(0).key());
+        assertEquals("Toronto FC", hits.get(1).title());
+    }
+
+    @Test
+    void searchEmptyQueryReturnsEmpty() throws Exception {
+        // Defensive — handler shouldn't pass blank, but if it did we shouldn't
+        // make a wasted round-trip.
+        assertEquals(List.of(), client.search("", 5));
+        assertEquals(List.of(), client.search(null, 5));
+    }
+
+    @Test
+    void searchEmptyResultsReturnsEmptyList() throws Exception {
+        serve("/w/rest.php/v1/search/page", 200, """
+                {"pages": []}
+                """);
+        assertEquals(List.of(), client.search("zzzzzznope", 1));
+    }
+
+    @Test
+    void searchPassesQueryAndLimit() throws Exception {
+        AtomicReference<String> rawQuery = new AtomicReference<>();
+        server.createContext("/w/rest.php/v1/search/page", ex -> {
+            rawQuery.set(ex.getRequestURI().getRawQuery());
+            byte[] bytes = SEARCH_RESPONSE.getBytes(StandardCharsets.UTF_8);
+            ex.getResponseHeaders().add("Content-Type", "application/json");
+            ex.sendResponseHeaders(200, bytes.length);
+            try (var os = ex.getResponseBody()) { os.write(bytes); }
+        });
+        client.search("torono", 1);
+        assertTrue(rawQuery.get().contains("q=torono"), () -> "got: " + rawQuery.get());
+        assertTrue(rawQuery.get().contains("limit=1"), () -> "got: " + rawQuery.get());
+    }
+}

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/wiki/WikiEmbedBuilderTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/wiki/WikiEmbedBuilderTest.java
@@ -1,0 +1,139 @@
+package ca.ryanmorrison.chatterbox.features.wiki;
+
+import ca.ryanmorrison.chatterbox.features.wiki.dto.ContentUrlSet;
+import ca.ryanmorrison.chatterbox.features.wiki.dto.PageSummary;
+import ca.ryanmorrison.chatterbox.features.wiki.dto.Thumbnail;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WikiEmbedBuilderTest {
+
+    private static PageSummary toronto() {
+        return new PageSummary(
+                "standard",
+                "Toronto",
+                "Capital city of Ontario, Canada",
+                "Toronto is the capital city of the Canadian province of Ontario.",
+                new Thumbnail("https://upload.wikimedia.org/thumb.jpg", 320, 213),
+                Map.of("desktop", new ContentUrlSet("https://en.wikipedia.org/wiki/Toronto")));
+    }
+
+    @Test
+    void titleIsHyperlinkedToArticle() {
+        MessageEmbed embed = WikiEmbedBuilder.build(toronto());
+        assertEquals("Toronto", embed.getTitle());
+        assertEquals("https://en.wikipedia.org/wiki/Toronto", embed.getUrl());
+    }
+
+    @Test
+    void descriptionContainsShortDescriptionAndExtract() {
+        MessageEmbed embed = WikiEmbedBuilder.build(toronto());
+        String desc = embed.getDescription();
+        assertNotNull(desc);
+        assertTrue(desc.contains("Capital city of Ontario, Canada"), desc);
+        assertTrue(desc.contains("Toronto is the capital city"), desc);
+    }
+
+    @Test
+    void thumbnailIsSet() {
+        MessageEmbed embed = WikiEmbedBuilder.build(toronto());
+        assertEquals("https://upload.wikimedia.org/thumb.jpg", embed.getThumbnail().getUrl());
+    }
+
+    @Test
+    void footerIsWikipedia() {
+        MessageEmbed embed = WikiEmbedBuilder.build(toronto());
+        assertEquals("Wikipedia", embed.getFooter().getText());
+    }
+
+    // ---- disambiguation ----
+
+    @Test
+    void disambiguationDescriptionLeadsWithHint() {
+        PageSummary s = new PageSummary(
+                "disambiguation", "Java", null, "Java may refer to:",
+                null, Map.of("desktop", new ContentUrlSet("https://en.wikipedia.org/wiki/Java")));
+        MessageEmbed embed = WikiEmbedBuilder.build(s);
+        String desc = embed.getDescription();
+        assertNotNull(desc);
+        assertTrue(desc.startsWith(WikiEmbedBuilder.DISAMBIGUATION_HINT),
+                () -> "expected disambiguation hint to lead, got: " + desc);
+        assertTrue(desc.contains("Java may refer to:"), () -> desc);
+    }
+
+    // ---- defensive paths ----
+
+    @Test
+    void missingThumbnailIsNotSet() {
+        PageSummary s = new PageSummary(
+                "standard", "Toronto", "desc", "extract", null,
+                Map.of("desktop", new ContentUrlSet("https://en.wikipedia.org/wiki/Toronto")));
+        MessageEmbed embed = WikiEmbedBuilder.build(s);
+        assertNull(embed.getThumbnail());
+    }
+
+    @Test
+    void missingDescriptionStillRendersExtract() {
+        PageSummary s = new PageSummary(
+                "standard", "Toronto", null, "Just an extract.", null,
+                Map.of("desktop", new ContentUrlSet("https://en.wikipedia.org/wiki/Toronto")));
+        MessageEmbed embed = WikiEmbedBuilder.build(s);
+        assertTrue(embed.getDescription().contains("Just an extract."), embed.getDescription());
+    }
+
+    @Test
+    void missingArticleUrlStillProducesEmbed() {
+        PageSummary s = new PageSummary(
+                "standard", "Toronto", "desc", "extract", null, Map.of());
+        MessageEmbed embed = WikiEmbedBuilder.build(s);
+        assertEquals("Toronto", embed.getTitle());
+        assertNull(embed.getUrl());
+    }
+
+    @Test
+    void emptyDescriptionAndExtractProducesNoDescriptionField() {
+        PageSummary s = new PageSummary(
+                "standard", "Toronto", "", "", null, Map.of());
+        MessageEmbed embed = WikiEmbedBuilder.build(s);
+        // Embed itself still builds with title; description should be unset.
+        assertNull(embed.getDescription());
+    }
+
+    // ---- truncation ----
+
+    @Test
+    void shortExtractIsNotTruncated() {
+        String s = "Hello world.";
+        assertEquals(s, WikiEmbedBuilder.truncate(s, 100));
+    }
+
+    @Test
+    void longExtractIsTruncatedWithEllipsisOnWordBoundary() {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 200; i++) sb.append("word ");
+        String long200 = sb.toString();
+        String truncated = WikiEmbedBuilder.truncate(long200, 50);
+        assertTrue(truncated.length() <= 51, () -> "got " + truncated.length() + ": " + truncated);
+        assertTrue(truncated.endsWith("…"), truncated);
+        // Should end on a word boundary — no orphan partial word before the ellipsis.
+        String beforeEllipsis = truncated.substring(0, truncated.length() - 1);
+        assertTrue(beforeEllipsis.endsWith("word"), () -> beforeEllipsis);
+    }
+
+    @Test
+    void truncationFallsBackToHardCutWhenNoLateSpace() {
+        // Pathological: a single very long word with no whitespace late in the
+        // window. We hard-cut at max rather than scanning back so far we
+        // truncate to almost nothing.
+        String word = "a".repeat(200);
+        String truncated = WikiEmbedBuilder.truncate(word, 50);
+        assertEquals("a".repeat(50) + "…", truncated);
+    }
+}


### PR DESCRIPTION
## Summary
Adds a new `/wiki` Discord slash command that looks up topics on Wikipedia and returns formatted embed results. The implementation includes direct title lookup with a search-on-404 fallback to handle typos and partial matches.

## Key Changes

- **WikiModule**: New module that registers the `/wiki query:<text> [private:<bool>]` slash command with optional private/ephemeral reply mode
- **WikiClient**: HTTP client for Wikipedia's REST API with two endpoints:
  - `/api/rest_v1/page/summary/{title}` for direct page lookups
  - `/w/rest.php/v1/search/page?q=...&limit=N` as fallback full-text search on 404
  - Handles rate limiting (429), timeouts, and response validation with user-safe error messages
- **WikiHandler**: Event listener that orchestrates the lookup flow—tries summary first, falls back to search if needed, and renders results as Discord embeds
- **WikiEmbedBuilder**: Formats PageSummary objects as Discord message embeds with:
  - Hyperlinked title
  - Short description + lead paragraph (truncated to ~1500 chars on word boundaries)
  - Thumbnail image if available
  - Special handling for disambiguation pages with an italic hint
- **DTOs**: Jackson-annotated records for API response shapes (PageSummary, SearchHit, SearchResponse, Thumbnail, ContentUrlSet)

## Notable Implementation Details

- **Defensive parsing**: All DTOs use `@JsonIgnoreProperties(ignoreUnknown = true)` so the bot won't break when Wikipedia adds new fields
- **URL encoding**: Properly handles spaces as `%20` (path encoding) rather than `+` (form encoding)
- **Mention suppression**: Replies use `setAllowedMentions(EnumSet.noneOf(...))` to prevent Wikipedia extracts containing `@everyone` from pinging the channel
- **Truncation**: Smart word-boundary truncation with fallback to hard cut for pathological cases (very long words with no spaces)
- **Error handling**: All failures (rate limits, timeouts, parse errors, not found) map to ephemeral user-safe text messages rather than exceptions
- **Hostname hardcoded**: `en.wikipedia.org` is baked in—no SSRF surface to defend
- **Comprehensive test coverage**: 20+ tests covering happy paths, failure modes, URL encoding, truncation, and disambiguation detection

https://claude.ai/code/session_01Sx89PCe12XmPkoe5HiaQsV