### PR TITLE
Add Dependabot config for Maven, Docker, and Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+# Dependabot version updates for Chatterbox.
+# Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Maven dependencies declared in pom.xml.
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      # Bundle low-risk minor/patch bumps into a single PR to cut noise.
+      maven-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Base images used in the Dockerfile.
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # GitHub Actions used in .github/workflows.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary
Enables Dependabot version updates for all three package ecosystems present in the repo:

- **Maven** — dependencies in `pom.xml` (JDA, etc.)
- **Docker** — base images in the `Dockerfile` (`maven:3.9-eclipse-temurin-25`, `eclipse-temurin:25-jre`)
- **GitHub Actions** — actions pinned across the workflows in `.github/workflows/`

## Details
- All three run on a **weekly** schedule.
- Minor/patch bumps for Maven and Actions are **grouped** into a single PR each to reduce noise; major bumps still arrive as separate PRs for manual review.
- Maven `open-pull-requests-limit` raised to 10 to give the largest ecosystem headroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)