### PR TITLE
Add pgweb database GUI (loopback-only, SSH tunnel)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,13 @@ POSTGRES_DB=chatterbox
 POSTGRES_USER=chatterbox
 POSTGRES_PASSWORD=replace-me-with-a-strong-password
 
+# pgweb database GUI. Runs bound to the host loopback only (never exposed to
+# the internet) and is reached over an SSH tunnel:
+#   ssh -L 8081:127.0.0.1:8081 user@host   then open http://localhost:8081
+# This is the host-side port pgweb binds to on 127.0.0.1; change it only if
+# 8081 is already taken on the server.
+PGWEB_BIND_PORT=8081
+
 # false = register slash commands globally (production).
 # true  = register per-guild for instant updates (development only).
 CHATTERBOX_DEV_MODE=false

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -48,6 +48,7 @@ jobs:
             del(.services.postgres) |
             del(.services."postgres-backup") |
             del(.services."backup-sync") |
+            del(.services.pgweb) |
             del(.volumes) |
             del(.services.chatterbox.depends_on) |
             .services.chatterbox.image = "chatterbox:staging" |

--- a/README.md
+++ b/README.md
@@ -160,6 +160,29 @@ automatically and keeps you under the 2 GB free-tier limit.
 | `DROPBOX_REMOTE_PATH`  | no       | `chatterbox-backups`  | Folder inside the app folder to sync into. |
 | `BACKUP_SYNC_INTERVAL` | no       | `3600`                | Seconds between sync runs. |
 
+## Database GUI (pgweb)
+
+The `pgweb` service runs a lightweight web console for the Postgres database.
+It is chosen for its tiny footprint (a single Go binary, ~30 MB resident,
+capped at 64 MB) so it fits alongside the rest of the stack on a 1 GB host.
+
+For safety it is **not** exposed through Traefik and has no public route. The
+container publishes its port on the host loopback only
+(`127.0.0.1:${PGWEB_BIND_PORT:-8081}`), so the only way in is an SSH tunnel:
+
+```sh
+ssh -L 8081:127.0.0.1:8081 user@host
+```
+
+Then open <http://localhost:8081> in your browser. pgweb reads
+`PGWEB_DATABASE_URL` from the compose file and connects automatically — no
+credentials to enter. Because it always runs, there is nothing to start or
+stop by hand; the tunnel is the only step.
+
+| Variable          | Required | Default | Purpose |
+|-------------------|----------|---------|---------|
+| `PGWEB_BIND_PORT` | no       | `8081`  | Host-side loopback port pgweb binds to. Change only if `8081` is already taken on the server. |
+
 ## Architecture
 
 ### Module SPI

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,30 @@ services:
         max-size: "10m"
         max-file: "3"
 
+  pgweb:
+    image: sosedoff/pgweb:0.17.0
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      PGWEB_DATABASE_URL: postgres://${POSTGRES_USER:-chatterbox}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@postgres:5432/${POSTGRES_DB:-chatterbox}?sslmode=disable
+    # Bound to loopback only — the GUI is never exposed to the internet.
+    # Reach it with an SSH tunnel: ssh -L 8081:127.0.0.1:8081 user@host
+    ports:
+      - "127.0.0.1:${PGWEB_BIND_PORT:-8081}:8081"
+    networks:
+      - internal
+    deploy:
+      resources:
+        limits:
+          memory: 64M
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
   backup-sync:
     profiles: ["dropbox-sync"]
     image: rclone/rclone:1.74


### PR DESCRIPTION
## What

Adds a **pgweb** service to the stack — a lightweight web GUI for the Postgres database.

## Why pgweb

The 1GB Nanode budget rules out heavier consoles (pgAdmin ~200–400M, CloudBeaver 300M+). pgweb is a single Go binary, ~30M resident, capped here at **64M**, which fits alongside the existing services (postgres 256M + chatterbox 384M + backup 64M + traefik 128M).

## Security posture

- **Not** exposed through Traefik; no public route.
- Published to the host **loopback only** (`127.0.0.1:${PGWEB_BIND_PORT:-8081}`), so the only way in is an SSH tunnel:
  ```sh
  ssh -L 8081:127.0.0.1:8081 user@host   # then open http://localhost:8081
  ```
- Auto-connects via `PGWEB_DATABASE_URL` — no credentials entered in the browser.
- Always on (`restart: unless-stopped`, no profile gate) — nothing to start by hand.

## Staging

The derived staging compose (`deploy-staging.yml`) strips the Postgres services and runs chatterbox on in-memory SQLite, so pgweb is excluded there too — otherwise it would crash-loop pointing at a nonexistent `postgres:5432`.

## Verified rather than assumed

- Pinned to current stable **`sosedoff/pgweb:0.17.0`** (0.16.2 was over a year old).
- Confirmed `PGWEB_DATABASE_URL` is the correct connection env var (has a `DATABASE_URL` fallback).
- pgweb's `--bind` defaults to `localhost` *inside the container*, but the image's `ENTRYPOINT` already sets `--bind=0.0.0.0`, so publishing to the host works — no command override needed.

## Not verified

`docker compose config` was not run — Docker isn't available in the dev environment. YAML is hand-verified against existing structure.

## Changes

- `docker-compose.yml` — new `pgweb` service
- `.env.example` — `PGWEB_BIND_PORT` (default 8081)
- `README.md` — "Database GUI (pgweb)" section
- `.github/workflows/deploy-staging.yml` — exclude pgweb from derived staging compose

🤖 Generated with [Claude Code](https://claude.com/claude-code)