### PR TITLE
Add click analytics to URL shortener

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,15 @@ it — useful for vetting a suspicious link before clicking. Replies
 ephemerally by default; pass `share:true` to post the result to the channel
 instead (e.g. so a moderator can warn others publicly).
 
+#### `/shorten stats target:<URL or token>`
+
+Available to everyone. Replies ephemerally with click stats for a short
+URL: total click count, last-click timestamp (rendered as a Discord
+relative timestamp), creator, creation time, and — if the row was
+soft-deleted — the deleter and deletion time. Stats remain queryable for
+soft-deleted entries so admins can see what was popular before takedown.
+Accepts either the bare 6-character token or the full short URL.
+
 #### `GET /{token}`
 
 Public endpoint exposed via Javalin. Outcomes:
@@ -387,8 +396,12 @@ Public endpoint exposed via Javalin. Outcomes:
 - **Live token** — `301 Moved Permanently` with the original URL in the
   `Location` header plus a tiny HTML body carrying an anchor (matches
   bit.ly's shape so Discord's preview crawler unfurls it correctly).
+  Each successful redirect atomically increments the row's `click_count`
+  and refreshes `last_clicked_at`. Counter bumps are best-effort: if the
+  database is briefly unavailable the redirect still completes.
 - **Soft-deleted token** — `410 Gone`. Tokens are never reissued, so this
   is a permanent state; 410 communicates that more accurately than 404.
+  410s do not increment the counter.
 - **Unknown token** — `404 Not Found`.
 
 Token lookups are case-insensitive.

--- a/src/generated/jooq/ca/ryanmorrison/chatterbox/db/generated/tables/ShortenedUrls.java
+++ b/src/generated/jooq/ca/ryanmorrison/chatterbox/db/generated/tables/ShortenedUrls.java
@@ -90,6 +90,16 @@ public class ShortenedUrls extends TableImpl<ShortenedUrlsRecord> {
      */
     public final TableField<ShortenedUrlsRecord, Long> DELETED_BY = createField(DSL.name("deleted_by"), SQLDataType.BIGINT, this, "");
 
+    /**
+     * The column <code>public.shortened_urls.click_count</code>.
+     */
+    public final TableField<ShortenedUrlsRecord, Long> CLICK_COUNT = createField(DSL.name("click_count"), SQLDataType.BIGINT.nullable(false).defaultValue(DSL.field(DSL.raw("0"), SQLDataType.BIGINT)), this, "");
+
+    /**
+     * The column <code>public.shortened_urls.last_clicked_at</code>.
+     */
+    public final TableField<ShortenedUrlsRecord, OffsetDateTime> LAST_CLICKED_AT = createField(DSL.name("last_clicked_at"), SQLDataType.TIMESTAMPWITHTIMEZONE(6), this, "");
+
     private ShortenedUrls(Name alias, Table<ShortenedUrlsRecord> aliased) {
         this(alias, aliased, (Field<?>[]) null, null);
     }

--- a/src/generated/jooq/ca/ryanmorrison/chatterbox/db/generated/tables/records/ShortenedUrlsRecord.java
+++ b/src/generated/jooq/ca/ryanmorrison/chatterbox/db/generated/tables/records/ShortenedUrlsRecord.java
@@ -118,6 +118,34 @@ public class ShortenedUrlsRecord extends UpdatableRecordImpl<ShortenedUrlsRecord
         return (Long) get(6);
     }
 
+    /**
+     * Setter for <code>public.shortened_urls.click_count</code>.
+     */
+    public void setClickCount(Long value) {
+        set(7, value);
+    }
+
+    /**
+     * Getter for <code>public.shortened_urls.click_count</code>.
+     */
+    public Long getClickCount() {
+        return (Long) get(7);
+    }
+
+    /**
+     * Setter for <code>public.shortened_urls.last_clicked_at</code>.
+     */
+    public void setLastClickedAt(OffsetDateTime value) {
+        set(8, value);
+    }
+
+    /**
+     * Getter for <code>public.shortened_urls.last_clicked_at</code>.
+     */
+    public OffsetDateTime getLastClickedAt() {
+        return (OffsetDateTime) get(8);
+    }
+
     // -------------------------------------------------------------------------
     // Primary key information
     // -------------------------------------------------------------------------
@@ -141,7 +169,7 @@ public class ShortenedUrlsRecord extends UpdatableRecordImpl<ShortenedUrlsRecord
     /**
      * Create a detached, initialised ShortenedUrlsRecord
      */
-    public ShortenedUrlsRecord(Long id, String token, String url, Long createdBy, OffsetDateTime createdAt, OffsetDateTime deletedAt, Long deletedBy) {
+    public ShortenedUrlsRecord(Long id, String token, String url, Long createdBy, OffsetDateTime createdAt, OffsetDateTime deletedAt, Long deletedBy, Long clickCount, OffsetDateTime lastClickedAt) {
         super(ShortenedUrls.SHORTENED_URLS);
 
         setId(id);
@@ -151,6 +179,8 @@ public class ShortenedUrlsRecord extends UpdatableRecordImpl<ShortenedUrlsRecord
         setCreatedAt(createdAt);
         setDeletedAt(deletedAt);
         setDeletedBy(deletedBy);
+        setClickCount(clickCount);
+        setLastClickedAt(lastClickedAt);
         resetTouchedOnNotNull();
     }
 }

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/shortener/ShortenedUrl.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/shortener/ShortenedUrl.java
@@ -10,7 +10,9 @@ record ShortenedUrl(
         long createdBy,
         OffsetDateTime createdAt,
         Optional<OffsetDateTime> deletedAt,
-        Optional<Long> deletedBy) {
+        Optional<Long> deletedBy,
+        long clickCount,
+        Optional<OffsetDateTime> lastClickedAt) {
 
     boolean isDeleted() {
         return deletedAt.isPresent();

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/shortener/ShortenerHandler.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/shortener/ShortenerHandler.java
@@ -42,6 +42,7 @@ final class ShortenerHandler extends ListenerAdapter {
     static final String SUB_CREATE = "create";
     static final String SUB_DELETE = "delete";
     static final String SUB_PEEK = "peek";
+    static final String SUB_STATS = "stats";
     static final String OPTION_URL = "url";
     static final String OPTION_TARGET = "target";
     static final String OPTION_SHARE = "share";
@@ -79,6 +80,7 @@ final class ShortenerHandler extends ListenerAdapter {
             case SUB_CREATE -> handleCreate(event);
             case SUB_DELETE -> handleDelete(event);
             case SUB_PEEK   -> handlePeek(event);
+            case SUB_STATS  -> handleStats(event);
             default -> { /* unknown subcommand — silently ignore */ }
         }
     }
@@ -205,6 +207,36 @@ final class ShortenerHandler extends ListenerAdapter {
         event.editMessage("Cancelled.").setEmbeds().setComponents().queue();
     }
 
+    // -- stats --------------------------------------------------------------
+
+    /**
+     * Read-only view of click analytics for one shortened URL. Anyone can
+     * call it (counts aren't sensitive); replies are ephemeral so a quick
+     * stats check doesn't clutter the channel. Stats are visible for both
+     * live and soft-deleted entries — useful when an admin wants to know
+     * how popular something was before they nuked it.
+     */
+    private void handleStats(SlashCommandInteractionEvent event) {
+        String baseUrl = resolveBaseUrlOrReply(event);
+        if (baseUrl == null) return;
+
+        String target = optionString(event, OPTION_TARGET);
+        Optional<String> token = TargetParser.extractToken(target, baseUrl);
+        if (token.isEmpty()) {
+            event.reply(INVALID_TARGET_MESSAGE).setEphemeral(true).queue();
+            return;
+        }
+
+        // Including-deleted: stats stay queryable post-soft-delete (the
+        // delete confirmation embed already shows that the link is gone).
+        Optional<ShortenedUrl> match = repository.findByTokenIncludingDeleted(token.get());
+        if (match.isEmpty()) {
+            event.reply(NOT_FOUND_MESSAGE).setEphemeral(true).queue();
+            return;
+        }
+        event.replyEmbeds(buildStatsEmbed(match.get(), baseUrl)).setEphemeral(true).queue();
+    }
+
     // -- peek ---------------------------------------------------------------
 
     private void handlePeek(SlashCommandInteractionEvent event) {
@@ -268,5 +300,33 @@ final class ShortenerHandler extends ListenerAdapter {
                 .addField("Created", "<t:" + createdAtSeconds + ":f> (<t:" + createdAtSeconds + ":R>)", true)
                 .setFooter("This cannot be undone. The token will not be reissued.")
                 .build();
+    }
+
+    static net.dv8tion.jda.api.entities.MessageEmbed buildStatsEmbed(ShortenedUrl entry, String baseUrl) {
+        long createdAtSeconds = entry.createdAt().toEpochSecond();
+        EmbedBuilder eb = new EmbedBuilder()
+                .setTitle("Click stats: " + entry.token())
+                .setColor(entry.isDeleted() ? 0x90A4AE : 0x4F8DDC)
+                .addField("Short URL", "`" + buildShortUrl(baseUrl, entry.token()) + "`", false)
+                .addField("Destination", entry.url(), false)
+                .addField("Clicks", String.valueOf(entry.clickCount()), true)
+                .addField("Created",
+                        "<t:" + createdAtSeconds + ":R> by <@" + entry.createdBy() + ">",
+                        true);
+        eb.addField("Last clicked",
+                entry.lastClickedAt()
+                        .map(ts -> "<t:" + ts.toEpochSecond() + ":R>")
+                        .orElse("*Never*"),
+                true);
+        if (entry.isDeleted()) {
+            String deletedLine = entry.deletedAt()
+                    .map(ts -> "<t:" + ts.toEpochSecond() + ":R>")
+                    .orElse("(unknown)");
+            String deleter = entry.deletedBy()
+                    .map(id -> " by <@" + id + ">")
+                    .orElse("");
+            eb.addField("Deleted", deletedLine + deleter, false);
+        }
+        return eb.build();
     }
 }

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/shortener/ShortenerModule.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/shortener/ShortenerModule.java
@@ -107,7 +107,11 @@ public final class ShortenerModule implements Module {
                                 .addOption(OptionType.STRING, ShortenerHandler.OPTION_TARGET,
                                         "Full short URL or 6-character short code.", true)
                                 .addOption(OptionType.BOOLEAN, ShortenerHandler.OPTION_SHARE,
-                                        "Post the result to the channel instead of just to you.", false)));
+                                        "Post the result to the channel instead of just to you.", false),
+                        new SubcommandData(ShortenerHandler.SUB_STATS,
+                                "Show click stats for a short URL.")
+                                .addOption(OptionType.STRING, ShortenerHandler.OPTION_TARGET,
+                                        "Full short URL or 6-character short code.", true)));
     }
 
     @Override

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/shortener/ShortenerRedirectHandler.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/shortener/ShortenerRedirectHandler.java
@@ -3,7 +3,11 @@ package ca.ryanmorrison.chatterbox.features.shortener;
 import io.javalin.http.Context;
 import io.javalin.http.Handler;
 import io.javalin.http.HttpStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.time.Clock;
+import java.time.OffsetDateTime;
 import java.util.Locale;
 import java.util.Optional;
 
@@ -28,10 +32,19 @@ final class ShortenerRedirectHandler implements Handler {
     static final String PATH = "/{token}";
     static final String PATH_PARAM = "token";
 
+    private static final Logger log = LoggerFactory.getLogger(ShortenerRedirectHandler.class);
+
     private final ShortenerRepository repository;
+    private final Clock clock;
 
     ShortenerRedirectHandler(ShortenerRepository repository) {
+        this(repository, Clock.systemUTC());
+    }
+
+    /** Test seam — lets tests pin "now" for deterministic last_clicked_at values. */
+    ShortenerRedirectHandler(ShortenerRepository repository, Clock clock) {
         this.repository = repository;
+        this.clock = clock;
     }
 
     @Override
@@ -48,6 +61,15 @@ final class ShortenerRedirectHandler implements Handler {
             ctx.status(HttpStatus.GONE).result("This short URL has been removed.");
             return;
         }
+        // Best-effort click counter bump. A DB hiccup here must never block
+        // the redirect — analytics accuracy is strictly subordinate to
+        // redirect availability.
+        try {
+            repository.incrementClicks(entry.id(), OffsetDateTime.now(clock));
+        } catch (RuntimeException e) {
+            log.warn("Couldn't bump click counter for token {}: {}", entry.token(), e.toString());
+        }
+
         String url = entry.url();
         ctx.status(HttpStatus.MOVED_PERMANENTLY)
                 .header("Location", url)

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/shortener/ShortenerRepository.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/shortener/ShortenerRepository.java
@@ -94,6 +94,21 @@ final class ShortenerRepository {
                 .execute();
     }
 
+    /**
+     * Atomically bumps {@code click_count} and refreshes {@code last_clicked_at}
+     * for {@code id}. Returns the number of rows updated (0 if the id is gone,
+     * which the caller treats as a silent no-op — analytics never block a
+     * redirect). The increment is a single UPDATE so concurrent clicks
+     * stay correct without explicit locking.
+     */
+    int incrementClicks(long id, OffsetDateTime when) {
+        return dsl.update(SHORTENED_URLS)
+                .set(SHORTENED_URLS.CLICK_COUNT, SHORTENED_URLS.CLICK_COUNT.plus(1L))
+                .set(SHORTENED_URLS.LAST_CLICKED_AT, when)
+                .where(SHORTENED_URLS.ID.eq(id))
+                .execute();
+    }
+
     private static ShortenedUrl toShortenedUrl(Record r) {
         return new ShortenedUrl(
                 r.get(SHORTENED_URLS.ID),
@@ -102,6 +117,8 @@ final class ShortenerRepository {
                 r.get(SHORTENED_URLS.CREATED_BY),
                 r.get(SHORTENED_URLS.CREATED_AT),
                 Optional.ofNullable(r.get(SHORTENED_URLS.DELETED_AT)),
-                Optional.ofNullable(r.get(SHORTENED_URLS.DELETED_BY)));
+                Optional.ofNullable(r.get(SHORTENED_URLS.DELETED_BY)),
+                r.get(SHORTENED_URLS.CLICK_COUNT),
+                Optional.ofNullable(r.get(SHORTENED_URLS.LAST_CLICKED_AT)));
     }
 }

--- a/src/main/resources/db/migration/shortener/postgresql/V20260509200000__shortener_click_stats.sql
+++ b/src/main/resources/db/migration/shortener/postgresql/V20260509200000__shortener_click_stats.sql
@@ -1,0 +1,5 @@
+-- Click analytics: per-token redirect counter and last-click timestamp.
+-- Counter increments atomically on each live-token redirect; soft-deleted
+-- hits return 410 and don't bump the count.
+ALTER TABLE shortened_urls ADD COLUMN click_count     BIGINT NOT NULL DEFAULT 0;
+ALTER TABLE shortened_urls ADD COLUMN last_clicked_at TIMESTAMPTZ;

--- a/src/main/resources/db/migration/shortener/sqlite/V20260509200000__shortener_click_stats.sql
+++ b/src/main/resources/db/migration/shortener/sqlite/V20260509200000__shortener_click_stats.sql
@@ -1,0 +1,5 @@
+-- Click analytics: per-token redirect counter and last-click timestamp.
+-- Counter increments atomically on each live-token redirect; soft-deleted
+-- hits return 410 and don't bump the count.
+ALTER TABLE shortened_urls ADD COLUMN click_count     INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE shortened_urls ADD COLUMN last_clicked_at TEXT;

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/shortener/ShortenerHandlerTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/shortener/ShortenerHandlerTest.java
@@ -1,0 +1,137 @@
+package ca.ryanmorrison.chatterbox.features.shortener;
+
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Coverage for the static {@code buildStatsEmbed} renderer behind
+ * {@code /shorten stats}. The slash-command plumbing itself isn't worth
+ * mocking (matches the pattern in {@link AutoShortenListenerTest}); the
+ * embed builder is the bit with branches.
+ */
+class ShortenerHandlerTest {
+
+    private static final String BASE_URL = "https://s.example";
+    private static final long USER = 4242L;
+    private static final long MOD = 9999L;
+    private static final OffsetDateTime CREATED =
+            OffsetDateTime.of(2026, 5, 1, 12, 0, 0, 0, ZoneOffset.UTC);
+    private static final OffsetDateTime CLICKED =
+            OffsetDateTime.of(2026, 5, 9, 18, 0, 0, 0, ZoneOffset.UTC);
+    private static final OffsetDateTime DELETED =
+            OffsetDateTime.of(2026, 5, 9, 19, 0, 0, 0, ZoneOffset.UTC);
+
+    private static String fieldValue(MessageEmbed embed, String name) {
+        for (MessageEmbed.Field f : embed.getFields()) {
+            if (name.equals(f.getName())) return f.getValue();
+        }
+        throw new AssertionError("Missing field: " + name + " in " + embed.getFields());
+    }
+
+    private static List<String> fieldNames(MessageEmbed embed) {
+        return embed.getFields().stream().map(MessageEmbed.Field::getName).toList();
+    }
+
+    @Test
+    void liveZeroClicksRendersNeverLastClicked() {
+        ShortenedUrl entry = new ShortenedUrl(
+                1L, "abc123", "https://example.com/x",
+                USER, CREATED,
+                Optional.empty(), Optional.empty(),
+                0L, Optional.empty());
+
+        MessageEmbed embed = ShortenerHandler.buildStatsEmbed(entry, BASE_URL);
+
+        assertEquals("Click stats: abc123", embed.getTitle());
+        assertEquals("`https://s.example/abc123`", fieldValue(embed, "Short URL"));
+        assertEquals("https://example.com/x", fieldValue(embed, "Destination"));
+        assertEquals("0", fieldValue(embed, "Clicks"));
+        assertEquals("*Never*", fieldValue(embed, "Last clicked"));
+        assertTrue(fieldValue(embed, "Created").contains("<@" + USER + ">"));
+        assertTrue(fieldValue(embed, "Created").contains("<t:" + CREATED.toEpochSecond() + ":R>"));
+        // Live entries should not surface a Deleted row.
+        assertTrue(fieldNames(embed).stream().noneMatch("Deleted"::equals));
+    }
+
+    @Test
+    void liveWithClicksRendersCountAndTimestamp() {
+        ShortenedUrl entry = new ShortenedUrl(
+                1L, "abc123", "https://example.com/x",
+                USER, CREATED,
+                Optional.empty(), Optional.empty(),
+                42L, Optional.of(CLICKED));
+
+        MessageEmbed embed = ShortenerHandler.buildStatsEmbed(entry, BASE_URL);
+
+        assertEquals("42", fieldValue(embed, "Clicks"));
+        assertEquals("<t:" + CLICKED.toEpochSecond() + ":R>",
+                fieldValue(embed, "Last clicked"));
+    }
+
+    @Test
+    void deletedEntryIncludesDeletionLineAndGreyColor() {
+        ShortenedUrl entry = new ShortenedUrl(
+                1L, "abc123", "https://example.com/x",
+                USER, CREATED,
+                Optional.of(DELETED), Optional.of(MOD),
+                7L, Optional.of(CLICKED));
+
+        MessageEmbed embed = ShortenerHandler.buildStatsEmbed(entry, BASE_URL);
+
+        assertEquals(0x90A4AE, embed.getColorRaw());
+        String deleted = fieldValue(embed, "Deleted");
+        assertTrue(deleted.contains("<t:" + DELETED.toEpochSecond() + ":R>"),
+                "expected delete timestamp, got: " + deleted);
+        assertTrue(deleted.contains("<@" + MOD + ">"),
+                "expected deleter mention, got: " + deleted);
+        // Click count is preserved even after deletion — admins still want the
+        // historical figure.
+        assertEquals("7", fieldValue(embed, "Clicks"));
+    }
+
+    @Test
+    void liveEntryUsesBlueAccentColor() {
+        ShortenedUrl entry = new ShortenedUrl(
+                1L, "abc123", "https://example.com/x",
+                USER, CREATED,
+                Optional.empty(), Optional.empty(),
+                0L, Optional.empty());
+
+        MessageEmbed embed = ShortenerHandler.buildStatsEmbed(entry, BASE_URL);
+        assertEquals(0x4F8DDC, embed.getColorRaw());
+    }
+
+    @Test
+    void baseUrlWithTrailingSlashStillRendersOneSlash() {
+        ShortenedUrl entry = new ShortenedUrl(
+                1L, "abc123", "https://example.com/x",
+                USER, CREATED,
+                Optional.empty(), Optional.empty(),
+                0L, Optional.empty());
+
+        MessageEmbed embed = ShortenerHandler.buildStatsEmbed(entry, "https://s.example/");
+        assertEquals("`https://s.example/abc123`", fieldValue(embed, "Short URL"));
+    }
+
+    @Test
+    void deletedWithoutDeleterStillRenders() {
+        // Defensive: deleted_at present but deleted_by null shouldn't NPE.
+        ShortenedUrl entry = new ShortenedUrl(
+                1L, "abc123", "https://example.com/x",
+                USER, CREATED,
+                Optional.of(DELETED), Optional.empty(),
+                0L, Optional.empty());
+
+        MessageEmbed embed = ShortenerHandler.buildStatsEmbed(entry, BASE_URL);
+        assertNotNull(fieldValue(embed, "Deleted"));
+    }
+}

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/shortener/ShortenerRedirectHandlerTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/shortener/ShortenerRedirectHandlerTest.java
@@ -1,6 +1,27 @@
 package ca.ryanmorrison.chatterbox.features.shortener;
 
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import io.javalin.Javalin;
+import org.flywaydb.core.Flyway;
+import org.jooq.DSLContext;
+import org.jooq.SQLDialect;
+import org.jooq.conf.Settings;
+import org.jooq.impl.DSL;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -31,5 +52,121 @@ class ShortenerRedirectHandlerTest {
         String escaped = ShortenerRedirectHandler.escapeAttr(hostile);
         assertFalse(escaped.contains("<script>"));
         assertTrue(escaped.contains("&lt;script&gt;"));
+    }
+
+    // -- end-to-end click counter behaviour ---------------------------------
+    //
+    // These tests stand up a real SQLite-backed repository and a Javalin
+    // server on an ephemeral port, then exercise the handler over HTTP. We
+    // care about the user-visible contract:
+    //   - live redirects bump click_count and stamp last_clicked_at;
+    //   - 410 Gone (deleted) and 404 (unknown) paths must not increment.
+
+    private static final long USER = 4242L;
+    private static final long MOD = 9999L;
+    private static final OffsetDateTime CLICK_TIME =
+            OffsetDateTime.of(2026, 5, 9, 20, 0, 0, 0, ZoneOffset.UTC);
+
+    private Path dbFile;
+    private HikariDataSource dataSource;
+    private DSLContext dsl;
+    private ShortenerRepository repo;
+    private Javalin app;
+    private HttpClient http;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbFile = Files.createTempFile("chatterbox-redirect-test", ".db");
+        Files.delete(dbFile);
+
+        var hc = new HikariConfig();
+        hc.setJdbcUrl("jdbc:sqlite:" + dbFile);
+        hc.setMaximumPoolSize(1);
+        hc.setConnectionInitSql("PRAGMA foreign_keys = ON");
+        dataSource = new HikariDataSource(hc);
+
+        Flyway.configure()
+                .dataSource(dataSource)
+                .locations("classpath:db/migration/shortener/sqlite")
+                .load()
+                .migrate();
+
+        dsl = DSL.using(dataSource, SQLDialect.SQLITE, new Settings().withRenderSchema(false));
+        repo = new ShortenerRepository(dsl);
+
+        Clock fixed = Clock.fixed(CLICK_TIME.toInstant(), ZoneOffset.UTC);
+        var handler = new ShortenerRedirectHandler(repo, fixed);
+        app = Javalin.create(cfg -> cfg.routes.get(ShortenerRedirectHandler.PATH, handler));
+        app.start(0);
+
+        http = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(2))
+                .followRedirects(HttpClient.Redirect.NEVER)
+                .build();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (app != null) app.stop();
+        if (dataSource != null) dataSource.close();
+        if (dbFile != null) Files.deleteIfExists(dbFile);
+    }
+
+    private HttpResponse<String> get(String token) throws Exception {
+        URI uri = URI.create("http://localhost:" + app.port() + "/" + token);
+        return http.send(HttpRequest.newBuilder(uri).GET().build(),
+                HttpResponse.BodyHandlers.ofString());
+    }
+
+    @Test
+    void liveTokenRedirectsAndIncrementsCounter() throws Exception {
+        long id = repo.insert("abc123", "https://example.com/x", USER, CLICK_TIME).orElseThrow().id();
+
+        HttpResponse<String> res = get("abc123");
+        assertEquals(301, res.statusCode());
+        assertEquals("https://example.com/x", res.headers().firstValue("Location").orElseThrow());
+
+        ShortenedUrl after = repo.findByIdIncludingDeleted(id).orElseThrow();
+        assertEquals(1L, after.clickCount());
+        assertEquals(CLICK_TIME, after.lastClickedAt().orElseThrow());
+    }
+
+    @Test
+    void multipleRedirectsAccumulate() throws Exception {
+        long id = repo.insert("abc123", "https://example.com/x", USER, CLICK_TIME).orElseThrow().id();
+        for (int i = 0; i < 3; i++) {
+            assertEquals(301, get("abc123").statusCode());
+        }
+        assertEquals(3L, repo.findByIdIncludingDeleted(id).orElseThrow().clickCount());
+    }
+
+    @Test
+    void deletedTokenReturnsGoneAndDoesNotIncrement() throws Exception {
+        long id = repo.insert("abc123", "https://example.com/x", USER, CLICK_TIME).orElseThrow().id();
+        repo.softDelete(id, MOD, CLICK_TIME);
+
+        HttpResponse<String> res = get("abc123");
+        assertEquals(410, res.statusCode());
+        assertEquals(0L, repo.findByIdIncludingDeleted(id).orElseThrow().clickCount());
+    }
+
+    @Test
+    void unknownTokenReturnsNotFound() throws Exception {
+        // Pre-existing live row to confirm its counter is untouched by an
+        // unrelated 404.
+        long id = repo.insert("abc123", "https://example.com/x", USER, CLICK_TIME).orElseThrow().id();
+        HttpResponse<String> res = get("zzzzzz");
+        assertEquals(404, res.statusCode());
+        assertEquals(0L, repo.findByIdIncludingDeleted(id).orElseThrow().clickCount());
+    }
+
+    @Test
+    void uppercasePathIsNormalisedToLowercase() throws Exception {
+        // Tokens are stored lowercase; the handler should be case-insensitive
+        // so users typing the URL by hand still land on the destination AND
+        // get counted.
+        long id = repo.insert("abc123", "https://example.com/x", USER, CLICK_TIME).orElseThrow().id();
+        assertEquals(301, get("ABC123").statusCode());
+        assertEquals(1L, repo.findByIdIncludingDeleted(id).orElseThrow().clickCount());
     }
 }

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/shortener/ShortenerRepositorySqliteTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/shortener/ShortenerRepositorySqliteTest.java
@@ -156,4 +156,54 @@ class ShortenerRepositorySqliteTest {
         ShortenedUrl byId = repo.findByIdIncludingDeleted(id).orElseThrow();
         assertTrue(byId.isDeleted());
     }
+
+    // -- click stats --------------------------------------------------------
+
+    @Test
+    void newRowsHaveZeroClicksAndNoLastClickTimestamp() {
+        ShortenedUrl row = repo.insert("abc123", "https://example.com/x", USER, NOW).orElseThrow();
+        assertEquals(0L, row.clickCount());
+        assertTrue(row.lastClickedAt().isEmpty());
+    }
+
+    @Test
+    void incrementClicksBumpsCounterAndStampsTimestamp() {
+        long id = repo.insert("abc123", "https://example.com/x", USER, NOW).orElseThrow().id();
+        int updated = repo.incrementClicks(id, LATER);
+        assertEquals(1, updated);
+
+        ShortenedUrl after = repo.findByToken("abc123").orElseThrow();
+        assertEquals(1L, after.clickCount());
+        assertEquals(LATER, after.lastClickedAt().orElseThrow());
+    }
+
+    @Test
+    void incrementClicksAccumulates() {
+        long id = repo.insert("abc123", "https://example.com/x", USER, NOW).orElseThrow().id();
+        for (int i = 0; i < 5; i++) {
+            repo.incrementClicks(id, LATER);
+        }
+        assertEquals(5L, repo.findByToken("abc123").orElseThrow().clickCount());
+    }
+
+    @Test
+    void incrementClicksOnUnknownIdIsSilentNoOp() {
+        // Analytics must never block a redirect — a missing id (e.g. row was
+        // deleted between read and update) is a no-op, not an error.
+        int updated = repo.incrementClicks(99_999L, LATER);
+        assertEquals(0, updated);
+    }
+
+    @Test
+    void incrementClicksWorksOnSoftDeletedRow() {
+        // Operationally we don't increment for deleted rows (the redirect
+        // handler 410s before getting here), but the storage doesn't
+        // discriminate — useful if we ever want to count would-be clicks.
+        long id = repo.insert("abc123", "https://example.com/x", USER, NOW).orElseThrow().id();
+        repo.softDelete(id, MOD, LATER);
+        int updated = repo.incrementClicks(id, LATER);
+        assertEquals(1, updated);
+        ShortenedUrl after = repo.findByTokenIncludingDeleted("abc123").orElseThrow();
+        assertEquals(1L, after.clickCount());
+    }
 }


### PR DESCRIPTION
## Summary
Adds click tracking and analytics to the URL shortener feature. Each redirect now atomically increments a click counter and records the timestamp of the last click. A new `/shorten stats` slash command allows users to view click statistics for any shortened URL, including soft-deleted entries.

## Key Changes

- **Database schema**: Added `click_count` (BIGINT, default 0) and `last_clicked_at` (TIMESTAMPTZ/TEXT) columns to `shortened_urls` table via new migration files for both PostgreSQL and SQLite
- **Click tracking**: Modified `ShortenerRedirectHandler` to atomically increment click counters on successful redirects via new `incrementClicks()` repository method. Counter bumps are best-effort and never block redirects
- **Stats command**: Implemented `/shorten stats` subcommand that displays click analytics in an embed, including:
  - Total click count
  - Last-click timestamp (Discord relative format)
  - Creator and creation time
  - Deletion info (timestamp and deleter) for soft-deleted entries
- **Repository layer**: Added `incrementClicks(id, when)` method that atomically updates both counter and timestamp in a single UPDATE statement
- **Record model**: Updated `ShortenedUrl` record to include `clickCount` and `lastClickedAt` fields
- **Testing**: 
  - Added comprehensive unit tests for `buildStatsEmbed()` covering live entries, deleted entries, edge cases, and URL formatting
  - Added end-to-end integration tests for redirect handler verifying click counter behavior across live, deleted, and unknown tokens
  - Added repository tests for click increment operations

## Implementation Details

- Click counter increments use SQL `CLICK_COUNT + 1` to ensure concurrent clicks accumulate correctly without explicit locking
- Analytics failures are logged but never block redirects (fail-open design)
- Stats remain queryable for soft-deleted entries, allowing admins to see historical popularity
- Handler accepts both bare tokens and full short URLs via existing `TargetParser`
- Test infrastructure includes real SQLite database with Flyway migrations and ephemeral Javalin server for integration testing

https://claude.ai/code/session_01Sx89PCe12XmPkoe5HiaQsV