### PR TITLE
Migrate from Jackson 2.x to Jackson 3.1.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <logback.version>1.5.37</logback.version>
         <rome.version>2.1.0</rome.version>
         <jsoup.version>1.22.2</jsoup.version>
-        <jackson.version>2.22.0</jackson.version>
+        <jackson.version>3.1.4</jackson.version>
         <javalin.version>7.2.2</javalin.version>
         <junit.version>6.1.1</junit.version>
         <testcontainers.version>1.21.4</testcontainers.version>
@@ -41,6 +41,23 @@
         <enforcer.plugin.version>3.6.3</enforcer.plugin.version>
         <groovy.maven.plugin.version>2.1.1</groovy.maven.plugin.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!--
+                Jackson BOM governs the versions of all tools.jackson.* artifacts
+                (databind, core, annotations, ...) so individual dependencies can
+                omit their <version>.
+            -->
+            <dependency>
+                <groupId>tools.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -126,15 +143,14 @@
             <version>${jsoup.version}</version>
         </dependency>
 
+        <!--
+            Jackson 3: java.time (JSR-310) support is now built into
+            jackson-databind, so no separate datatype module is needed. The
+            version is governed by the imported jackson-bom above.
+        -->
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/frinkiac/FrinkiacClient.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/frinkiac/FrinkiacClient.java
@@ -1,10 +1,11 @@
 package ca.ryanmorrison.chatterbox.features.frinkiac;
 
 import ca.ryanmorrison.chatterbox.features.frinkiac.dto.SearchResult;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.io.IOException;
 import java.net.URI;
@@ -69,6 +70,10 @@ final class FrinkiacClient {
         this.mapper = JsonMapper.builder()
                 .findAndAddModules()
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                // Jackson 3 enables FAIL_ON_NULL_FOR_PRIMITIVES by default; these
+                // upstream APIs omit optional primitive fields, which the DTOs
+                // expect to default to zero as in Jackson 2.
+                .configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, false)
                 .build();
     }
 
@@ -81,7 +86,7 @@ final class FrinkiacClient {
         byte[] body = getBytes("/api/search?q=" + encoded, MAX_JSON_BYTES);
         try {
             return mapper.readValue(body, new TypeReference<List<SearchResult>>() {});
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             throw new FrinkiacException("Frinkiac returned an unexpected search response.");
         }
     }
@@ -109,7 +114,7 @@ final class FrinkiacClient {
             json = mapper.writeValueAsString(
                     CaptionOverlay.singlePanel(episode.trim().toUpperCase(Locale.ROOT), timestamp,
                             text == null ? "" : text));
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             throw new FrinkiacException("Couldn't serialise the caption payload.");
         }
         // URL-safe alphabet (- and _ instead of + and /) — the comic renderer's b64

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/nhl/NhlClient.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/nhl/NhlClient.java
@@ -4,9 +4,10 @@ import ca.ryanmorrison.chatterbox.features.nhl.dto.Game;
 import ca.ryanmorrison.chatterbox.features.nhl.dto.GameDay;
 import ca.ryanmorrison.chatterbox.features.nhl.dto.ScheduleResponse;
 import ca.ryanmorrison.chatterbox.features.nhl.dto.TeamWeekResponse;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.io.IOException;
 import java.net.URI;
@@ -54,6 +55,10 @@ final class NhlClient {
         this.mapper = JsonMapper.builder()
                 .findAndAddModules()
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                // Jackson 3 enables FAIL_ON_NULL_FOR_PRIMITIVES by default; these
+                // upstream APIs omit optional primitive fields (e.g. Team.score),
+                // which the DTOs expect to default to zero as in Jackson 2.
+                .configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, false)
                 .build();
     }
 
@@ -143,7 +148,7 @@ final class NhlClient {
         }
         try {
             return mapper.readValue(body, type);
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             throw new NhlException("The NHL API returned an unexpected response.");
         }
     }

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/stock/StockClient.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/stock/StockClient.java
@@ -2,9 +2,10 @@ package ca.ryanmorrison.chatterbox.features.stock;
 
 import ca.ryanmorrison.chatterbox.features.stock.dto.ChartMeta;
 import ca.ryanmorrison.chatterbox.features.stock.dto.ChartResponse;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.io.IOException;
 import java.net.URI;
@@ -66,6 +67,10 @@ final class StockClient {
         this.mapper = JsonMapper.builder()
                 .findAndAddModules()
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                // Jackson 3 enables FAIL_ON_NULL_FOR_PRIMITIVES by default; these
+                // upstream APIs omit optional primitive fields, which the DTOs
+                // expect to default to zero as in Jackson 2.
+                .configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, false)
                 .build();
     }
 
@@ -128,7 +133,7 @@ final class StockClient {
         ChartResponse parsed;
         try {
             parsed = mapper.readValue(body, ChartResponse.class);
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             throw new StockException("Yahoo Finance returned an unexpected response.");
         }
         // Some 200-class responses still carry a populated error block when
@@ -151,7 +156,7 @@ final class StockClient {
                 return new StockException("Couldn't find symbol `" + symbol + "`. "
                         + "It may be delisted, or check the spelling.");
             }
-        } catch (IOException ignored) {
+        } catch (JacksonException ignored) {
             // Fall through to the generic message.
         }
         return new StockException("Couldn't find symbol `" + symbol + "`. "

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/weather/WeatherClient.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/weather/WeatherClient.java
@@ -1,9 +1,10 @@
 package ca.ryanmorrison.chatterbox.features.weather;
 
 import ca.ryanmorrison.chatterbox.features.weather.dto.WeatherResponse;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.io.IOException;
 import java.net.URI;
@@ -63,6 +64,10 @@ final class WeatherClient {
         this.mapper = JsonMapper.builder()
                 .findAndAddModules()
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                // Jackson 3 enables FAIL_ON_NULL_FOR_PRIMITIVES by default; these
+                // upstream APIs omit optional primitive fields, which the DTOs
+                // expect to default to zero as in Jackson 2.
+                .configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, false)
                 .build();
     }
 
@@ -126,7 +131,7 @@ final class WeatherClient {
         }
         try {
             return mapper.readValue(body, WeatherResponse.class);
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             throw new WeatherException("wttr.in returned an unexpected response.");
         }
     }

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/wiki/WikiClient.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/wiki/WikiClient.java
@@ -3,9 +3,10 @@ package ca.ryanmorrison.chatterbox.features.wiki;
 import ca.ryanmorrison.chatterbox.features.wiki.dto.PageSummary;
 import ca.ryanmorrison.chatterbox.features.wiki.dto.SearchHit;
 import ca.ryanmorrison.chatterbox.features.wiki.dto.SearchResponse;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.io.IOException;
 import java.net.URI;
@@ -60,6 +61,10 @@ final class WikiClient {
         this.mapper = JsonMapper.builder()
                 .findAndAddModules()
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                // Jackson 3 enables FAIL_ON_NULL_FOR_PRIMITIVES by default; these
+                // upstream APIs omit optional primitive fields, which the DTOs
+                // expect to default to zero as in Jackson 2.
+                .configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, false)
                 .build();
     }
 
@@ -90,7 +95,7 @@ final class WikiClient {
         if (body.length == 0) throw new WikiException("Wikipedia returned an empty response.");
         try {
             return Optional.of(mapper.readValue(body, PageSummary.class));
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             throw new WikiException("Wikipedia returned an unexpected response.");
         }
     }
@@ -118,7 +123,7 @@ final class WikiClient {
         if (body.length == 0) return List.of();
         try {
             return mapper.readValue(body, SearchResponse.class).hits();
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             throw new WikiException("Wikipedia returned an unexpected response.");
         }
     }

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/frinkiac/FrinkiacClientTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/frinkiac/FrinkiacClientTest.java
@@ -1,7 +1,7 @@
 package ca.ryanmorrison.chatterbox.features.frinkiac;
 
 import ca.ryanmorrison.chatterbox.features.frinkiac.dto.SearchResult;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import com.sun.net.httpserver.HttpServer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -116,7 +116,7 @@ class FrinkiacClientTest {
         assertTrue(!b64.contains("+") && !b64.contains("/"),
                 () -> "expected URL-safe base64, got: " + b64);
         byte[] json = Base64.getUrlDecoder().decode(b64);
-        ObjectMapper mapper = new ObjectMapper();
+        JsonMapper mapper = JsonMapper.builder().build();
         @SuppressWarnings("unchecked")
         List<Map<String, Object>> panels = mapper.readValue(json, List.class);
         assertEquals(1, panels.size(), "expected single-panel payload");


### PR DESCRIPTION
## Summary

Migrates the project from Jackson **2.22.0** to Jackson **3.1.4**, following the [official Jackson 3 migration guide](https://github.com/FasterXML/jackson/blob/main/jackson3/MIGRATING_TO_JACKSON_3.md), and adopts the **`jackson-bom`** for centralized version management.

Jackson 3 is a hard fork: Maven groupIds and Java packages move from `com.fasterxml.jackson.*` to `tools.jackson.*`, databind exceptions become **unchecked** (`JacksonException extends RuntimeException`), and `java.time`/JSR-310 support is now built into `jackson-databind`.

## Changes

**`pom.xml`**
- Import `tools.jackson:jackson-bom:3.1.4` in `<dependencyManagement>` — governs all `tools.jackson.*` artifact versions.
- Re-coordinate `jackson-databind` to `tools.jackson.core` (version now managed by the BOM).
- Remove `jackson-datatype-jsr310` — `java.time` support is embedded in databind in Jackson 3.

**The five HTTP clients** (`Wiki`, `Frinkiac`, `NHL`, `Weather`, `Stock`)
- Swap databind/core imports to `tools.jackson.*`.
- Change the parse/serialize `catch (IOException)` blocks to the now-unchecked `catch (JacksonException)` (in Jackson 3 `readValue`/`writeValueAsString` no longer throw `IOException`).

**Behavioral fix — lenient primitive defaulting**
- Jackson 3 enables `FAIL_ON_NULL_FOR_PRIMITIVES` by default. This broke deserialization of API responses that omit optional primitive fields — e.g. NHL `Team.score`, which the DTO explicitly documents as defaulting to zero. Disabled on all five mappers to preserve the pre-migration contract.

**Test**
- `FrinkiacClientTest` now builds its mapper via `JsonMapper.builder().build()`.

## Notes

- **DTO annotations are unchanged.** `@JsonProperty` / `@JsonIgnoreProperties` / `@JsonInclude` live in `com.fasterxml.jackson.annotation`, which Jackson 3 keeps — no DTO edits.
- **JDA still bundles Jackson 2** (`jackson-core`/`jackson-databind` 2.22.0, runtime scope) for its own internal use. It coexists with our Jackson 3 in a different package namespace with no conflict — the same situation as before the migration; only our *direct* dependency moved to Jackson 3.
- **Future JSON APIs (Javalin):** Javalin 7.2.2 already ships a Jackson 3 mapper (`JavalinJackson3`) and pulls no Jackson transitively (both bindings are `optional`). When JSON endpoints are added, select it with `config.jsonMapper(new JavalinJackson3())` — no Jackson 2 dependency required.

## Verification

- `mvn clean compile` — BOM resolves, coordinates + exception edits compile.
- `mvn test` — **497 tests pass** (all non-Testcontainers tests, covering every Jackson serialize/deserialize path, including the exception-wrapping regression guard). The 4 Testcontainers/Postgres repository tests require Docker (unavailable in the local dev env, unaffected by Jackson) and are covered by CI.
- `mvn package` — the shade uber-jar assembles cleanly with the Jackson 3 jars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)