### PR TITLE
Add stock quote lookup feature via Yahoo Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -895,3 +895,51 @@ extract are suppressed so a Wikipedia article that happens to contain
 `@everyone` can't ping the channel.
 
 Hostname is hard-coded `en.wikipedia.org`, so no SSRF surface to defend.
+
+### Stock
+
+`/stock symbol:<text> [private:<bool>]` — current quote for a NYSE,
+NASDAQ, or TSX-listed security via Yahoo Finance's
+[`v8/finance/chart`](https://query1.finance.yahoo.com/v8/finance/chart/AAPL?interval=1d&range=1d)
+endpoint. No API key required.
+
+Symbol convention follows Yahoo:
+
+| Exchange | Format | Example |
+| --- | --- | --- |
+| NASDAQ | bare ticker | `AAPL` |
+| NYSE | bare ticker | `KO` |
+| TSX | `.TO` suffix | `SHOP.TO`, `RY.TO` |
+
+Output is a Discord embed:
+
+- Title: company name + ticker, hyperlinked to the Yahoo Finance quote page.
+- Description: current price + change (absolute and %, prefixed with
+  ▲/▼/▬), day's high/low, 52-week high/low, and volume formatted with
+  thousands separators.
+- Embed colour reflects the day's change — green up, red down, grey flat.
+- Footer: exchange + currency + "via Yahoo Finance · prices may be
+  delayed", with the quote timestamp rendered as a Discord
+  `<t:UNIX:R>` so each viewer sees freshness in their own timezone.
+
+Failure modes map to ephemeral text replies — bad symbols get a
+"couldn't find … try the Yahoo format" hint (Yahoo's structured
+"may be delisted" message is preserved when present), rate limits
+(HTTP 429) get a friendly "try again in a minute", other upstream
+errors come through as "HTTP N", and timeouts/network errors produce
+"couldn't reach Yahoo Finance".
+
+**Caveats worth knowing:**
+
+- Yahoo's `v8/finance/chart` endpoint is not officially documented or
+  supported. It's been stable for years and is widely used by Discord
+  bots, but Yahoo could change or block it without notice. Swapping to
+  a key-based provider (Alpha Vantage, Finnhub, etc.) would be a
+  single-file change if that ever happens.
+- Free Yahoo quotes are typically delayed ~15 minutes by exchange policy.
+  The footer notes this so callers aren't surprised.
+- Yahoo blanket-403s bot-shaped User-Agents (same WAF behaviour we
+  worked around for `/isitdown`); the client sends a Chrome-shaped UA
+  to get through.
+
+No SSRF surface: hostname is hard-coded `query1.finance.yahoo.com`.

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/stock/StockClient.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/stock/StockClient.java
@@ -1,0 +1,165 @@
+package ca.ryanmorrison.chatterbox.features.stock;
+
+import ca.ryanmorrison.chatterbox.features.stock.dto.ChartMeta;
+import ca.ryanmorrison.chatterbox.features.stock.dto.ChartResponse;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpTimeoutException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Locale;
+
+/**
+ * Talks to Yahoo Finance's {@code v8/finance/chart} endpoint.
+ *
+ * <h2>Caveats</h2>
+ * <ul>
+ *   <li>This endpoint is not officially documented and Yahoo could change
+ *       or block it without notice. Widely used and stable for years; if it
+ *       breaks, swapping to a key-based provider (Alpha Vantage, Finnhub)
+ *       is a single-file change.</li>
+ *   <li>Yahoo blanket-403s bot-flavoured user-agents — same WAF behaviour
+ *       we hit on {@code /isitdown}. We send a Chrome-shaped UA to get
+ *       through, with a TODO to bump it when sniffing tools start flagging
+ *       the version as old.</li>
+ *   <li>Free quotes are exchange-delayed (typically 15 minutes). The embed
+ *       footer notes this so callers aren't surprised.</li>
+ * </ul>
+ *
+ * <p>Posture mirrors {@code NhlClient} / {@code WeatherClient}: 10s timeout,
+ * 1 MB body cap, all failures funnelled into {@link StockException} with
+ * messages safe to surface in a Discord reply.
+ */
+final class StockClient {
+
+    static final String BASE_URL = "https://query1.finance.yahoo.com";
+    static final int MAX_RESPONSE_BYTES = 1024 * 1024;
+    static final Duration HTTP_TIMEOUT = Duration.ofSeconds(10);
+    static final String USER_AGENT =
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+                    + "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
+
+    private final HttpClient http;
+    private final String baseUrl;
+    private final ObjectMapper mapper;
+
+    StockClient() {
+        this(HttpClient.newBuilder()
+                        .connectTimeout(HTTP_TIMEOUT)
+                        .followRedirects(HttpClient.Redirect.NORMAL)
+                        .build(),
+                BASE_URL);
+    }
+
+    /** Test seam — lets tests point at a local {@code HttpServer}. */
+    StockClient(HttpClient http, String baseUrl) {
+        this.http = http;
+        this.baseUrl = baseUrl;
+        this.mapper = JsonMapper.builder()
+                .findAndAddModules()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .build();
+    }
+
+    /** Fetch the meta block for {@code symbol}. Throws {@link StockException} on any failure. */
+    ChartMeta fetch(String symbol) throws StockException {
+        if (symbol == null || symbol.isBlank()) {
+            throw new StockException("Tell me a stock symbol.");
+        }
+        // URLEncoder uses form-encoding (+ for space); paths need %20. Symbols
+        // shouldn't contain spaces, but be defensive — Yahoo treats `BRK B`
+        // and `BRK-B` differently, and we don't want a stray space silently
+        // changing the meaning.
+        String trimmed = symbol.trim();
+        String encoded = URLEncoder.encode(trimmed, StandardCharsets.UTF_8).replace("+", "%20");
+        URI uri;
+        try {
+            uri = URI.create(baseUrl + "/v8/finance/chart/" + encoded + "?interval=1d&range=1d");
+        } catch (IllegalArgumentException e) {
+            throw new StockException("That doesn't look like a valid symbol.");
+        }
+        HttpRequest req = HttpRequest.newBuilder(uri)
+                .timeout(HTTP_TIMEOUT)
+                .header("User-Agent", USER_AGENT)
+                .header("Accept", "application/json")
+                .GET()
+                .build();
+        HttpResponse<byte[]> resp;
+        try {
+            resp = http.send(req, HttpResponse.BodyHandlers.ofByteArray());
+        } catch (HttpTimeoutException e) {
+            throw new StockException("Yahoo Finance didn't respond within "
+                    + HTTP_TIMEOUT.toSeconds() + " seconds.");
+        } catch (IOException e) {
+            throw new StockException("Couldn't reach Yahoo Finance.");
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new StockException("Request was interrupted.");
+        }
+        int status = resp.statusCode();
+        byte[] body = resp.body() == null ? new byte[0] : resp.body();
+        if (body.length > MAX_RESPONSE_BYTES) {
+            throw new StockException("Yahoo Finance response was too large.");
+        }
+
+        if (status == 429) {
+            throw new StockException("Yahoo Finance is rate-limiting us. Try again in a minute.");
+        }
+        // Yahoo returns 404 with a structured JSON error for unknown symbols.
+        // Try to parse it for a richer message; fall back to a generic typo
+        // prompt if the body shape changed.
+        if (status == 404) {
+            throw notFoundException(trimmed, body);
+        }
+        if (status / 100 != 2) {
+            throw new StockException("Yahoo Finance returned HTTP " + status + ".");
+        }
+        if (body.length == 0) {
+            throw new StockException("Yahoo Finance returned an empty response.");
+        }
+        ChartResponse parsed;
+        try {
+            parsed = mapper.readValue(body, ChartResponse.class);
+        } catch (IOException e) {
+            throw new StockException("Yahoo Finance returned an unexpected response.");
+        }
+        // Some 200-class responses still carry a populated error block when
+        // the symbol is valid-looking but unsupported. Treat as "not found".
+        if (parsed.error().isPresent() && parsed.meta().isEmpty()) {
+            throw notFoundException(trimmed, body);
+        }
+        return parsed.meta().orElseThrow(
+                () -> new StockException("Yahoo Finance returned no data for `" + trimmed + "`."));
+    }
+
+    private StockException notFoundException(String symbol, byte[] body) {
+        // Best-effort: parse the structured error if present, otherwise generic.
+        try {
+            ChartResponse parsed = mapper.readValue(body, ChartResponse.class);
+            String detail = parsed.error()
+                    .map(e -> e.description() == null ? "" : e.description())
+                    .orElse("");
+            if (detail.toLowerCase(Locale.ROOT).contains("delisted")) {
+                return new StockException("Couldn't find symbol `" + symbol + "`. "
+                        + "It may be delisted, or check the spelling.");
+            }
+        } catch (IOException ignored) {
+            // Fall through to the generic message.
+        }
+        return new StockException("Couldn't find symbol `" + symbol + "`. "
+                + "Try the Yahoo format — e.g. `AAPL` (NASDAQ), `KO` (NYSE), `SHOP.TO` (TSX).");
+    }
+
+    /** User-safe checked exception for any fetch/parse failure. */
+    static final class StockException extends Exception {
+        StockException(String message) { super(message); }
+    }
+}

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/stock/StockEmbedBuilder.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/stock/StockEmbedBuilder.java
@@ -1,0 +1,144 @@
+package ca.ryanmorrison.chatterbox.features.stock;
+
+import ca.ryanmorrison.chatterbox.features.stock.dto.ChartMeta;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+
+import java.awt.Color;
+import java.text.NumberFormat;
+import java.util.Locale;
+
+/**
+ * Renders a {@link ChartMeta} as a Discord embed.
+ *
+ * <p>Layout:
+ * <ul>
+ *   <li>Title: "{display name} ({symbol})", hyperlinked to the Yahoo Finance quote page.</li>
+ *   <li>Description: current price + change (absolute and %, with ▲/▼/▬),
+ *       day range, 52-week range, volume.</li>
+ *   <li>Embed colour reflects the day's change: green up, red down,
+ *       grey flat.</li>
+ *   <li>Footer: exchange + currency + freshness timestamp + a "may be delayed"
+ *       note (Yahoo's free feed is typically 15-minute-delayed by exchange policy).</li>
+ * </ul>
+ */
+final class StockEmbedBuilder {
+
+    static final Color UP_COLOR   = new Color(0x4CAF50);
+    static final Color DOWN_COLOR = new Color(0xE53935);
+    static final Color FLAT_COLOR = new Color(0x90A4AE);
+
+    private static final NumberFormat VOLUME_FORMAT = NumberFormat.getInstance(Locale.US);
+
+    private StockEmbedBuilder() {}
+
+    static MessageEmbed build(ChartMeta meta) {
+        Double price = meta.regularMarketPrice();
+        Double prev  = meta.chartPreviousClose();
+        Double change = (price != null && prev != null) ? price - prev : null;
+        Double changePct = (change != null && prev != null && prev != 0.0) ? (change / prev) * 100.0 : null;
+
+        EmbedBuilder eb = new EmbedBuilder().setColor(colorFor(change));
+        eb.setTitle(titleFor(meta), quoteUrl(meta.symbol()));
+        eb.setDescription(buildDescription(meta, price, change, changePct));
+        eb.setFooter(footerFor(meta));
+        if (meta.regularMarketTime() != null && meta.regularMarketTime() > 0) {
+            eb.setTimestamp(java.time.Instant.ofEpochSecond(meta.regularMarketTime()));
+        }
+        return eb.build();
+    }
+
+    private static String titleFor(ChartMeta meta) {
+        String name = meta.displayName();
+        String symbol = meta.symbol() == null ? "" : meta.symbol();
+        if (name.isBlank()) return symbol;
+        if (name.equals(symbol)) return symbol;
+        return name + " (" + symbol + ")";
+    }
+
+    private static String quoteUrl(String symbol) {
+        if (symbol == null || symbol.isBlank()) return null;
+        return "https://finance.yahoo.com/quote/"
+                + java.net.URLEncoder.encode(symbol, java.nio.charset.StandardCharsets.UTF_8)
+                .replace("+", "%20");
+    }
+
+    private static String buildDescription(ChartMeta meta, Double price, Double change, Double changePct) {
+        String currency = meta.currency() == null ? "" : meta.currency();
+        StringBuilder sb = new StringBuilder();
+
+        // Headline: arrow + price + change.
+        sb.append(arrowFor(change)).append(" ").append("**");
+        sb.append(formatPrice(price));
+        if (!currency.isBlank()) sb.append(" ").append(currency);
+        sb.append("**");
+        if (change != null && changePct != null) {
+            sb.append("  ").append(formatChange(change, changePct));
+        }
+        sb.append('\n');
+
+        if (meta.regularMarketDayLow() != null || meta.regularMarketDayHigh() != null) {
+            sb.append("Day: ")
+                    .append(formatPrice(meta.regularMarketDayLow()))
+                    .append(" – ")
+                    .append(formatPrice(meta.regularMarketDayHigh()))
+                    .append('\n');
+        }
+        if (meta.fiftyTwoWeekLow() != null || meta.fiftyTwoWeekHigh() != null) {
+            sb.append("52-week: ")
+                    .append(formatPrice(meta.fiftyTwoWeekLow()))
+                    .append(" – ")
+                    .append(formatPrice(meta.fiftyTwoWeekHigh()))
+                    .append('\n');
+        }
+        if (meta.regularMarketVolume() != null && meta.regularMarketVolume() > 0) {
+            sb.append("Volume: ")
+                    .append(VOLUME_FORMAT.format(meta.regularMarketVolume()));
+        }
+        return sb.toString().stripTrailing();
+    }
+
+    private static String footerFor(ChartMeta meta) {
+        StringBuilder f = new StringBuilder();
+        if (meta.fullExchangeName() != null && !meta.fullExchangeName().isBlank()) {
+            f.append(meta.fullExchangeName());
+        }
+        if (meta.currency() != null && !meta.currency().isBlank()) {
+            if (f.length() > 0) f.append(" · ");
+            f.append(meta.currency());
+        }
+        if (f.length() > 0) f.append(" · ");
+        f.append("via Yahoo Finance · prices may be delayed");
+        return f.toString();
+    }
+
+    static Color colorFor(Double change) {
+        if (change == null) return FLAT_COLOR;
+        if (change > 0)     return UP_COLOR;
+        if (change < 0)     return DOWN_COLOR;
+        return FLAT_COLOR;
+    }
+
+    static String arrowFor(Double change) {
+        if (change == null) return "▬";
+        if (change > 0)     return "▲";
+        if (change < 0)     return "▼";
+        return "▬";
+    }
+
+    /** "$293.32" / "—" for missing. */
+    static String formatPrice(Double v) {
+        if (v == null) return "—";
+        // Two decimals for prices; use `f` formatting (no thousands separator on prices —
+        // matches how most financial UIs render).
+        return String.format(Locale.US, "%.2f", v);
+    }
+
+    /** "+$5.89 (+2.05%)" / "−$5.89 (−2.05%)" / "±0.00 (0.00%)". */
+    static String formatChange(double change, double pct) {
+        char sign = change > 0 ? '+' : (change < 0 ? '−' : '±');
+        // For negative numbers, drop the built-in "-" sign and replace with the
+        // typographic minus we picked above.
+        return sign + String.format(Locale.US, "%.2f (%+.2f%%)", Math.abs(change), pct);
+    }
+}

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/stock/StockHandler.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/stock/StockHandler.java
@@ -1,0 +1,67 @@
+package ca.ryanmorrison.chatterbox.features.stock;
+
+import ca.ryanmorrison.chatterbox.features.stock.dto.ChartMeta;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Handles {@code /stock symbol:<text> [private:<bool>]}.
+ *
+ * <p>Defers the reply (network call), fetches the chart meta via
+ * {@link StockClient}, and renders an embed via {@link StockEmbedBuilder}.
+ * Failures map to ephemeral text replies via
+ * {@link StockClient.StockException}; raw exceptions are never surfaced.
+ */
+final class StockHandler extends ListenerAdapter {
+
+    private static final Logger log = LoggerFactory.getLogger(StockHandler.class);
+
+    private final StockClient client;
+
+    StockHandler(StockClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
+        if (!StockModule.COMMAND.equals(event.getName())) return;
+
+        String symbol = stringOption(event, StockModule.OPT_SYMBOL);
+        if (symbol == null || symbol.isBlank()) {
+            event.reply("Tell me a stock symbol.").setEphemeral(true).queue();
+            return;
+        }
+        boolean ephemeral = booleanOption(event, StockModule.OPT_PRIVATE);
+
+        event.deferReply(ephemeral).queue();
+
+        ChartMeta meta;
+        try {
+            meta = client.fetch(symbol);
+        } catch (StockClient.StockException e) {
+            event.getHook().sendMessage(e.getMessage()).queue();
+            return;
+        } catch (RuntimeException e) {
+            log.warn("Unexpected error fetching stock for {}", symbol, e);
+            event.getHook().sendMessage("Something went wrong fetching that quote.").queue();
+            return;
+        }
+
+        MessageEmbed embed = StockEmbedBuilder.build(meta);
+        event.getHook().sendMessageEmbeds(embed).queue();
+    }
+
+    private static String stringOption(SlashCommandInteractionEvent event, String name) {
+        OptionMapping opt = event.getOption(name);
+        return opt == null ? null : opt.getAsString();
+    }
+
+    private static boolean booleanOption(SlashCommandInteractionEvent event, String name) {
+        OptionMapping opt = event.getOption(name);
+        return opt != null && opt.getAsBoolean();
+    }
+}

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/stock/StockModule.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/stock/StockModule.java
@@ -1,0 +1,49 @@
+package ca.ryanmorrison.chatterbox.features.stock;
+
+import ca.ryanmorrison.chatterbox.module.InitContext;
+import ca.ryanmorrison.chatterbox.module.Module;
+import net.dv8tion.jda.api.hooks.EventListener;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.Commands;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
+
+import java.util.List;
+
+/**
+ * {@code /stock symbol:<text> [private:<bool>]} — current quote for a
+ * NYSE / NASDAQ / TSX symbol via Yahoo Finance's
+ * {@code v8/finance/chart} endpoint (no API key).
+ *
+ * <p>Symbol convention follows Yahoo: NYSE/NASDAQ tickers as-is
+ * ({@code AAPL}, {@code KO}), TSX with {@code .TO} suffix
+ * ({@code SHOP.TO}, {@code RY.TO}). Bad symbols return a clear "couldn't
+ * find" with a format hint. See {@link StockClient} for caveats around
+ * the unofficial endpoint and the typical 15-minute delay on free quotes.
+ */
+public final class StockModule implements Module {
+
+    static final String COMMAND     = "stock";
+    static final String OPT_SYMBOL  = "symbol";
+    static final String OPT_PRIVATE = "private";
+
+    @Override public String name() { return "stock"; }
+
+    @Override
+    public List<SlashCommandData> slashCommands(InitContext ctx) {
+        OptionData symbol = new OptionData(OptionType.STRING, OPT_SYMBOL,
+                "Ticker — e.g. AAPL (NASDAQ), KO (NYSE), SHOP.TO (TSX).",
+                true, false);
+        OptionData priv = new OptionData(OptionType.BOOLEAN, OPT_PRIVATE,
+                "Show the result only to you instead of the channel.",
+                false, false);
+        return List.of(Commands.slash(COMMAND,
+                        "Look up a stock quote (NYSE / NASDAQ / TSX) via Yahoo Finance.")
+                .addOptions(symbol, priv));
+    }
+
+    @Override
+    public List<EventListener> listeners(InitContext ctx) {
+        return List.of(new StockHandler(new StockClient()));
+    }
+}

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/stock/dto/ChartError.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/stock/dto/ChartError.java
@@ -1,0 +1,16 @@
+package ca.ryanmorrison.chatterbox.features.stock.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Error envelope Yahoo returns alongside HTTP 4xx/5xx, e.g.
+ * {@code {"code": "Not Found", "description": "No data found, symbol may be delisted"}}.
+ * Surfaced for typo-correction messages so the user sees Yahoo's actual
+ * complaint rather than just "HTTP 404".
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ChartError(
+        @JsonProperty("code") String code,
+        @JsonProperty("description") String description) {
+}

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/stock/dto/ChartMeta.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/stock/dto/ChartMeta.java
@@ -1,0 +1,38 @@
+package ca.ryanmorrison.chatterbox.features.stock.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * The {@code chart.result[0].meta} block from Yahoo's
+ * {@code v8/finance/chart/{symbol}} response — everything the embed
+ * needs is here, nothing nested.
+ *
+ * <p>Field names mirror Yahoo's camelCase JSON keys verbatim. Numeric
+ * fields are boxed so missing values come through as {@code null}
+ * rather than {@code 0.0}, which would otherwise look like real data.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ChartMeta(
+        @JsonProperty("symbol") String symbol,
+        @JsonProperty("longName") String longName,
+        @JsonProperty("shortName") String shortName,
+        @JsonProperty("currency") String currency,
+        @JsonProperty("exchangeName") String exchangeName,
+        @JsonProperty("fullExchangeName") String fullExchangeName,
+        @JsonProperty("regularMarketPrice") Double regularMarketPrice,
+        @JsonProperty("chartPreviousClose") Double chartPreviousClose,
+        @JsonProperty("regularMarketDayHigh") Double regularMarketDayHigh,
+        @JsonProperty("regularMarketDayLow") Double regularMarketDayLow,
+        @JsonProperty("fiftyTwoWeekHigh") Double fiftyTwoWeekHigh,
+        @JsonProperty("fiftyTwoWeekLow") Double fiftyTwoWeekLow,
+        @JsonProperty("regularMarketVolume") Long regularMarketVolume,
+        @JsonProperty("regularMarketTime") Long regularMarketTime) {
+
+    /** Best-effort display name: longName → shortName → symbol. */
+    public String displayName() {
+        if (longName != null && !longName.isBlank()) return longName;
+        if (shortName != null && !shortName.isBlank()) return shortName;
+        return symbol == null ? "" : symbol;
+    }
+}

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/stock/dto/ChartResponse.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/stock/dto/ChartResponse.java
@@ -1,0 +1,33 @@
+package ca.ryanmorrison.chatterbox.features.stock.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Top-level shape: {@code {"chart": {"result": [...], "error": {...}}}}.
+ * On a happy lookup, {@code result} has one entry and {@code error} is null;
+ * on 4xx/5xx, {@code result} is null and {@code error} carries the reason.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ChartResponse(@JsonProperty("chart") Chart chart) {
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Chart(
+            @JsonProperty("result") List<ChartResult> result,
+            @JsonProperty("error") ChartError error) {}
+
+    public Optional<ChartMeta> meta() {
+        if (chart == null || chart.result() == null || chart.result().isEmpty()) {
+            return Optional.empty();
+        }
+        ChartResult first = chart.result().get(0);
+        return Optional.ofNullable(first == null ? null : first.meta());
+    }
+
+    public Optional<ChartError> error() {
+        return Optional.ofNullable(chart == null ? null : chart.error());
+    }
+}

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/stock/dto/ChartResult.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/stock/dto/ChartResult.java
@@ -1,0 +1,8 @@
+package ca.ryanmorrison.chatterbox.features.stock.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ChartResult(@JsonProperty("meta") ChartMeta meta) {
+}

--- a/src/main/resources/META-INF/services/ca.ryanmorrison.chatterbox.module.Module
+++ b/src/main/resources/META-INF/services/ca.ryanmorrison.chatterbox.module.Module
@@ -15,3 +15,4 @@ ca.ryanmorrison.chatterbox.features.when.WhenModule
 ca.ryanmorrison.chatterbox.features.timezone.TimezoneModule
 ca.ryanmorrison.chatterbox.features.weather.WeatherModule
 ca.ryanmorrison.chatterbox.features.wiki.WikiModule
+ca.ryanmorrison.chatterbox.features.stock.StockModule

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/stock/StockClientTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/stock/StockClientTest.java
@@ -1,0 +1,214 @@
+package ca.ryanmorrison.chatterbox.features.stock;
+
+import ca.ryanmorrison.chatterbox.features.stock.dto.ChartMeta;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StockClientTest {
+
+    private HttpServer server;
+    private StockClient client;
+    private String baseUrl;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.start();
+        baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
+        HttpClient http = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(2)).build();
+        client = new StockClient(http, baseUrl);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) server.stop(0);
+    }
+
+    private void serve(String path, int status, String body) {
+        server.createContext(path, ex -> {
+            byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+            ex.getResponseHeaders().add("Content-Type", "application/json");
+            ex.sendResponseHeaders(status, bytes.length);
+            try (var os = ex.getResponseBody()) { os.write(bytes); }
+        });
+    }
+
+    /** Captured-shape NASDAQ response (AAPL). */
+    private static final String AAPL_OK = """
+            {"chart":{"result":[{"meta":{
+              "currency":"USD","symbol":"AAPL",
+              "exchangeName":"NMS","fullExchangeName":"NasdaqGS",
+              "regularMarketTime":1778270402,
+              "regularMarketPrice":293.32,
+              "fiftyTwoWeekHigh":294.76,"fiftyTwoWeekLow":193.46,
+              "regularMarketDayHigh":294.76,"regularMarketDayLow":290.0,
+              "regularMarketVolume":45708423,
+              "longName":"Apple Inc.","shortName":"Apple Inc.",
+              "chartPreviousClose":287.423
+            }}],"error":null}}
+            """;
+
+    /** Captured-shape TSX response (SHOP.TO). */
+    private static final String SHOP_TO_OK = """
+            {"chart":{"result":[{"meta":{
+              "currency":"CAD","symbol":"SHOP.TO",
+              "exchangeName":"TOR","fullExchangeName":"Toronto",
+              "regularMarketTime":1778270402,
+              "regularMarketPrice":150.68,
+              "chartPreviousClose":152.57,
+              "longName":"Shopify Inc."
+            }}],"error":null}}
+            """;
+
+    private static final String NOT_FOUND = """
+            {"chart":{"result":null,"error":{
+              "code":"Not Found",
+              "description":"No data found, symbol may be delisted"
+            }}}
+            """;
+
+    // ---- happy paths ----
+
+    @Test
+    void parsesNasdaqResponse() throws Exception {
+        serve("/v8/finance/chart/AAPL", 200, AAPL_OK);
+        ChartMeta meta = client.fetch("AAPL");
+        assertEquals("AAPL", meta.symbol());
+        assertEquals("Apple Inc.", meta.longName());
+        assertEquals("USD", meta.currency());
+        assertEquals("NasdaqGS", meta.fullExchangeName());
+        assertEquals(293.32, meta.regularMarketPrice(), 0.0001);
+        assertEquals(287.423, meta.chartPreviousClose(), 0.0001);
+        assertEquals(45_708_423L, meta.regularMarketVolume());
+    }
+
+    @Test
+    void parsesTsxResponse() throws Exception {
+        serve("/v8/finance/chart/SHOP.TO", 200, SHOP_TO_OK);
+        ChartMeta meta = client.fetch("SHOP.TO");
+        assertEquals("SHOP.TO", meta.symbol());
+        assertEquals("CAD", meta.currency());
+        assertEquals("Toronto", meta.fullExchangeName());
+        assertEquals(150.68, meta.regularMarketPrice(), 0.0001);
+    }
+
+    @Test
+    void displayNameFallsBackThroughLongShortAndSymbol() {
+        // longName present
+        ChartMeta a = new ChartMeta("AAPL", "Apple Inc.", "Apple", "USD", "NMS", "NasdaqGS",
+                1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1L, 1L);
+        assertEquals("Apple Inc.", a.displayName());
+        // long blank, short present
+        ChartMeta b = new ChartMeta("AAPL", "", "Apple", "USD", "NMS", "NasdaqGS",
+                1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1L, 1L);
+        assertEquals("Apple", b.displayName());
+        // both blank — symbol
+        ChartMeta c = new ChartMeta("AAPL", null, null, "USD", "NMS", "NasdaqGS",
+                1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1L, 1L);
+        assertEquals("AAPL", c.displayName());
+    }
+
+    // ---- failure paths ----
+
+    @Test
+    void notFoundSurfacedWithDelistedHintWhenYahooSaysSo() {
+        serve("/v8/finance/chart/ZZZ", 404, NOT_FOUND);
+        var ex = assertThrows(StockClient.StockException.class, () -> client.fetch("ZZZ"));
+        assertTrue(ex.getMessage().toLowerCase().contains("delisted"),
+                () -> "expected delisted hint, got: " + ex.getMessage());
+    }
+
+    @Test
+    void notFoundFallsBackToFormatHintWhenBodyShapeChanged() {
+        // 404 with no parseable error block — we still produce a typo prompt
+        // rather than a noisy "HTTP 404".
+        serve("/v8/finance/chart/ZZZ", 404, "<!doctype html>not json");
+        var ex = assertThrows(StockClient.StockException.class, () -> client.fetch("ZZZ"));
+        assertTrue(ex.getMessage().toLowerCase().contains("couldn't find"), () -> ex.getMessage());
+        assertTrue(ex.getMessage().contains("AAPL"),
+                () -> "expected format hint with examples, got: " + ex.getMessage());
+    }
+
+    @Test
+    void notFoundShapeIn200StillTreatedAsNotFound() {
+        // Yahoo occasionally returns 200 with a populated error block.
+        serve("/v8/finance/chart/ZZZ", 200, NOT_FOUND);
+        var ex = assertThrows(StockClient.StockException.class, () -> client.fetch("ZZZ"));
+        assertTrue(ex.getMessage().toLowerCase().contains("delisted"),
+                () -> ex.getMessage());
+    }
+
+    @Test
+    void rateLimitSurfacesFriendlyMessage() {
+        serve("/v8/finance/chart/AAPL", 429, "");
+        var ex = assertThrows(StockClient.StockException.class, () -> client.fetch("AAPL"));
+        assertTrue(ex.getMessage().toLowerCase().contains("rate"), () -> ex.getMessage());
+    }
+
+    @Test
+    void otherServerErrorBubblesGenericHttpStatus() {
+        serve("/v8/finance/chart/AAPL", 503, "service unavailable");
+        var ex = assertThrows(StockClient.StockException.class, () -> client.fetch("AAPL"));
+        assertTrue(ex.getMessage().contains("503"), () -> ex.getMessage());
+    }
+
+    @Test
+    void unparseableBodySurfacedAsUnexpected() {
+        serve("/v8/finance/chart/AAPL", 200, "{not json");
+        var ex = assertThrows(StockClient.StockException.class, () -> client.fetch("AAPL"));
+        assertTrue(ex.getMessage().toLowerCase().contains("unexpected"), () -> ex.getMessage());
+    }
+
+    @Test
+    void blankSymbolRejectedClientSide() {
+        assertThrows(StockClient.StockException.class, () -> client.fetch(""));
+        assertThrows(StockClient.StockException.class, () -> client.fetch("   "));
+        assertThrows(StockClient.StockException.class, () -> client.fetch(null));
+    }
+
+    // ---- request shape ----
+
+    @Test
+    void browserUserAgentSentSinceYahooBlocksBotShapedUAs() throws Exception {
+        AtomicReference<String> ua = new AtomicReference<>();
+        server.createContext("/v8/finance/chart/AAPL", ex -> {
+            ua.set(ex.getRequestHeaders().getFirst("User-Agent"));
+            byte[] bytes = AAPL_OK.getBytes(StandardCharsets.UTF_8);
+            ex.getResponseHeaders().add("Content-Type", "application/json");
+            ex.sendResponseHeaders(200, bytes.length);
+            try (var os = ex.getResponseBody()) { os.write(bytes); }
+        });
+        client.fetch("AAPL");
+        assertNotNull(ua.get());
+        assertTrue(ua.get().toLowerCase().contains("mozilla") || ua.get().toLowerCase().contains("chrome"),
+                () -> "expected browser-shaped UA, got: " + ua.get());
+    }
+
+    @Test
+    void intervalAndRangeQueryParamsAreSet() throws Exception {
+        AtomicReference<String> rawQuery = new AtomicReference<>();
+        server.createContext("/v8/finance/chart/AAPL", ex -> {
+            rawQuery.set(ex.getRequestURI().getRawQuery());
+            byte[] bytes = AAPL_OK.getBytes(StandardCharsets.UTF_8);
+            ex.getResponseHeaders().add("Content-Type", "application/json");
+            ex.sendResponseHeaders(200, bytes.length);
+            try (var os = ex.getResponseBody()) { os.write(bytes); }
+        });
+        client.fetch("AAPL");
+        assertEquals("interval=1d&range=1d", rawQuery.get());
+    }
+}

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/stock/StockEmbedBuilderTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/stock/StockEmbedBuilderTest.java
@@ -1,0 +1,178 @@
+package ca.ryanmorrison.chatterbox.features.stock;
+
+import ca.ryanmorrison.chatterbox.features.stock.dto.ChartMeta;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StockEmbedBuilderTest {
+
+    private static ChartMeta meta(double price, double prev) {
+        return new ChartMeta(
+                "AAPL", "Apple Inc.", "Apple", "USD", "NMS", "NasdaqGS",
+                price, prev,
+                price + 1.5, price - 1.5,         // day high/low
+                price + 50.0, price - 100.0,      // 52-week
+                45_708_423L,
+                1778270402L);
+    }
+
+    // ---- title / link ----
+
+    @Test
+    void titleIncludesNameAndSymbolAndIsHyperlinked() {
+        MessageEmbed embed = StockEmbedBuilder.build(meta(293.32, 287.423));
+        assertEquals("Apple Inc. (AAPL)", embed.getTitle());
+        assertEquals("https://finance.yahoo.com/quote/AAPL", embed.getUrl());
+    }
+
+    @Test
+    void titleIsJustSymbolWhenNameMissing() {
+        ChartMeta m = new ChartMeta("AAPL", null, null, "USD", "NMS", "NasdaqGS",
+                100.0, 99.0, 101.0, 99.0, 200.0, 50.0, 1L, 1L);
+        MessageEmbed embed = StockEmbedBuilder.build(m);
+        assertEquals("AAPL", embed.getTitle());
+    }
+
+    @Test
+    void tsxSymbolIsUrlEncodedInQuoteLink() {
+        ChartMeta m = new ChartMeta("SHOP.TO", "Shopify Inc.", "Shopify", "CAD",
+                "TOR", "Toronto",
+                150.68, 152.57, 152.0, 149.0, 200.0, 100.0, 1_000_000L, 1L);
+        MessageEmbed embed = StockEmbedBuilder.build(m);
+        // The dot is fine in URLs; we just confirm the link points at the right page.
+        assertEquals("https://finance.yahoo.com/quote/SHOP.TO", embed.getUrl());
+    }
+
+    // ---- color ----
+
+    @Test
+    void greenWhenUp() {
+        MessageEmbed embed = StockEmbedBuilder.build(meta(101.0, 100.0));
+        assertEquals(StockEmbedBuilder.UP_COLOR.getRGB(), embed.getColorRaw());
+    }
+
+    @Test
+    void redWhenDown() {
+        MessageEmbed embed = StockEmbedBuilder.build(meta(99.0, 100.0));
+        assertEquals(StockEmbedBuilder.DOWN_COLOR.getRGB(), embed.getColorRaw());
+    }
+
+    @Test
+    void greyWhenFlat() {
+        MessageEmbed embed = StockEmbedBuilder.build(meta(100.0, 100.0));
+        assertEquals(StockEmbedBuilder.FLAT_COLOR.getRGB(), embed.getColorRaw());
+    }
+
+    @Test
+    void greyWhenChangeUncomputable() {
+        // Missing previous close → can't compute change. Don't pretend.
+        ChartMeta m = new ChartMeta("AAPL", "Apple", null, "USD", "NMS", "NasdaqGS",
+                100.0, null, 101.0, 99.0, 200.0, 50.0, 1L, 1L);
+        MessageEmbed embed = StockEmbedBuilder.build(m);
+        assertEquals(StockEmbedBuilder.FLAT_COLOR.getRGB(), embed.getColorRaw());
+    }
+
+    // ---- description content ----
+
+    @Test
+    void descriptionContainsPriceCurrencyAndChange() {
+        MessageEmbed embed = StockEmbedBuilder.build(meta(293.32, 287.423));
+        String d = embed.getDescription();
+        assertNotNull(d);
+        assertTrue(d.contains("293.32"), d);
+        assertTrue(d.contains("USD"), d);
+        // Up-arrow + signed change + percent (formatChange uses "+" for positives).
+        assertTrue(d.contains("▲"), d);
+        assertTrue(d.contains("+5.90"), () -> "expected +5.90, got: " + d);
+        assertTrue(d.contains("+2.05%"), () -> "expected +2.05%, got: " + d);
+    }
+
+    @Test
+    void downArrowAndTypographicMinusForNegative() {
+        MessageEmbed embed = StockEmbedBuilder.build(meta(95.0, 100.0));
+        String d = embed.getDescription();
+        assertTrue(d.contains("▼"), d);
+        // Typographic minus on the absolute change, regular "-" on the percent.
+        assertTrue(d.contains("−5.00"), () -> d);
+        assertTrue(d.contains("-5.00%"), () -> d);
+    }
+
+    @Test
+    void volumeFormattedWithThousandsSeparators() {
+        MessageEmbed embed = StockEmbedBuilder.build(meta(293.32, 287.423));
+        assertTrue(embed.getDescription().contains("Volume: 45,708,423"),
+                embed.getDescription());
+    }
+
+    @Test
+    void dayAnd52WeekRangesPresent() {
+        MessageEmbed embed = StockEmbedBuilder.build(meta(293.32, 287.423));
+        String d = embed.getDescription();
+        assertTrue(d.contains("Day:"),  d);
+        assertTrue(d.contains("52-week:"), d);
+    }
+
+    @Test
+    void missingFieldsRenderEmDashRatherThanZero() {
+        ChartMeta m = new ChartMeta("AAPL", "Apple", null, "USD", "NMS", "NasdaqGS",
+                100.0, 99.0,
+                null, null,           // day range missing
+                null, null,           // 52-week missing
+                null, 1L);
+        MessageEmbed embed = StockEmbedBuilder.build(m);
+        String d = embed.getDescription();
+        assertFalse(d.contains("Day:"), () -> "no day range when both null: " + d);
+        assertFalse(d.contains("52-week:"), () -> d);
+        assertFalse(d.contains("Volume:"), () -> d);
+    }
+
+    // ---- footer ----
+
+    @Test
+    void footerNamesExchangeCurrencyAndDelay() {
+        MessageEmbed embed = StockEmbedBuilder.build(meta(293.32, 287.423));
+        String f = embed.getFooter().getText();
+        assertTrue(f.contains("NasdaqGS"), f);
+        assertTrue(f.contains("USD"), f);
+        assertTrue(f.toLowerCase().contains("yahoo"), f);
+        assertTrue(f.toLowerCase().contains("delayed"), f);
+    }
+
+    // ---- formatting helpers ----
+
+    @Test
+    void formatChangeUsesPlusForPositives() {
+        // Direct exposure of the helper for non-pricing-edge sanity.
+        assertEquals("+5.00 (+2.50%)", StockEmbedBuilder.formatChange(5.0, 2.5));
+    }
+
+    @Test
+    void formatChangeUsesTypographicMinusForNegatives() {
+        // The percent uses the regular - because String.format's %+ inserts ASCII;
+        // we leave that consistent across the change and the percent's own sign.
+        assertEquals("−5.00 (-2.50%)", StockEmbedBuilder.formatChange(-5.0, -2.5));
+    }
+
+    @Test
+    void formatChangeUsesPlusMinusForExactlyZero() {
+        assertEquals("±0.00 (+0.00%)", StockEmbedBuilder.formatChange(0.0, 0.0));
+    }
+
+    @Test
+    void arrowPicker() {
+        assertEquals("▲", StockEmbedBuilder.arrowFor(1.0));
+        assertEquals("▼", StockEmbedBuilder.arrowFor(-1.0));
+        assertEquals("▬", StockEmbedBuilder.arrowFor(0.0));
+        assertEquals("▬", StockEmbedBuilder.arrowFor(null));
+    }
+
+    @Test
+    void formatPriceHandlesNull() {
+        assertEquals("—", StockEmbedBuilder.formatPrice(null));
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new `/stock` slash command that fetches and displays current stock quotes for NYSE, NASDAQ, and TSX-listed securities using Yahoo Finance's undocumented `v8/finance/chart` endpoint.

## Changes

- **StockModule**: New module registering the `/stock symbol:<text> [private:<bool>]` command with options for ticker symbol and optional ephemeral reply.

- **StockClient**: HTTP client for Yahoo Finance's chart endpoint with:
  - 10-second timeout and 1 MB response cap (consistent with existing clients)
  - Browser User-Agent spoofing to bypass Yahoo's bot-blocking WAF
  - Structured error handling mapping HTTP status codes and JSON error blocks to user-friendly messages
  - Support for NYSE/NASDAQ bare tickers and TSX `.TO` suffix format
  - Validation and URL encoding of symbols

- **StockHandler**: Event listener that defers replies, fetches quotes via StockClient, and renders embeds via StockEmbedBuilder. Failures surface as ephemeral text replies.

- **StockEmbedBuilder**: Renders ChartMeta as a Discord embed with:
  - Title: company name + ticker, hyperlinked to Yahoo Finance quote page
  - Description: current price + change (absolute and %, with ▲/▼/▬ arrows), day/52-week ranges, volume with thousands separators
  - Color: green (up), red (down), grey (flat)
  - Footer: exchange, currency, freshness timestamp, and "may be delayed" note

- **DTO classes** (ChartMeta, ChartResponse, ChartResult, ChartError): Jackson-annotated records mapping Yahoo's JSON response structure.

- **Tests**: Comprehensive test suites for StockClient (happy paths, error handling, request shape validation) and StockEmbedBuilder (formatting, color logic, null handling).

- **Documentation**: README updated with symbol format table, output description, failure modes, and caveats (unofficial endpoint, 15-minute delay, WAF workaround).

## Notable Implementation Details

- Numeric fields in ChartMeta are boxed (Double/Long) so missing values come through as null rather than 0, preventing false data.
- Error messages preserve Yahoo's structured "may be delisted" hint when available, falling back to a format hint with examples for unparseable responses.
- Typographic minus (−) used for negative changes in descriptions; regular minus (-) in percent to match String.format's %+ behavior.
- No SSRF surface: hostname is hard-coded to `query1.finance.yahoo.com`.

https://claude.ai/code/session_01Sx89PCe12XmPkoe5HiaQsV