### PR TITLE
Fix SSRF, correctness, and deploy-gating issues found in review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   push:
     branches: [main]
+  # Lets the deploy workflow depend on this job instead of racing it.
+  workflow_call:
 
 permissions:
   contents: read
@@ -29,8 +31,12 @@ jobs:
           java-version: '25'
           cache: maven
 
-      - name: Run unit tests
-        run: mvn --batch-mode --no-transfer-progress test
+      # verify, not test: this is the only thing that exercises the shade
+      # plugin, including the ServicesResourceTransformer the whole
+      # ServiceLoader module system depends on. With only `test`, a broken
+      # META-INF/services merge would first surface in production.
+      - name: Build and run tests
+        run: mvn --batch-mode --no-transfer-progress verify
 
       - name: Upload Surefire reports
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,31 @@ jobs:
       - name: Build and run tests
         run: mvn --batch-mode --no-transfer-progress verify
 
+      # Surfaces failing tests as annotations and a run summary, so a red build
+      # is readable from the run page instead of by downloading XML.
+      #
+      # report_mode: workflow, not the default auto. auto publishes via the
+      # Checks API, which needs checks: write -- and Dependabot-triggered runs
+      # get a read-only GITHUB_TOKEN no matter what the workflow requests, so
+      # auto would 403 and fail CI on every Dependabot PR. workflow mode uses
+      # native annotations plus the step summary, needs no extra permission,
+      # and behaves the same whether the run came from a PR, a push, or the
+      # deploy workflow calling this one.
+      - name: Publish test report
+        if: always()
+        uses: ScalableCapital/action-surefire-report@v2.0.4
+        with:
+          report_mode: workflow
+          # Belt and braces. mvn verify already fails on a test failure, so
+          # this only matters if surefire is ever set to ignore failures --
+          # in which case the gate would otherwise disappear silently.
+          fail_on_test_failures: true
+          # Default, but load-bearing enough to be explicit: a suite that
+          # silently stops running is exactly what a test gate must catch.
+          fail_if_no_tests: true
+
+      # Kept alongside the report: the annotations are for reading, the
+      # artifact is for when you need the raw XML.
       - name: Upload Surefire reports
         if: always()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,14 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Gate: previously this workflow ran in parallel with CI with no dependency
+  # between them, and the image is built with -DskipTests -- so a commit with
+  # failing tests deployed to production anyway.
+  test:
+    uses: ./.github/workflows/ci.yml
+
   build-and-deploy:
+    needs: test
     runs-on: ubuntu-latest
     environment: production
     timeout-minutes: 20

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,40 @@
 # syntax=docker/dockerfile:1.7
-FROM maven:3-eclipse-temurin-26 AS build
+# Build JDK matches the runtime JRE and the JDK that CI tests on. They had
+# drifted (build on 26, run on 25, test on 25), which meant the jar shipped to
+# production was produced by a compiler no test run ever exercised.
+FROM maven:3-eclipse-temurin-25 AS build
 WORKDIR /src
 
 # Cache dependencies first.
 COPY pom.xml .
 RUN --mount=type=cache,target=/root/.m2 mvn -B -ntp -q dependency:go-offline
 
-# Build.
+# Build. Tests are skipped here on purpose -- CI runs them, and the deploy
+# workflow now gates on that CI job rather than racing it.
 COPY src ./src
 RUN --mount=type=cache,target=/root/.m2 mvn -B -ntp -q -DskipTests package
 
 FROM eclipse-temurin:25-jre
 WORKDIR /app
 
+# curl is only here for HEALTHCHECK: a JRE image has no javac, so there is no
+# way to run a throwaway Java HTTP client, and the base image ships no wget.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl \
+ && rm -rf /var/lib/apt/lists/*
+
 RUN groupadd --system --gid 10001 chatterbox \
  && useradd  --system --uid 10001 --gid 10001 --no-create-home chatterbox
 
 COPY --from=build /src/target/chatterbox.jar /app/chatterbox.jar
+
+ENV CHATTERBOX_HTTP_PORT=8080
+
+# /health returns 503 until JDA is connected, so start-period covers the
+# gateway handshake and the container only reports healthy once the bot can
+# actually serve. Without this a hung bot stayed "up" indefinitely.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+  CMD curl -fsS "http://127.0.0.1:${CHATTERBOX_HTTP_PORT}/health" || exit 1
 
 USER chatterbox
 ENTRYPOINT ["java", "-jar", "/app/chatterbox.jar"]

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ deployment.
 | `CHATTERBOX_DB_PASSWORD`   | no       | —       | DB password (Postgres). Unused for SQLite. |
 | `CHATTERBOX_DEV_MODE`      | no       | `false` | When `true`, slash commands register per-guild for instant updates. When `false`, they register globally. The opposite scope is cleared on each startup, so switching modes never leaves duplicates. |
 | `CHATTERBOX_LOG_LEVEL`     | no       | `INFO`  | Root logger level. |
-| `CHATTERBOX_HTTP_PORT`     | no       | `8080`  | Port the bot's internal HTTP server binds to. The server only starts when at least one module registers a route. |
+| `CHATTERBOX_HTTP_PORT`     | no       | `8080`  | Port the bot's internal HTTP server binds to. Always bound, since the server serves `/health`. |
 | `CHATTERBOX_SHORTENER_BASE_URL` | no  | —       | Public-facing prefix for the URL shortener (e.g. `https://example.com`). Required only when `/shorten` is invoked or `CHATTERBOX_AUTOSHORTEN_ENABLED=true`; the bot can run without it set. |
 | `CHATTERBOX_AUTOSHORTEN_ENABLED` | no | `true` | Auto-shorten long URLs in guild messages by replacing the originals. Requires the bot to have **Manage Messages** in each channel. See [Auto-shortener](#auto-shortener). |
 | `CHATTERBOX_AUTOSHORTEN_THRESHOLD` | no | `160` | Minimum URL length (characters) that triggers auto-shortening. |
@@ -254,13 +254,28 @@ The dialect is selected from the JDBC URL (`postgresql` → `POSTGRES`,
 
 A bot-wide [Javalin](https://javalin.io) instance is available to modules that
 want to expose HTTP endpoints alongside their Discord behaviour. Modules
-register routes via `registerHttpRoutes(HttpRouter, InitContext)`; the server
-only binds its port when at least one module has registered a route, so a
-deployment without HTTP-using modules pays no port cost.
+register routes via `registerHttpRoutes(HttpRouter, InitContext)`.
 
 The server listens on `CHATTERBOX_HTTP_PORT` (default `8080`). In the
 default `docker-compose.yml`, traffic reaches it through Traefik — see
 [Reverse proxy and TLS](#reverse-proxy-and-tls) below.
+
+### Health endpoint
+
+`GET /health` is owned by the server itself rather than by a module, so it is
+always available:
+
+- **`200 ok`** — JDA is connected and the bot can serve.
+- **`503 starting`** — the port is bound but the gateway isn't up yet.
+
+The port binds before JDA connects, which is why the distinction matters: a
+healthcheck that answered `200` during that window would report a bot as ready
+before it could do anything. Both the Dockerfile `HEALTHCHECK` and the
+`docker-compose.yml` healthcheck probe this endpoint, so a container only
+reports healthy once the bot is genuinely usable.
+
+The route is registered ahead of module routes so it wins over the URL
+shortener's `GET /{token}`, for which `health` is a syntactically valid token.
 
 ### Logging
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,6 +137,14 @@ services:
       CHATTERBOX_AUTOSHORTEN_THRESHOLD: ${CHATTERBOX_AUTOSHORTEN_THRESHOLD:-160}
       CHATTERBOX_SHORTENER_BASE_URL: ${CHATTERBOX_SHORTENER_BASE_URL:-}
       JAVA_TOOL_OPTIONS: -XX:MaxRAMPercentage=75.0
+    # /health answers 503 until JDA is connected, so this only reports healthy
+    # once the bot can actually serve. start_period covers the gateway handshake.
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:${CHATTERBOX_HTTP_PORT:-8080}/health"]
+      interval: 30s
+      timeout: 5s
+      start_period: 60s
+      retries: 3
     networks:
       - internal
       - web

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
         <javalin.version>7.2.2</javalin.version>
         <junit.version>6.1.2</junit.version>
         <testcontainers.version>1.21.4</testcontainers.version>
+        <mockito.version>5.20.0</mockito.version>
 
         <compiler.plugin.version>3.15.0</compiler.plugin.version>
         <shade.plugin.version>3.6.2</shade.plugin.version>
@@ -175,6 +176,17 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!--
+          The JDA-facing seam (handlers, listeners, permission gates) can't be
+          tested without stubbing interaction events, which is why none of it
+          had tests before this was added.
+        -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/ca/ryanmorrison/chatterbox/Bootstrap.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/Bootstrap.java
@@ -24,6 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.bridge.SLF4JBridgeHandler;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashSet;
@@ -35,6 +36,11 @@ public final class Bootstrap {
 
     private static final Logger log = LoggerFactory.getLogger(Bootstrap.class);
 
+    /** How long to let JDA drain in-flight events before closing the DB pool. */
+    private static final Duration SHUTDOWN_TIMEOUT = Duration.ofSeconds(10);
+    /** Follow-up grace period after shutdownNow(). */
+    private static final Duration FORCED_SHUTDOWN_TIMEOUT = Duration.ofSeconds(5);
+
     public static void run() throws InterruptedException {
         SLF4JBridgeHandler.removeHandlersForRootLogger();
         SLF4JBridgeHandler.install();
@@ -45,7 +51,26 @@ public final class Bootstrap {
         List<Module> modules = ModuleRegistry.discover();
 
         Database database = new Database(config.database());
+        HttpServer httpServer = new HttpServer(config.http().port());
+        try {
+            start(config, modules, database, httpServer);
+        } catch (InterruptedException | RuntimeException | Error e) {
+            // The shutdown hook isn't registered until the very end of start(),
+            // so anything thrown before then -- a Flyway failure, a duplicate
+            // config key, a module blowing up, an interrupt during
+            // awaitReady() -- would otherwise leave the Hikari pool and the
+            // bound HTTP port behind. The process is exiting either way, but
+            // this also keeps run() usable from a test.
+            closeQuietly(httpServer::stop, "HTTP server");
+            closeQuietly(database::close, "database");
+            throw e;
+        }
+    }
 
+    private static void start(Config config,
+                              List<Module> modules,
+                              Database database,
+                              HttpServer httpServer) throws InterruptedException {
         var migrationLocations = new ArrayList<String>();
         modules.forEach(m -> migrationLocations.addAll(m.migrationLocations()));
         // The /config slash command lives in a feature module too, but its
@@ -63,19 +88,25 @@ public final class Bootstrap {
 
         InitContext initCtx = new InitContextImpl(config, database.dsl(), runtimeConfig);
 
-        HttpServer httpServer = new HttpServer(config.http().port());
-
         Set<GatewayIntent> intents = new HashSet<>();
         EnumSet<CacheFlag> cacheFlags = EnumSet.noneOf(CacheFlag.class);
         List<SlashCommandData> commands = new ArrayList<>();
         List<EventListener> listeners = new ArrayList<>();
 
         for (Module m : modules) {
-            intents.addAll(m.intents());
-            cacheFlags.addAll(m.cacheFlags());
-            commands.addAll(m.slashCommands(initCtx));
-            listeners.addAll(m.listeners(initCtx));
-            m.registerHttpRoutes(httpServer.router(), initCtx);
+            // Guarded the same way onStart is below. Modules arrive via a
+            // ServiceLoader SPI, so a third-party one throwing here used to
+            // take the whole bot down, while the identical failure in onStart
+            // was logged and skipped.
+            try {
+                intents.addAll(m.intents());
+                cacheFlags.addAll(m.cacheFlags());
+                commands.addAll(m.slashCommands(initCtx));
+                listeners.addAll(m.listeners(initCtx));
+                m.registerHttpRoutes(httpServer.router(), initCtx);
+            } catch (RuntimeException e) {
+                log.error("Module {} failed to initialise; continuing without it.", m.name(), e);
+            }
         }
         log.info("Aggregated {} intent(s), {} command(s), {} listener(s) across {} module(s).",
                 intents.size(), commands.size(), listeners.size(), modules.size());
@@ -120,17 +151,46 @@ public final class Bootstrap {
             if (!shuttingDown.compareAndSet(false, true)) return;
             log.info("Shutdown signal received.");
             for (Module m : modules) {
+                // Throwable, not RuntimeException: an Error from any one module
+                // used to skip the HTTP stop, the JDA shutdown and the pool
+                // close for everything else.
                 try {
                     m.onStop();
-                } catch (RuntimeException e) {
-                    log.warn("Module {} failed during shutdown.", m.name(), e);
+                } catch (Throwable t) {
+                    log.warn("Module {} failed during shutdown.", m.name(), t);
                 }
             }
-            httpServer.stop();
-            jda.shutdown();
-            database.close();
+            closeQuietly(httpServer::stop, "HTTP server");
+            // JDA#shutdown is asynchronous, so closing the pool straight after
+            // tore it down while listener threads were still draining in-flight
+            // events -- an in-flight handler would fail mid-write with
+            // "HikariDataSource has been closed". Wait for the drain first.
+            try {
+                jda.shutdown();
+                if (!jda.awaitShutdown(SHUTDOWN_TIMEOUT)) {
+                    log.warn("JDA didn't finish shutting down within {}s; forcing.",
+                            SHUTDOWN_TIMEOUT.toSeconds());
+                    jda.shutdownNow();
+                    jda.awaitShutdown(FORCED_SHUTDOWN_TIMEOUT);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.warn("Interrupted while waiting for JDA to shut down.");
+            } catch (RuntimeException e) {
+                log.warn("JDA shutdown failed.", e);
+            }
+            closeQuietly(database::close, "database");
             log.info("Shutdown complete.");
         }, "chatterbox-shutdown"));
+    }
+
+    /** Runs a cleanup step, logging rather than propagating so later steps still run. */
+    private static void closeQuietly(Runnable step, String what) {
+        try {
+            step.run();
+        } catch (Throwable t) {
+            log.warn("Failed to shut down the {} cleanly.", what, t);
+        }
     }
 
     private record InitContextImpl(Config config, DSLContext database, RuntimeConfig runtimeConfig)

--- a/src/main/java/ca/ryanmorrison/chatterbox/Bootstrap.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/Bootstrap.java
@@ -111,11 +111,9 @@ public final class Bootstrap {
         log.info("Aggregated {} intent(s), {} command(s), {} listener(s) across {} module(s).",
                 intents.size(), commands.size(), listeners.size(), modules.size());
 
-        if (httpServer.hasRoutes()) {
-            httpServer.start();
-        } else {
-            log.info("No modules registered HTTP routes; skipping HTTP server bind.");
-        }
+        // Always start: the server owns /health, which has to answer before
+        // JDA is up (with 503) for a container healthcheck to mean anything.
+        httpServer.start();
 
         CommandSync commandSync = new CommandSync(commands, config.devMode());
 
@@ -129,6 +127,9 @@ public final class Bootstrap {
         jda.awaitReady();
         log.info("JDA ready. Connected as {} in {} guild(s).",
                 jda.getSelfUser().getName(), jda.getGuilds().size());
+
+        // Only now does the bot actually work, so only now does /health say so.
+        httpServer.setReadiness(() -> jda.getStatus() == JDA.Status.CONNECTED);
 
         commandSync.syncAll(jda);
 

--- a/src/main/java/ca/ryanmorrison/chatterbox/commands/CommandSync.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/commands/CommandSync.java
@@ -35,8 +35,11 @@ public final class CommandSync extends ListenerAdapter {
     public void syncAll(JDA jda) {
         if (devMode) {
             log.info("Dev mode: registering {} command(s) per-guild and clearing globals.", commands.size());
+            // No addCommands: this clears every global command. The count of
+            // commands we're about to register per-guild is unrelated to how
+            // many globals were removed, so don't report it as if it were.
             jda.updateCommands().queue(
-                    ok -> log.debug("Cleared {} global command(s).", commands.size()),
+                    ok -> log.debug("Cleared all global commands."),
                     err -> log.warn("Failed to clear global commands: {}", err.toString()));
             for (Guild g : jda.getGuilds()) {
                 pushToGuild(g);

--- a/src/main/java/ca/ryanmorrison/chatterbox/common/net/BoundedBody.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/common/net/BoundedBody.java
@@ -1,0 +1,56 @@
+package ca.ryanmorrison.chatterbox.common.net;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Reads an HTTP response body with a hard ceiling, enforced <em>while</em>
+ * streaming.
+ *
+ * <p>Exists because the obvious spelling is wrong in a way that looks right:
+ * {@code BodyHandlers.ofByteArray()} buffers the entire response first, so
+ * checking {@code body.length} afterwards enforces nothing. A server that
+ * streams gigabytes exhausts the heap long before the check runs — and several
+ * of these endpoints are reached with a user-supplied URL.
+ *
+ * <p>Pair with {@code BodyHandlers.ofInputStream()}.
+ */
+public final class BoundedBody {
+
+    private BoundedBody() {}
+
+    /** Signals that the body exceeded {@code maxBytes}; the read is abandoned at that point. */
+    public static final class TooLargeException extends IOException {
+        private final int maxBytes;
+
+        public TooLargeException(int maxBytes) {
+            super("response body exceeded " + maxBytes + " bytes");
+            this.maxBytes = maxBytes;
+        }
+
+        public int maxBytes() { return maxBytes; }
+
+        /** Convenience for user-facing messages, which quote the cap in KB. */
+        public int maxKilobytes() { return maxBytes / 1024; }
+    }
+
+    /**
+     * Reads {@code in} fully, or throws as soon as more than {@code maxBytes}
+     * have arrived.
+     *
+     * @throws TooLargeException if the body exceeds the cap
+     */
+    public static byte[] read(InputStream in, int maxBytes) throws IOException {
+        byte[] buf = new byte[8192];
+        var out = new ByteArrayOutputStream();
+        int total = 0;
+        int n;
+        while ((n = in.read(buf)) >= 0) {
+            total += n;
+            if (total > maxBytes) throw new TooLargeException(maxBytes);
+            out.write(buf, 0, n);
+        }
+        return out.toByteArray();
+    }
+}

--- a/src/main/java/ca/ryanmorrison/chatterbox/common/net/HttpClients.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/common/net/HttpClients.java
@@ -1,0 +1,47 @@
+package ca.ryanmorrison.chatterbox.common.net;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.http.HttpClient;
+import java.time.Duration;
+
+/**
+ * Shutdown helper for the module-owned {@link HttpClient} instances.
+ *
+ * <p>Each of these owns a selector thread and an executor. They live for the
+ * process, so leaving them open leaks nothing in practice — but closing them
+ * on module stop keeps {@code onStop} honest and makes the modules reusable
+ * from a test without accumulating threads.
+ */
+public final class HttpClients {
+
+    private static final Logger log = LoggerFactory.getLogger(HttpClients.class);
+
+    /** Brief grace period for in-flight requests before forcing the issue. */
+    private static final Duration DRAIN = Duration.ofSeconds(2);
+
+    private HttpClients() {}
+
+    /**
+     * Shuts {@code client} down without ever blocking for long.
+     *
+     * <p>Deliberately not {@link HttpClient#close()}: that waits for every
+     * in-flight request to finish, and this runs from a shutdown hook where a
+     * single slow upstream would stall the whole exit.
+     */
+    public static void closeQuietly(HttpClient client) {
+        if (client == null) return;
+        try {
+            client.shutdown();
+            if (!client.awaitTermination(DRAIN)) {
+                client.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            client.shutdownNow();
+        } catch (RuntimeException e) {
+            log.debug("Ignoring error while closing an HTTP client: {}", e.toString());
+        }
+    }
+}

--- a/src/main/java/ca/ryanmorrison/chatterbox/common/net/SafeHttp.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/common/net/SafeHttp.java
@@ -1,0 +1,150 @@
+package ca.ryanmorrison.chatterbox.common.net;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * Sends a request and follows redirects <em>manually</em>, re-running
+ * {@link UrlGuard} against every hop.
+ *
+ * <p>This exists because {@link HttpClient.Redirect#NORMAL} defeats an SSRF
+ * deny-list entirely: the guard validates the URL the user supplied, but the
+ * client then silently follows a {@code 302} to wherever the remote server
+ * points — including {@code 169.254.169.254} and friends. Validating hop 0 and
+ * then trusting the client to stay there is not a check at all.
+ *
+ * <p>Clients passed here must therefore be built with
+ * {@link HttpClient.Redirect#NEVER}; otherwise the client follows redirects
+ * internally and this class never sees them.
+ *
+ * <p><strong>Hop 0 is the caller's responsibility.</strong> This class
+ * validates only the targets it is redirected to, so callers must run
+ * {@link UrlGuard#parse} and {@link UrlGuard#resolve} on the initial URI
+ * themselves. Keeping it that way avoids a redundant DNS lookup on the common
+ * no-redirect path, where the caller has already resolved the host to decide
+ * whether to send at all.
+ */
+public final class SafeHttp {
+
+    /** Matches the redirect cap the JDK client applies by default. */
+    public static final int MAX_REDIRECTS = 5;
+
+    private SafeHttp() {}
+
+    /**
+     * Signals that a redirect target was refused by {@link UrlGuard}, carrying
+     * the guard's user-safe reason.
+     *
+     * <p>Extends {@link IOException} so it flows through the same failure paths
+     * callers already handle — but callers that distinguish "blocked" from
+     * "network error" should catch this <em>before</em> their generic
+     * {@code IOException} branch.
+     */
+    public static final class BlockedException extends IOException {
+        public BlockedException(String reason) { super(reason); }
+    }
+
+    /**
+     * Sends {@code request}, following up to {@link #MAX_REDIRECTS} redirects
+     * and validating each target against {@link UrlGuard}.
+     *
+     * <p>Bodies of intermediate redirect responses are closed before the next
+     * hop, so streaming body handlers don't leak connections.
+     *
+     * @throws BlockedException if a redirect target fails the guard, or if the
+     *         redirect chain is malformed (missing/unparseable {@code Location},
+     *         too many hops)
+     */
+    public static <T> HttpResponse<T> send(HttpClient http,
+                                           HttpRequest request,
+                                           HttpResponse.BodyHandler<T> handler)
+            throws IOException, InterruptedException {
+        return send(http, request, handler, UrlGuard::systemResolver);
+    }
+
+    /**
+     * Test seam: lets tests drive redirect-following against a loopback server
+     * without the guard rejecting every hop. The resolver only feeds the deny
+     * check — the connection still goes to the URI's real host.
+     */
+    public static <T> HttpResponse<T> send(HttpClient http,
+                                           HttpRequest request,
+                                           HttpResponse.BodyHandler<T> handler,
+                                           Function<String, InetAddress[]> resolver)
+            throws IOException, InterruptedException {
+
+        HttpRequest current = request;
+        for (int hop = 0; hop <= MAX_REDIRECTS; hop++) {
+            HttpResponse<T> response = http.send(current, handler);
+            if (!isRedirect(response.statusCode())) {
+                return response;
+            }
+
+            Optional<String> location = response.headers().firstValue("Location");
+            closeQuietly(response.body());
+            if (location.isEmpty() || location.get().isBlank()) {
+                throw new BlockedException("server sent a redirect with no destination.");
+            }
+
+            URI target = resolveTarget(current.uri(), location.get());
+            guard(target, resolver);
+            // Copy method, headers, timeout, and version; only the target changes.
+            current = HttpRequest.newBuilder(current, (name, value) -> true).uri(target).build();
+        }
+        throw new BlockedException("too many redirects (more than " + MAX_REDIRECTS + ").");
+    }
+
+    /**
+     * 300 and 304 are excluded deliberately: neither carries a destination we
+     * should chase (300 is a choice for the user agent, 304 is a cache hit).
+     */
+    private static boolean isRedirect(int status) {
+        return status == 301 || status == 302 || status == 303
+                || status == 307 || status == 308;
+    }
+
+    private static URI resolveTarget(URI base, String location) throws BlockedException {
+        try {
+            // Relative Locations are legal and common, so resolve against the
+            // URI we actually requested rather than assuming an absolute one.
+            return base.resolve(new URI(location.trim()));
+        } catch (URISyntaxException | IllegalArgumentException e) {
+            throw new BlockedException("server sent an unparseable redirect destination.");
+        }
+    }
+
+    /** Runs both guard stages against a redirect target. */
+    private static void guard(URI target, Function<String, InetAddress[]> resolver)
+            throws BlockedException {
+        UrlGuard.ParsedUrl parsed = UrlGuard.parse(target.toString());
+        if (parsed instanceof UrlGuard.ParsedUrl.Rejected(String reason)) {
+            throw new BlockedException("redirect to " + reason);
+        }
+        UrlGuard.ResolvedUrl resolved =
+                UrlGuard.resolve(((UrlGuard.ParsedUrl.Ok) parsed).uri(), resolver);
+        switch (resolved) {
+            case UrlGuard.ResolvedUrl.Ok ok -> { }
+            case UrlGuard.ResolvedUrl.DnsFailure(String host) ->
+                    throw new BlockedException("redirect target " + host + " didn't resolve.");
+            case UrlGuard.ResolvedUrl.Disallowed(String reason) ->
+                    throw new BlockedException("redirect to a blocked address: " + reason);
+        }
+    }
+
+    private static void closeQuietly(Object body) {
+        if (body instanceof AutoCloseable closeable) {
+            try {
+                closeable.close();
+            } catch (Exception e) {
+                // Nothing useful to do — we're discarding this hop's body anyway.
+            }
+        }
+    }
+}

--- a/src/main/java/ca/ryanmorrison/chatterbox/common/net/UrlGuard.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/common/net/UrlGuard.java
@@ -1,5 +1,6 @@
-package ca.ryanmorrison.chatterbox.features.isitdown;
+package ca.ryanmorrison.chatterbox.common.net;
 
+import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.URI;
@@ -9,50 +10,56 @@ import java.util.Locale;
 import java.util.Set;
 
 /**
- * Pre-flight validation for URLs supplied to {@code /isitdown}.
+ * Pre-flight validation for user-supplied URLs the bot will fetch on a
+ * caller's behalf.
  *
  * <p>Two stages:
  * <ol>
  *   <li>{@link #parse} — syntactic checks (well-formed, allowed scheme,
  *       length cap). Result is a sanitised {@link URI} ready for the HTTP
- *       client, or a {@link CheckResult.InvalidUrl} explaining the reject
+ *       client, or a {@link ParsedUrl.Rejected} explaining the reject
  *       reason.</li>
  *   <li>{@link #resolve} — DNS resolution plus an SSRF deny-list. Any
  *       resolved address that's loopback, link-local, site-local
- *       (RFC 1918), IPv6 unique-local (fc00::/7), multicast, or the
- *       wildcard fails the check. <em>All</em> resolved addresses must
- *       pass, so a hostname that resolves to both a public and a private
- *       address is rejected — defence in depth against split-horizon
- *       resolvers and DNS rebinding.</li>
+ *       (RFC 1918), carrier-grade NAT, IETF protocol assignment,
+ *       benchmarking, IPv6 unique-local, multicast, or the wildcard fails
+ *       the check. <em>All</em> resolved addresses must pass, so a hostname
+ *       that resolves to both a public and a private address is rejected —
+ *       defence in depth against split-horizon resolvers and DNS
+ *       rebinding.</li>
  * </ol>
  *
+ * <p>Validating the URL is only half the job: an allowed host can still
+ * redirect to a denied one. Callers must either disable redirects or route
+ * them through {@link SafeHttp}, which re-runs both stages on every hop.
+ *
  * <p>The TOCTOU gap between this resolve and the HttpClient's own resolve
- * inside {@link IsItDownChecker} is a known but low-severity concern: an
- * attacker would have to time DNS responses across two lookups. Acceptable
- * for a Discord bot; if that ever changes, switch to connecting via the
- * resolved IP and setting a {@code Host:} header explicitly.
+ * is a known but low-severity concern: an attacker would have to time DNS
+ * responses across two lookups. Acceptable for a Discord bot; if that ever
+ * changes, switch to connecting via the resolved IP and setting a
+ * {@code Host:} header explicitly.
  */
-final class UrlGuard {
+public final class UrlGuard {
 
-    static final int MAX_URL_LENGTH = 2048;
-    static final Set<String> ALLOWED_SCHEMES = Set.of("http", "https");
+    public static final int MAX_URL_LENGTH = 2048;
+    public static final Set<String> ALLOWED_SCHEMES = Set.of("http", "https");
 
     private UrlGuard() {}
 
     /** Result of {@link #parse}: either a usable URI or a rejection reason. */
-    sealed interface ParsedUrl {
+    public sealed interface ParsedUrl {
         record Ok(URI uri) implements ParsedUrl {}
         record Rejected(String reason) implements ParsedUrl {}
     }
 
     /** Result of {@link #resolve}: either pass-through or a rejection. */
-    sealed interface ResolvedUrl {
+    public sealed interface ResolvedUrl {
         record Ok() implements ResolvedUrl {}
         record DnsFailure(String host) implements ResolvedUrl {}
         record Disallowed(String reason) implements ResolvedUrl {}
     }
 
-    static ParsedUrl parse(String raw) {
+    public static ParsedUrl parse(String raw) {
         if (raw == null) return new ParsedUrl.Rejected("URL is required.");
         String trimmed = raw.trim();
         // Discord users often paste URLs wrapped in <> to suppress embeds.
@@ -91,17 +98,16 @@ final class UrlGuard {
     }
 
     /**
-     * Resolves the URL's host and rejects any address that's loopback,
-     * link-local, RFC 1918 / IPv6 ULA, multicast, or the wildcard. Returns
-     * {@link ResolvedUrl.Ok} only when <em>every</em> resolved address
+     * Resolves the URL's host and rejects any address in a deny-listed range.
+     * Returns {@link ResolvedUrl.Ok} only when <em>every</em> resolved address
      * passes.
      */
-    static ResolvedUrl resolve(URI uri) {
+    public static ResolvedUrl resolve(URI uri) {
         return resolve(uri, UrlGuard::lookup);
     }
 
     /** Test seam: lets unit tests inject fake DNS results without hitting the network. */
-    static ResolvedUrl resolve(URI uri, java.util.function.Function<String, InetAddress[]> resolver) {
+    public static ResolvedUrl resolve(URI uri, java.util.function.Function<String, InetAddress[]> resolver) {
         String host = uri.getHost();
         InetAddress[] addresses;
         try {
@@ -127,16 +133,35 @@ final class UrlGuard {
      * {@code null} if the address is acceptable. Each category corresponds
      * to a real-world SSRF target: loopback (own host), link-local
      * (cloud-metadata services like {@code 169.254.169.254}), site-local
-     * (corporate intranets), IPv6 ULA (the IPv6 equivalent of RFC 1918),
-     * multicast and wildcard (administrative addresses).
+     * (corporate intranets), carrier-grade NAT (ISP-internal space that
+     * routes but shouldn't be probed), IETF protocol assignments and
+     * benchmarking ranges (neither is legitimate fetch territory), IPv6 ULA
+     * (the IPv6 equivalent of RFC 1918), multicast and wildcard
+     * (administrative addresses).
+     *
+     * <p>Decimal ({@code 2130706433}) and IPv4-mapped-IPv6
+     * ({@code [::ffff:127.0.0.1]}) spellings need no special handling —
+     * {@link InetAddress} normalises both before this method sees them.
      */
-    static String denyReason(InetAddress addr) {
+    public static String denyReason(InetAddress addr) {
         if (addr.isAnyLocalAddress())   return "wildcard address";
         if (addr.isLoopbackAddress())   return "loopback address";
         if (addr.isLinkLocalAddress())  return "link-local address";
         if (addr.isSiteLocalAddress())  return "private (RFC 1918) address";
         if (addr.isMulticastAddress())  return "multicast address";
         if (isIpv6UniqueLocal(addr))    return "IPv6 unique-local address";
+
+        byte[] v4 = ipv4Bytes(addr);
+        if (v4 != null) {
+            int a = v4[0] & 0xFF;
+            int b = v4[1] & 0xFF;
+            // 100.64.0.0/10 — carrier-grade NAT (RFC 6598).
+            if (a == 100 && b >= 64 && b <= 127) return "carrier-grade NAT address";
+            // 192.0.0.0/24 — IETF protocol assignments (RFC 6890).
+            if (a == 192 && b == 0 && (v4[2] & 0xFF) == 0) return "IETF protocol assignment address";
+            // 198.18.0.0/15 — benchmarking (RFC 2544).
+            if (a == 198 && (b == 18 || b == 19)) return "benchmarking address";
+        }
         return null;
     }
 
@@ -152,7 +177,32 @@ final class UrlGuard {
         return (bytes[0] & 0xFE) == 0xFC;
     }
 
-    private static InetAddress[] lookup(String host) {
+    /**
+     * The four IPv4 bytes of {@code addr}, or null if it isn't IPv4. Handles
+     * the IPv4-mapped IPv6 form ({@code ::ffff:a.b.c.d}) too — Java usually
+     * hands those back as {@link Inet4Address} already, but an
+     * {@link Inet6Address} carrying a mapped address would otherwise skip
+     * every IPv4 range check below.
+     */
+    private static byte[] ipv4Bytes(InetAddress addr) {
+        if (addr instanceof Inet4Address) return addr.getAddress();
+        byte[] bytes = addr.getAddress();
+        if (bytes.length != 16) return null;
+        for (int i = 0; i < 10; i++) {
+            if (bytes[i] != 0) return null;
+        }
+        if ((bytes[10] & 0xFF) != 0xFF || (bytes[11] & 0xFF) != 0xFF) return null;
+        return new byte[] { bytes[12], bytes[13], bytes[14], bytes[15] };
+    }
+
+    /**
+     * The production resolver: a real DNS lookup. Exposed so callers that
+     * thread a resolver through several layers (see {@link SafeHttp}) have a
+     * default to pass, and so tests can substitute a fake one.
+     *
+     * @throws DnsFailureException if the host doesn't resolve
+     */
+    public static InetAddress[] systemResolver(String host) {
         try {
             return InetAddress.getAllByName(host);
         } catch (UnknownHostException e) {
@@ -160,8 +210,12 @@ final class UrlGuard {
         }
     }
 
-    /** Internal sentinel; never escapes the package. */
-    static final class DnsFailureException extends RuntimeException {
-        DnsFailureException() { super(null, null, false, false); }
+    private static InetAddress[] lookup(String host) {
+        return systemResolver(host);
+    }
+
+    /** Internal sentinel; never escapes this class. */
+    public static final class DnsFailureException extends RuntimeException {
+        public DnsFailureException() { super(null, null, false, false); }
     }
 }

--- a/src/main/java/ca/ryanmorrison/chatterbox/common/permissions/Permissions.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/common/permissions/Permissions.java
@@ -38,6 +38,9 @@ public final class Permissions {
      * button handler entry points.
      */
     public static boolean canManageMessages(IReplyCallback event) {
+        // getGuildChannel() throws outside a guild rather than returning null,
+        // so the guild check has to come first.
+        if (!event.isFromGuild()) return false;
         return canManageMessages(event.getMember(), event.getGuildChannel());
     }
 
@@ -51,6 +54,14 @@ public final class Permissions {
      * actually tells the user why.
      */
     public static boolean requireManageMessages(IReplyCallback event) {
+        // isFromGuild() first: getGuildChannel() throws IllegalStateException in
+        // a DM rather than returning null, so reading it up front made the
+        // rejection below unreachable and let the exception escape the listener
+        // instead.
+        if (!event.isFromGuild()) {
+            event.reply(NOT_A_GUILD_MESSAGE).setEphemeral(true).queue();
+            return false;
+        }
         Member member = event.getMember();
         GuildChannel channel = event.getGuildChannel();
         if (member == null || channel == null) {

--- a/src/main/java/ca/ryanmorrison/chatterbox/config/Config.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/config/Config.java
@@ -1,15 +1,47 @@
 package ca.ryanmorrison.chatterbox.config;
 
+/**
+ * Startup configuration, read once from the environment.
+ *
+ * <p>Note that {@code CHATTERBOX_LOG_LEVEL} is deliberately absent: logback
+ * reads that variable directly (see {@code logback.xml}), so carrying it here
+ * as well only created a field nothing ever read.
+ */
 public record Config(
         String discordToken,
         boolean devMode,
         DatabaseConfig database,
-        HttpConfig http,
-        String logLevel) {
+        HttpConfig http) {
+
+    /**
+     * Overridden because the generated record toString would print the bot
+     * token verbatim. This record is embedded in the InitContext handed to
+     * every module, so a single {@code log.debug("ctx={}", ctx)} in any module
+     * — including a third-party one — would leak it.
+     */
+    @Override
+    public String toString() {
+        return "Config[discordToken=***, devMode=" + devMode
+                + ", database=" + database + ", http=" + http + "]";
+    }
 
     public record DatabaseConfig(String url, String user, String password) {
         public boolean isPostgres() { return url.startsWith("jdbc:postgresql:"); }
         public boolean isSqlite()   { return url.startsWith("jdbc:sqlite:"); }
+
+        /**
+         * Same reasoning as {@link Config#toString()}: never print the
+         * password. The URL is masked too, since credentials can be embedded
+         * in it as {@code //user:pass@host} rather than passed separately.
+         */
+        @Override
+        public String toString() {
+            return "DatabaseConfig[url=" + maskUserInfo(url) + ", user=" + user + ", password=***]";
+        }
+
+        private static String maskUserInfo(String url) {
+            return url == null ? "" : url.replaceAll("(?i)(//[^/@:]+):[^/@]*@", "$1:***@");
+        }
     }
 
     public record HttpConfig(int port) {}
@@ -22,7 +54,6 @@ public record Config(
         String token = required(env, "CHATTERBOX_DISCORD_TOKEN");
         String dbUrl = required(env, "CHATTERBOX_DB_URL");
         boolean devMode = Boolean.parseBoolean(envOrDefault(env, "CHATTERBOX_DEV_MODE", "false"));
-        String logLevel = envOrDefault(env, "CHATTERBOX_LOG_LEVEL", "INFO");
         int httpPort = parsePort(envOrDefault(env, "CHATTERBOX_HTTP_PORT", "8080"));
 
         var db = new DatabaseConfig(
@@ -30,7 +61,7 @@ public record Config(
                 envOrDefault(env, "CHATTERBOX_DB_USER", ""),
                 envOrDefault(env, "CHATTERBOX_DB_PASSWORD", ""));
 
-        return new Config(token, devMode, db, new HttpConfig(httpPort), logLevel);
+        return new Config(token, devMode, db, new HttpConfig(httpPort));
     }
 
     private static int parsePort(String raw) {

--- a/src/main/java/ca/ryanmorrison/chatterbox/config/runtime/RuntimeConfig.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/config/runtime/RuntimeConfig.java
@@ -8,6 +8,7 @@ import java.time.OffsetDateTime;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 
 /**
@@ -36,6 +37,15 @@ import java.util.function.Function;
  * busy channels); writes happen on the slash-command handler thread.
  * The cache map handles concurrency; the per-guild value map is built
  * fresh inside {@link #cacheFor(long)} and never mutated after publication.
+ *
+ * <p>The load deliberately runs <em>outside</em> the map's lock. Doing it
+ * inside {@code computeIfAbsent} held a ConcurrentHashMap bin lock across a
+ * database round-trip, so every other guild hashing to the same bin stalled
+ * behind it — on SQLite, where the pool is a single connection, for up to
+ * Hikari's connection timeout. A publish-if-unchanged counter
+ * ({@link #invalidations}) preserves what that lock used to give for free:
+ * a snapshot loaded before a concurrent {@code set} is discarded rather than
+ * published over the newer value.
  */
 public final class RuntimeConfig {
 
@@ -46,8 +56,21 @@ public final class RuntimeConfig {
     private final Function<String, String> envLookup;
     private final Clock clock;
 
-    /** Per-guild snapshot of override rows. Null map value means "not yet loaded". */
-    private final ConcurrentHashMap<Long, Map<String, String>> cache = new ConcurrentHashMap<>();
+    /**
+     * Per-guild snapshot of override rows. Absence of the key means "not yet
+     * loaded" — a ConcurrentHashMap cannot hold null values, so there is no
+     * null-means-unloaded state to check for.
+     */
+    private final ConcurrentHashMap<Long, Snapshot> cache = new ConcurrentHashMap<>();
+
+    /**
+     * Bumped by every {@link #invalidate(long)}. A load that started before the
+     * bump is not allowed to publish, which is what stops a slow read from
+     * resurrecting a value that {@code /config set} just replaced. Global
+     * rather than per-guild: writes are rare, so the occasional redundant
+     * re-load on an unrelated guild is cheaper than tracking versions per key.
+     */
+    private final AtomicLong invalidations = new AtomicLong();
 
     public RuntimeConfig(ConfigRegistry registry,
                          RuntimeConfigRepository repository,
@@ -116,12 +139,41 @@ public final class RuntimeConfig {
 
     /** Drops cached per-guild overrides; next read re-loads. */
     public void invalidate(long guildId) {
+        // Bump before removing, not after: a loader that finishes in between
+        // would otherwise see an unchanged counter and publish its stale
+        // snapshot straight back into the map.
+        invalidations.incrementAndGet();
         cache.remove(guildId);
     }
 
     private Map<String, String> cacheFor(long guildId) {
-        return cache.computeIfAbsent(guildId, repository::findAllForGuild);
+        Snapshot cached = cache.get(guildId);
+        if (cached != null) return cached.values();
+
+        long observed = invalidations.get();
+        Map<String, String> loaded;
+        try {
+            loaded = Map.copyOf(repository.findAllForGuild(guildId));
+        } catch (RuntimeException e) {
+            // Same tolerance as tryParse below: a database blip on this path
+            // would otherwise propagate into a JDA listener thread and kill
+            // message handling. Fall through to env vars and defaults, and
+            // don't cache the failure.
+            log.warn("Couldn't load runtime config for guild {}; using env/defaults: {}",
+                    guildId, e.toString());
+            return Map.of();
+        }
+
+        cache.compute(guildId, (k, existing) -> {
+            if (existing != null) return existing;                  // another thread won the race
+            if (invalidations.get() != observed) return null;       // invalidated mid-load; drop it
+            return new Snapshot(loaded);
+        });
+        return loaded;
     }
+
+    /** Immutable published snapshot of one guild's override rows. */
+    private record Snapshot(Map<String, String> values) {}
 
     /**
      * Tolerant parse for read paths: a stored value that's somehow invalid

--- a/src/main/java/ca/ryanmorrison/chatterbox/config/runtime/RuntimeConfigRepository.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/config/runtime/RuntimeConfigRepository.java
@@ -5,7 +5,6 @@ import org.jooq.DSLContext;
 import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 import static ca.ryanmorrison.chatterbox.db.generated.Tables.RUNTIME_CONFIG;
 
@@ -24,15 +23,6 @@ public final class RuntimeConfigRepository {
 
     public RuntimeConfigRepository(DSLContext dsl) {
         this.dsl = dsl;
-    }
-
-    /** Raw stored value for {@code (guildId, key)}, or empty if none. */
-    public Optional<String> findValue(long guildId, String key) {
-        return dsl.select(RUNTIME_CONFIG.VALUE)
-                .from(RUNTIME_CONFIG)
-                .where(RUNTIME_CONFIG.GUILD_ID.eq(guildId))
-                .and(RUNTIME_CONFIG.KEY.eq(key))
-                .fetchOptional(RUNTIME_CONFIG.VALUE);
     }
 
     /** Every override for {@code guildId} as a {key → raw value} map; empty if none. */

--- a/src/main/java/ca/ryanmorrison/chatterbox/db/Database.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/db/Database.java
@@ -26,8 +26,10 @@ public final class Database implements AutoCloseable {
     private final SQLDialect dialect;
 
     public Database(Config.DatabaseConfig config) {
-        this.dataSource = buildPool(config);
+        // Dialect first: an unsupported URL should fail with our redacted
+        // message, not with Hikari's, which echoes the raw jdbcUrl.
         this.dialect = dialectFor(config);
+        this.dataSource = buildPool(config);
         this.dsl = DSL.using(dataSource, dialect, settingsFor(dialect));
         log.info("Database initialised: {}", redact(config.url()));
     }
@@ -44,18 +46,41 @@ public final class Database implements AutoCloseable {
         return dialect;
     }
 
+    /** Hikari's default is 30s, which is far too long to block a JDA listener thread. */
+    private static final long CONNECTION_TIMEOUT_MS = 5_000L;
+    /**
+     * Warn about a connection held this long. Without it, a handler that leaks
+     * a connection deadlocks the bot permanently and silently — on SQLite the
+     * pool is a single connection, so one leak is total.
+     */
+    private static final long LEAK_DETECTION_MS = 20_000L;
+
     private static HikariDataSource buildPool(Config.DatabaseConfig cfg) {
         var hc = new HikariConfig();
         hc.setJdbcUrl(cfg.url());
         if (!cfg.user().isEmpty())     hc.setUsername(cfg.user());
         if (!cfg.password().isEmpty()) hc.setPassword(cfg.password());
         hc.setPoolName("chatterbox-pool");
+        hc.setConnectionTimeout(CONNECTION_TIMEOUT_MS);
+        hc.setLeakDetectionThreshold(LEAK_DETECTION_MS);
         if (cfg.isSqlite()) {
             // SQLite serialises writes; one connection is the safe default.
             hc.setMaximumPoolSize(1);
-            // SQLite has foreign keys disabled per-connection by default;
-            // re-enable on every Hikari-issued connection so ON DELETE CASCADE works.
-            hc.setConnectionInitSql("PRAGMA foreign_keys = ON");
+            // Everything funnels through that one connection: Jetty request
+            // threads, every JDA listener thread, and the RSS refresh pool.
+            //   - foreign_keys: off per-connection by default in SQLite, so
+            //     ON DELETE CASCADE needs it re-enabled on every connection.
+            //   - journal_mode=WAL: lets reads proceed during a write.
+            //   - busy_timeout: wait for a lock rather than failing instantly
+            //     with SQLITE_BUSY.
+            //
+            // Passed as driver properties, not as connectionInitSql: sqlite-jdbc
+            // executes only the first statement of a multi-statement string, so
+            // an init of "PRAGMA a; PRAGMA b; PRAGMA c" silently applies just
+            // the first and leaves the rest at their defaults.
+            hc.addDataSourceProperty("foreign_keys", "true");
+            hc.addDataSourceProperty("journal_mode", "WAL");
+            hc.addDataSourceProperty("busy_timeout", "5000");
         }
         return new HikariDataSource(hc);
     }
@@ -73,11 +98,24 @@ public final class Database implements AutoCloseable {
     private static SQLDialect dialectFor(Config.DatabaseConfig cfg) {
         if (cfg.isPostgres()) return SQLDialect.POSTGRES;
         if (cfg.isSqlite())   return SQLDialect.SQLITE;
-        throw new IllegalArgumentException("Unsupported JDBC URL: " + cfg.url());
+        // Redacted: this message reaches the log via Main's fatal-error handler,
+        // and the raw URL may carry credentials.
+        throw new IllegalArgumentException("Unsupported JDBC URL: " + redact(cfg.url()));
     }
 
-    private static String redact(String url) {
-        return url.replaceAll("(?i)(password=)[^&;]*", "$1***");
+    /**
+     * Masks credentials in a JDBC URL. Covers both spellings that carry them:
+     * the {@code password=} query parameter and the {@code //user:pass@host}
+     * userinfo form, which the original pattern missed entirely.
+     *
+     * <p>Visible for testing.
+     */
+    static String redact(String url) {
+        if (url == null) return "";
+        String out = url.replaceAll("(?i)(password=)[^&;]*", "$1***");
+        // scheme://user:secret@host -> scheme://user:***@host
+        out = out.replaceAll("(?i)(//[^/@:]+):[^/@]*@", "$1:***@");
+        return out;
     }
 
     @Override

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/autoreply/AutoReplyMatcher.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/autoreply/AutoReplyMatcher.java
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
@@ -25,9 +26,23 @@ final class AutoReplyMatcher {
 
     static final long DEFAULT_TIMEOUT_MILLIS = 100L;
 
+    /**
+     * Ceiling on cached channels. The cache previously grew an entry for every
+     * channel that ever received a message — including the overwhelming
+     * majority with no rules at all — and {@link #invalidate(long)} only fires
+     * on a write, so deleted channels stayed forever.
+     */
+    static final int MAX_CACHED_CHANNELS = 1_000;
+
     private final AutoReplyRepository repo;
     private final long timeoutMillis;
     private final ConcurrentHashMap<Long, List<CompiledRule>> cache = new ConcurrentHashMap<>();
+
+    /**
+     * Bumped by every {@link #invalidate(long)} so a load that began before a
+     * write can't publish its stale compilation. See {@link #rulesFor}.
+     */
+    private final AtomicLong invalidations = new AtomicLong();
 
     AutoReplyMatcher(AutoReplyRepository repo) {
         this(repo, DEFAULT_TIMEOUT_MILLIS);
@@ -40,15 +55,24 @@ final class AutoReplyMatcher {
 
     /** Returns the response of the first rule whose pattern matches, or empty. */
     Optional<String> firstMatch(long channelId, String content) {
-        List<CompiledRule> rules = cache.computeIfAbsent(channelId, this::loadAndCompile);
+        List<CompiledRule> rules = rulesFor(channelId);
+        // One budget for the whole message, not one per rule. Per-rule
+        // deadlines meant N pathological rules cost N x timeout on a JDA
+        // gateway thread for every message, and nothing caps rules per channel.
+        long deadline = WatchdogCharSequence.deadlineFrom(timeoutMillis);
         for (CompiledRule rule : rules) {
             try {
-                var input = WatchdogCharSequence.wrap(content, timeoutMillis);
+                var input = WatchdogCharSequence.wrapUntil(content, deadline);
                 if (rule.pattern().matcher(input).find()) {
                     return Optional.of(rule.response());
                 }
             } catch (WatchdogCharSequence.RegexTimeoutException e) {
-                log.warn("Regex timeout for rule {} in channel {}; skipping.", rule.id(), channelId);
+                // The budget covers the message, so it's spent — stop rather
+                // than letting the remaining rules each start a fresh match
+                // that will immediately time out too.
+                log.warn("Regex budget exhausted at rule {} in channel {}; skipping the rest.",
+                        rule.id(), channelId);
+                return Optional.empty();
             }
         }
         return Optional.empty();
@@ -56,7 +80,54 @@ final class AutoReplyMatcher {
 
     /** Drops the cached compilation for {@code channelId}, forcing a refresh on next match. */
     void invalidate(long channelId) {
+        // Bump before removing so a load in flight can't republish stale rules.
+        invalidations.incrementAndGet();
         cache.remove(channelId);
+    }
+
+    /**
+     * Cached rules for {@code channelId}, loading outside the map's lock.
+     *
+     * <p>The load used to sit inside {@code computeIfAbsent}, which holds a
+     * ConcurrentHashMap bin lock for the duration — a database round-trip on
+     * the message hot path, blocking every other channel in the same bin.
+     */
+    private List<CompiledRule> rulesFor(long channelId) {
+        List<CompiledRule> cached = cache.get(channelId);
+        if (cached != null) return cached;
+
+        long observed = invalidations.get();
+        List<CompiledRule> loaded;
+        try {
+            loaded = loadAndCompile(channelId);
+        } catch (RuntimeException e) {
+            // A database blip must not take down message handling; skip
+            // auto-replies for this message and try again on the next one.
+            log.warn("Couldn't load auto-reply rules for channel {}: {}", channelId, e.toString());
+            return List.of();
+        }
+
+        evictIfFull();
+        cache.compute(channelId, (k, existing) -> {
+            if (existing != null) return existing;
+            if (invalidations.get() != observed) return null;
+            return loaded;
+        });
+        return loaded;
+    }
+
+    /**
+     * Keeps the cache under {@link #MAX_CACHED_CHANNELS}. Eviction order is
+     * arbitrary — ConcurrentHashMap has none to offer — which is fine because
+     * a dropped entry costs one re-load and nothing depends on which one goes.
+     */
+    private void evictIfFull() {
+        if (cache.size() < MAX_CACHED_CHANNELS) return;
+        var it = cache.keySet().iterator();
+        while (cache.size() >= MAX_CACHED_CHANNELS && it.hasNext()) {
+            it.next();
+            it.remove();
+        }
     }
 
     private List<CompiledRule> loadAndCompile(long channelId) {

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/autoreply/WatchdogCharSequence.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/autoreply/WatchdogCharSequence.java
@@ -20,8 +20,20 @@ final class WatchdogCharSequence implements CharSequence {
     private final long deadlineNanos;
 
     static WatchdogCharSequence wrap(CharSequence delegate, long timeoutMillis) {
-        return new WatchdogCharSequence(delegate,
-                System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillis));
+        return wrapUntil(delegate, deadlineFrom(timeoutMillis));
+    }
+
+    /** An absolute {@link System#nanoTime()} deadline {@code timeoutMillis} from now. */
+    static long deadlineFrom(long timeoutMillis) {
+        return System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillis);
+    }
+
+    /**
+     * Wraps against a deadline the caller owns, so one budget can span several
+     * matches (see {@link AutoReplyMatcher#firstMatch}).
+     */
+    static WatchdogCharSequence wrapUntil(CharSequence delegate, long deadlineNanos) {
+        return new WatchdogCharSequence(delegate, deadlineNanos);
     }
 
     private WatchdogCharSequence(CharSequence delegate, long deadlineNanos) {
@@ -34,7 +46,10 @@ final class WatchdogCharSequence implements CharSequence {
 
     @Override
     public char charAt(int index) {
-        if (System.nanoTime() > deadlineNanos) throw new RegexTimeoutException();
+        // Subtract-then-compare, not a direct >. nanoTime()'s origin is
+        // arbitrary and the value can wrap, and a wrapped comparison would
+        // either fire instantly or never fire at all.
+        if (System.nanoTime() - deadlineNanos > 0) throw new RegexTimeoutException();
         return delegate.charAt(index);
     }
 

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/decide/DecideModule.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/decide/DecideModule.java
@@ -9,6 +9,7 @@ import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
 
 import java.util.EnumSet;
@@ -35,15 +36,27 @@ public final class DecideModule extends ListenerAdapter implements Module {
 
     private static final int MAX_FROM_LINE_LENGTH = 1500;
 
+    /** Discord rejects message bodies over this; exceeding it throws on reply. */
+    static final int MAX_MESSAGE_LENGTH = 2000;
+
+    /**
+     * Ceiling on the options string. Without it Discord's own 6000-char default
+     * applies, and a single whitespace-free option that long produced a reply
+     * of ~6009 chars: {@code options.size() == 1} skips the truncated "from"
+     * line entirely, so nothing else bounded the output.
+     */
+    static final int MAX_OPTIONS_LENGTH = 1000;
+
     @Override public String name() { return "decide"; }
 
     @Override
     public List<SlashCommandData> slashCommands(InitContext ctx) {
         return List.of(Commands.slash(COMMAND, "Pick one of several options at random.")
-                .addOption(OptionType.STRING, OPT_OPTIONS,
-                        "Options separated by whitespace, or use the word \"or\" between them.", true)
-                .addOption(OptionType.BOOLEAN, OPT_PRIVATE,
-                        "Show the result only to you instead of the channel.", false));
+                .addOptions(new OptionData(OptionType.STRING, OPT_OPTIONS,
+                                "Options separated by whitespace, or use the word \"or\" between them.", true)
+                                .setMaxLength(MAX_OPTIONS_LENGTH),
+                        new OptionData(OptionType.BOOLEAN, OPT_PRIVATE,
+                                "Show the result only to you instead of the channel.", false)));
     }
 
     @Override
@@ -88,6 +101,18 @@ public final class DecideModule extends ListenerAdapter implements Module {
             }
             sb.append("\n_(from: ").append(joined).append(")_");
         }
-        return sb.toString();
+        // Backstop on the rendered result, not just the input: the option cap
+        // bounds what a user can type, but this is what Discord actually
+        // measures, and it throws rather than truncating.
+        return truncate(sb.toString(), MAX_MESSAGE_LENGTH);
+    }
+
+    private static String truncate(String s, int max) {
+        if (s.length() <= max) return s;
+        // Never split a surrogate pair — emoji in an option would otherwise
+        // leave a lone surrogate and render as a replacement character.
+        int end = max - 1;
+        if (Character.isHighSurrogate(s.charAt(end - 1))) end--;
+        return s.substring(0, end) + "…";
     }
 }

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/format/FormatModule.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/format/FormatModule.java
@@ -30,7 +30,15 @@ public final class FormatModule extends ListenerAdapter implements Module {
     static final String OPT_TEXT    = "text";
     static final String OPT_PRIVATE = "private";
 
-    /** Discord caps message bodies at 2000 chars; cap the input to leave headroom. */
+    /** Discord caps message bodies at 2000 chars; exceeding it throws on reply. */
+    static final int MAX_MESSAGE_LENGTH = 2000;
+
+    /**
+     * Input cap. Not sufficient on its own: styles expand, so the output is
+     * what actually has to be bounded — {@code clap} replaces every whitespace
+     * run with {@code " 👏 "} (4 UTF-16 units), turning 750 single-character
+     * words into ~3750 chars from a 1500-char input.
+     */
     static final int MAX_INPUT_LENGTH = 1500;
 
     @Override public String name() { return "format"; }
@@ -79,7 +87,7 @@ public final class FormatModule extends ListenerAdapter implements Module {
         if (text.length() > MAX_INPUT_LENGTH) {
             text = text.substring(0, MAX_INPUT_LENGTH);
         }
-        String formatted = style.apply(text);
+        String formatted = truncate(style.apply(text), MAX_MESSAGE_LENGTH);
         if (formatted.isEmpty()) {
             event.reply("Give me something with at least one character to work with.")
                     .setEphemeral(true).queue();
@@ -93,5 +101,15 @@ public final class FormatModule extends ListenerAdapter implements Module {
                 .setEphemeral(ephemeral)
                 .setAllowedMentions(EnumSet.noneOf(Message.MentionType.class))
                 .queue();
+    }
+
+    static String truncate(String s, int max) {
+        if (s.length() <= max) return s;
+        // Styles emit emoji (clap) and astral-plane characters (fullwidth), so
+        // a blind substring can split a surrogate pair and leave a lone
+        // surrogate that renders as a replacement character.
+        int end = max - 1;
+        if (Character.isHighSurrogate(s.charAt(end - 1))) end--;
+        return s.substring(0, end) + "…";
     }
 }

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/frinkiac/FrinkiacClient.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/frinkiac/FrinkiacClient.java
@@ -1,5 +1,6 @@
 package ca.ryanmorrison.chatterbox.features.frinkiac;
 
+import ca.ryanmorrison.chatterbox.common.net.HttpClients;
 import ca.ryanmorrison.chatterbox.common.net.BoundedBody;
 import ca.ryanmorrison.chatterbox.features.frinkiac.dto.SearchResult;
 import tools.jackson.core.JacksonException;
@@ -175,4 +176,10 @@ final class FrinkiacClient {
     static final class FrinkiacException extends Exception {
         FrinkiacException(String message) { super(message); }
     }
+
+    /** Releases the HTTP client's selector thread and executor. */
+    void close() {
+        HttpClients.closeQuietly(http);
+    }
+
 }

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/frinkiac/FrinkiacClient.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/frinkiac/FrinkiacClient.java
@@ -1,5 +1,6 @@
 package ca.ryanmorrison.chatterbox.features.frinkiac;
 
+import ca.ryanmorrison.chatterbox.common.net.BoundedBody;
 import ca.ryanmorrison.chatterbox.features.frinkiac.dto.SearchResult;
 import tools.jackson.core.JacksonException;
 import tools.jackson.core.type.TypeReference;
@@ -8,6 +9,7 @@ import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.net.http.HttpClient;
@@ -139,9 +141,9 @@ final class FrinkiacClient {
                 .header("Accept", "application/json,image/*;q=0.9,*/*;q=0.5")
                 .GET()
                 .build();
-        HttpResponse<byte[]> resp;
+        HttpResponse<InputStream> resp;
         try {
-            resp = http.send(req, HttpResponse.BodyHandlers.ofByteArray());
+            resp = http.send(req, HttpResponse.BodyHandlers.ofInputStream());
         } catch (IOException e) {
             throw new FrinkiacException("Couldn't reach Frinkiac.");
         } catch (InterruptedException e) {
@@ -152,12 +154,19 @@ final class FrinkiacClient {
         if (status / 100 != 2) {
             throw new FrinkiacException("Frinkiac returned HTTP " + status + ".");
         }
-        byte[] body = resp.body();
-        if (body == null || body.length == 0) {
-            throw new FrinkiacException("Frinkiac returned an empty response.");
-        }
-        if (body.length > maxBytes) {
+        // Cap while streaming: ofByteArray would buffer the whole response
+        // before any size check could run. Matters most for the image
+        // endpoints, whose cap is 5 MB.
+        byte[] body;
+        try (InputStream in = resp.body()) {
+            body = BoundedBody.read(in, maxBytes);
+        } catch (BoundedBody.TooLargeException e) {
             throw new FrinkiacException("Frinkiac response was too large.");
+        } catch (IOException e) {
+            throw new FrinkiacException("Couldn't read the Frinkiac response.");
+        }
+        if (body.length == 0) {
+            throw new FrinkiacException("Frinkiac returned an empty response.");
         }
         return body;
     }

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/frinkiac/FrinkiacModule.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/frinkiac/FrinkiacModule.java
@@ -20,6 +20,9 @@ public final class FrinkiacModule implements Module {
     static final String COMMAND = "frinkiac";
     static final String OPTION_QUERY = "query";
 
+    /** Retained so {@link #onStop()} can release its HTTP client. */
+    private volatile FrinkiacClient client;
+
     @Override public String name() { return "frinkiac"; }
 
     @Override
@@ -34,6 +37,15 @@ public final class FrinkiacModule implements Module {
 
     @Override
     public List<EventListener> listeners(InitContext ctx) {
-        return List.of(new FrinkiacHandler(new FrinkiacClient(), new FrinkiacSessions()));
+        FrinkiacClient c = new FrinkiacClient();
+        this.client = c;
+        return List.of(new FrinkiacHandler(c, new FrinkiacSessions()));
     }
+
+    @Override
+    public void onStop() {
+        FrinkiacClient c = client;
+        if (c != null) c.close();
+    }
+
 }

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/frinkiac/FrinkiacSessions.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/frinkiac/FrinkiacSessions.java
@@ -4,7 +4,6 @@ import ca.ryanmorrison.chatterbox.features.frinkiac.dto.SearchResult;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -32,8 +31,12 @@ final class FrinkiacSessions {
     UUID create(long requestedBy, long channelId, String query, List<SearchResult> hits) {
         evictExpired();
         UUID token = UUID.randomUUID();
+        // ConcurrentHashMap, not HashMap: writes go through computeIfPresent's
+        // bin lock, but captionFor() is reached via sessions.get() from the
+        // button handlers with no lock at all, so a read could race a resizing
+        // put and observe a torn table.
         sessions.put(token, new Session(requestedBy, channelId, query, hits,
-                /* index = */ 0, new HashMap<>(), Instant.now()));
+                /* index = */ 0, new ConcurrentHashMap<>(), Instant.now()));
         return token;
     }
 

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/isitdown/IsItDownChecker.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/isitdown/IsItDownChecker.java
@@ -1,5 +1,6 @@
 package ca.ryanmorrison.chatterbox.features.isitdown;
 
+import ca.ryanmorrison.chatterbox.common.net.HttpClients;
 import ca.ryanmorrison.chatterbox.common.net.SafeHttp;
 import ca.ryanmorrison.chatterbox.common.net.UrlGuard;
 import org.slf4j.Logger;
@@ -208,4 +209,10 @@ final class IsItDownChecker {
             total += n;
         }
     }
+
+    /** Releases the HTTP client's selector thread and executor. */
+    void close() {
+        HttpClients.closeQuietly(http);
+    }
+
 }

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/isitdown/IsItDownChecker.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/isitdown/IsItDownChecker.java
@@ -1,5 +1,7 @@
 package ca.ryanmorrison.chatterbox.features.isitdown;
 
+import ca.ryanmorrison.chatterbox.common.net.SafeHttp;
+import ca.ryanmorrison.chatterbox.common.net.UrlGuard;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -7,6 +9,7 @@ import javax.net.ssl.SSLException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.ConnectException;
+import java.net.InetAddress;
 import java.net.NoRouteToHostException;
 import java.net.URI;
 import java.net.UnknownHostException;
@@ -16,6 +19,7 @@ import java.net.http.HttpResponse;
 import java.net.http.HttpTimeoutException;
 import java.time.Duration;
 import java.util.Locale;
+import java.util.function.Function;
 
 /**
  * Probes a URL and classifies the outcome into a {@link CheckResult}.
@@ -27,7 +31,7 @@ import java.util.Locale;
  *   <li>{@code Range: bytes=0-1023} on the GET so well-behaved servers send
  *       only 1 KB; for servers that ignore the header, the body stream is
  *       read up to {@link #MAX_RESPONSE_BYTES} client-side and then closed.</li>
- *   <li>Redirects followed by the underlying client (so a typical
+ *   <li>Redirects followed by {@link SafeHttp} (so a typical
  *       {@code http → https} 301 still reports as live).</li>
  * </ul>
  *
@@ -37,9 +41,13 @@ import java.util.Locale;
  * the caller, so user-facing messages can be rendered safely.
  *
  * <h2>SSRF</h2>
- * The constructor expects a URI that has already passed {@link UrlGuard}'s
- * resolve check. The class itself does no extra deny-listing — keeping the
- * security check in one place avoids drift.
+ * The caller must hand us a URI that has already passed {@link UrlGuard}'s
+ * resolve check — that covers the first hop only. Redirects are <em>not</em>
+ * delegated to the HTTP client, because {@link HttpClient.Redirect#NORMAL}
+ * would follow a {@code 302} to a denied address without re-checking and
+ * defeat the guard outright. Instead the client is built with
+ * {@link HttpClient.Redirect#NEVER} and {@link SafeHttp} walks the chain,
+ * re-running the guard on every hop.
  */
 final class IsItDownChecker {
 
@@ -67,25 +75,40 @@ final class IsItDownChecker {
 
     private final HttpClient http;
     private final int requestTimeoutSeconds;
+    private final Function<String, InetAddress[]> resolver;
 
     IsItDownChecker() {
+        // NEVER, not NORMAL: SafeHttp follows redirects itself so each hop can
+        // be re-checked against UrlGuard.
         this(HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(CONNECT_TIMEOUT))
-                .followRedirects(HttpClient.Redirect.NORMAL)
+                .followRedirects(HttpClient.Redirect.NEVER)
                 .build(),
                 REQUEST_TIMEOUT);
     }
 
     /** Test seam — lets tests pass a client pointed at a local server and shorten the timeout. */
     IsItDownChecker(HttpClient http, int requestTimeoutSeconds) {
+        this(http, requestTimeoutSeconds, UrlGuard::systemResolver);
+    }
+
+    /**
+     * Test seam — additionally substitutes the resolver used to vet redirect
+     * targets, so tests can follow redirects on a loopback server without the
+     * deny-list rejecting every hop.
+     */
+    IsItDownChecker(HttpClient http, int requestTimeoutSeconds,
+                    Function<String, InetAddress[]> resolver) {
         this.http = http;
         this.requestTimeoutSeconds = requestTimeoutSeconds;
+        this.resolver = resolver;
     }
 
     /**
      * Probes {@code uri}. Pre-condition: {@code uri} must be syntactically
-     * valid and have already passed {@link UrlGuard#resolve}. Always returns
-     * a result; never throws checked exceptions to the caller.
+     * valid and have already passed {@link UrlGuard#resolve} — that covers the
+     * first hop; {@link SafeHttp} re-checks any redirect targets. Always
+     * returns a result; never throws checked exceptions to the caller.
      */
     CheckResult check(URI uri) {
         String host = uri.getHost();
@@ -113,7 +136,11 @@ final class IsItDownChecker {
         long startNs = System.nanoTime();
         HttpResponse<InputStream> resp;
         try {
-            resp = http.send(req, HttpResponse.BodyHandlers.ofInputStream());
+            resp = SafeHttp.send(http, req, HttpResponse.BodyHandlers.ofInputStream(), resolver);
+        } catch (SafeHttp.BlockedException e) {
+            // A redirect pointed somewhere the guard refuses. Report it the same
+            // way a blocked first hop is reported rather than as a generic error.
+            return new CheckResult.Disallowed(e.getMessage());
         } catch (HttpTimeoutException e) {
             return new CheckResult.Timeout(requestTimeoutSeconds);
         } catch (UnknownHostException e) {

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/isitdown/IsItDownHandler.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/isitdown/IsItDownHandler.java
@@ -1,5 +1,6 @@
 package ca.ryanmorrison.chatterbox.features.isitdown;
 
+import ca.ryanmorrison.chatterbox.common.net.UrlGuard;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/isitdown/IsItDownModule.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/isitdown/IsItDownModule.java
@@ -28,6 +28,9 @@ public final class IsItDownModule implements Module {
     static final String OPT_URL     = "url";
     static final String OPT_PRIVATE = "private";
 
+    /** Retained so {@link #onStop()} can release its HTTP client. */
+    private volatile IsItDownChecker checker;
+
     @Override public String name() { return "isitdown"; }
 
     @Override
@@ -42,6 +45,15 @@ public final class IsItDownModule implements Module {
 
     @Override
     public List<EventListener> listeners(InitContext ctx) {
-        return List.of(new IsItDownHandler(new IsItDownChecker()));
+        IsItDownChecker c = new IsItDownChecker();
+        this.checker = c;
+        return List.of(new IsItDownHandler(c));
     }
+
+    @Override
+    public void onStop() {
+        IsItDownChecker c = checker;
+        if (c != null) c.close();
+    }
+
 }

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/isitdown/IsItDownModule.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/isitdown/IsItDownModule.java
@@ -1,5 +1,6 @@
 package ca.ryanmorrison.chatterbox.features.isitdown;
 
+import ca.ryanmorrison.chatterbox.common.net.UrlGuard;
 import ca.ryanmorrison.chatterbox.module.InitContext;
 import ca.ryanmorrison.chatterbox.module.Module;
 import net.dv8tion.jda.api.hooks.EventListener;

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/nhl/NhlClient.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/nhl/NhlClient.java
@@ -1,5 +1,6 @@
 package ca.ryanmorrison.chatterbox.features.nhl;
 
+import ca.ryanmorrison.chatterbox.common.net.HttpClients;
 import ca.ryanmorrison.chatterbox.common.net.BoundedBody;
 import ca.ryanmorrison.chatterbox.features.nhl.dto.Game;
 import ca.ryanmorrison.chatterbox.features.nhl.dto.GameDay;
@@ -165,4 +166,10 @@ final class NhlClient {
     static final class NhlException extends Exception {
         NhlException(String message) { super(message); }
     }
+
+    /** Releases the HTTP client's selector thread and executor. */
+    void close() {
+        HttpClients.closeQuietly(http);
+    }
+
 }

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/nhl/NhlClient.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/nhl/NhlClient.java
@@ -1,5 +1,6 @@
 package ca.ryanmorrison.chatterbox.features.nhl;
 
+import ca.ryanmorrison.chatterbox.common.net.BoundedBody;
 import ca.ryanmorrison.chatterbox.features.nhl.dto.Game;
 import ca.ryanmorrison.chatterbox.features.nhl.dto.GameDay;
 import ca.ryanmorrison.chatterbox.features.nhl.dto.ScheduleResponse;
@@ -10,6 +11,7 @@ import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -122,9 +124,9 @@ final class NhlClient {
                 .header("Accept", "application/json")
                 .GET()
                 .build();
-        HttpResponse<byte[]> resp;
+        HttpResponse<InputStream> resp;
         try {
-            resp = http.send(req, HttpResponse.BodyHandlers.ofByteArray());
+            resp = http.send(req, HttpResponse.BodyHandlers.ofInputStream());
         } catch (IOException e) {
             throw new NhlException("Couldn't reach the NHL API.");
         } catch (InterruptedException e) {
@@ -139,12 +141,18 @@ final class NhlClient {
         if (status / 100 != 2) {
             throw new NhlException("The NHL API returned HTTP " + status + ".");
         }
-        byte[] body = resp.body();
-        if (body == null || body.length == 0) {
-            throw new NhlException("The NHL API returned an empty response.");
-        }
-        if (body.length > MAX_RESPONSE_BYTES) {
+        // Cap while streaming: ofByteArray would buffer the whole response
+        // before any size check could run.
+        byte[] body;
+        try (InputStream in = resp.body()) {
+            body = BoundedBody.read(in, MAX_RESPONSE_BYTES);
+        } catch (BoundedBody.TooLargeException e) {
             throw new NhlException("The NHL API response was too large.");
+        } catch (IOException e) {
+            throw new NhlException("Couldn't read the NHL API response.");
+        }
+        if (body.length == 0) {
+            throw new NhlException("The NHL API returned an empty response.");
         }
         try {
             return mapper.readValue(body, type);

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/nhl/NhlModule.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/nhl/NhlModule.java
@@ -24,6 +24,9 @@ public final class NhlModule implements Module {
     static final String SUBCOMMAND_SCHEDULE = "schedule";
     static final String OPTION_TEAM = "team";
 
+    /** Retained so {@link #onStop()} can release its HTTP client. */
+    private volatile NhlClient client;
+
     @Override public String name() { return "nhl"; }
 
     @Override
@@ -40,6 +43,15 @@ public final class NhlModule implements Module {
 
     @Override
     public List<EventListener> listeners(InitContext ctx) {
-        return List.of(new NhlHandler(new NhlClient()));
+        NhlClient c = new NhlClient();
+        this.client = c;
+        return List.of(new NhlHandler(c));
     }
+
+    @Override
+    public void onStop() {
+        NhlClient c = client;
+        if (c != null) c.close();
+    }
+
 }

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/rss/RssFetcher.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/rss/RssFetcher.java
@@ -1,5 +1,7 @@
 package ca.ryanmorrison.chatterbox.features.rss;
 
+import ca.ryanmorrison.chatterbox.common.net.SafeHttp;
+import ca.ryanmorrison.chatterbox.common.net.UrlGuard;
 import com.rometools.rome.feed.synd.SyndEntry;
 import com.rometools.rome.feed.synd.SyndFeed;
 import com.rometools.rome.io.FeedException;
@@ -8,15 +10,18 @@ import org.jsoup.parser.Parser;
 import org.xml.sax.InputSource;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetAddress;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.List;
 import java.util.Locale;
+import java.util.function.Function;
 
 /**
  * Loads and parses an RSS or Atom feed using the JDK HTTP client and Rome.
@@ -28,9 +33,16 @@ import java.util.Locale;
  *   <li>{@link #fetch} — used by the scheduler each refresh tick.
  * </ul>
  *
- * <p>Bounded for safety: 10s connect/response timeout, 2 MB max body, max 5
- * redirects, fixed {@code User-Agent}. Parsing happens in-memory from the
- * already-bounded byte array.
+ * <p>Bounded for safety: 10s connect/response timeout, 2 MB max body enforced
+ * <em>while streaming</em>, max 5 redirects, fixed {@code User-Agent}.
+ *
+ * <h2>SSRF</h2>
+ * The URL here is supplied by a Discord user, so every fetch runs through
+ * {@link UrlGuard} — on the initial URL and, via {@link SafeHttp}, on every
+ * redirect hop. The guard runs on {@link #fetch} as well as {@link #validate}:
+ * a host that was public when the feed was added can start resolving to a
+ * private address later, and the scheduler would otherwise keep fetching it
+ * every refresh tick.
  */
 final class RssFetcher {
 
@@ -39,17 +51,39 @@ final class RssFetcher {
     static final String USER_AGENT = "Chatterbox/0.1 (+RSS)";
 
     private final HttpClient http;
+    private final Function<String, InetAddress[]> resolver;
 
     RssFetcher() {
-        this(HttpClient.newBuilder()
-                .connectTimeout(HTTP_TIMEOUT)
-                .followRedirects(HttpClient.Redirect.NORMAL)
-                .build());
+        this(defaultClient(), UrlGuard::systemResolver);
+    }
+
+    /**
+     * Test seam — substitutes the resolver backing the SSRF deny check so tests
+     * can serve feeds from a loopback server. The connection still goes to the
+     * URL's real host; only the deny check consults this.
+     */
+    RssFetcher(Function<String, InetAddress[]> resolver) {
+        this(defaultClient(), resolver);
     }
 
     /** Test seam. */
     RssFetcher(HttpClient http) {
+        this(http, UrlGuard::systemResolver);
+    }
+
+    RssFetcher(HttpClient http, Function<String, InetAddress[]> resolver) {
         this.http = http;
+        this.resolver = resolver;
+    }
+
+    private static HttpClient defaultClient() {
+        // NEVER, not NORMAL: SafeHttp follows redirects itself so each hop can
+        // be re-checked against UrlGuard. With NORMAL the client would chase a
+        // 302 into private address space without asking.
+        return HttpClient.newBuilder()
+                .connectTimeout(HTTP_TIMEOUT)
+                .followRedirects(HttpClient.Redirect.NEVER)
+                .build();
     }
 
     /**
@@ -61,9 +95,9 @@ final class RssFetcher {
     /**
      * Fetches and parses {@code rawUrl}, returning the feed title to persist.
      *
-     * @throws FetchException for any failure (bad URL, network error, oversize,
-     *         unparseable XML, missing title). The message is safe to surface
-     *         to a Discord user.
+     * @throws FetchException for any failure (bad URL, blocked address, network
+     *         error, oversize, unparseable XML, missing title). The message is
+     *         safe to surface to a Discord user.
      */
     Validated validate(String rawUrl) throws FetchException {
         String normalised = normaliseUrl(rawUrl);
@@ -89,43 +123,73 @@ final class RssFetcher {
     // ---- internals ----
 
     private byte[] load(String url) throws FetchException {
-        URI uri;
-        try {
-            uri = URI.create(url);
-        } catch (IllegalArgumentException e) {
-            throw new FetchException("That isn't a valid URL.");
-        }
+        URI uri = guard(url);
         HttpRequest req = HttpRequest.newBuilder(uri)
                 .timeout(HTTP_TIMEOUT)
                 .header("User-Agent", USER_AGENT)
                 .header("Accept", "application/rss+xml, application/atom+xml, application/xml;q=0.9, */*;q=0.8")
                 .GET()
                 .build();
-        HttpResponse<byte[]> resp;
+        HttpResponse<InputStream> resp;
         try {
-            resp = http.send(req, HttpResponse.BodyHandlers.ofByteArray());
+            resp = SafeHttp.send(http, req, HttpResponse.BodyHandlers.ofInputStream(), resolver);
+        } catch (SafeHttp.BlockedException e) {
+            throw new FetchException("I won't fetch that: " + e.getMessage());
         } catch (IOException e) {
             throw new FetchException("Couldn't reach the URL: " + safeMessage(e));
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new FetchException("Fetch was interrupted.");
         }
+
         if (resp.statusCode() / 100 != 2) {
+            closeQuietly(resp.body());
             throw new FetchException("Server returned HTTP " + resp.statusCode() + ".");
         }
-        byte[] body = resp.body();
-        if (body == null || body.length == 0) {
-            throw new FetchException("Server returned an empty response.");
+
+        byte[] body;
+        try (InputStream in = resp.body()) {
+            body = readCapped(in);
+        } catch (IOException e) {
+            throw new FetchException("Couldn't read the feed: " + safeMessage(e));
         }
-        if (body.length > MAX_RESPONSE_BYTES) {
-            throw new FetchException("Feed is larger than the " + (MAX_RESPONSE_BYTES / 1024) + " KB limit.");
+        if (body.length == 0) {
+            throw new FetchException("Server returned an empty response.");
         }
         return body;
     }
 
+    /**
+     * Reads the body, aborting as soon as it exceeds
+     * {@link #MAX_RESPONSE_BYTES}. Streaming the cap matters: buffering the
+     * whole response first and checking its size afterwards means a host that
+     * streams gigabytes exhausts our heap before the check ever runs — and
+     * this URL is user-supplied.
+     */
+    private static byte[] readCapped(InputStream in) throws IOException, FetchException {
+        byte[] buf = new byte[8192];
+        var out = new ByteArrayOutputStream();
+        int total = 0;
+        int n;
+        while ((n = in.read(buf)) >= 0) {
+            total += n;
+            if (total > MAX_RESPONSE_BYTES) {
+                throw new FetchException(
+                        "Feed is larger than the " + (MAX_RESPONSE_BYTES / 1024) + " KB limit.");
+            }
+            out.write(buf, 0, n);
+        }
+        return out.toByteArray();
+    }
+
     private static SyndFeed parse(byte[] body) throws FetchException {
-        // Disable XInclude/DTD lookups by routing through SAX with a hardened InputSource.
-        SyndFeedInput input = new SyndFeedInput();
+        // Doctypes off means no DTD, so no external entities and no billion
+        // laughs. Rome already defaults allowDoctypes to false; setting it here
+        // pins the behaviour to our code rather than to a library default a
+        // future upgrade could flip. Do not remove: this parser is pointed at
+        // whatever host a Discord user names.
+        SyndFeedInput input = new SyndFeedInput(false, Locale.ROOT);
+        input.setAllowDoctypes(false);
         input.setXmlHealerOn(true);
         try {
             return input.build(new InputSource(new ByteArrayInputStream(body)));
@@ -134,24 +198,39 @@ final class RssFetcher {
         }
     }
 
+    /** Syntactic normalisation only; the address check happens in {@link #guard}. */
     private static String normaliseUrl(String raw) throws FetchException {
-        if (raw == null) throw new FetchException("URL is required.");
-        String trimmed = raw.trim();
-        if (trimmed.isEmpty()) throw new FetchException("URL is required.");
-        URI uri;
+        return guardParse(raw).toString();
+    }
+
+    /** Parses and address-checks {@code url}, returning the URI to request. */
+    private URI guard(String url) throws FetchException {
+        URI uri = guardParse(url);
+        UrlGuard.ResolvedUrl resolved = UrlGuard.resolve(uri, resolver);
+        switch (resolved) {
+            case UrlGuard.ResolvedUrl.Ok ok -> { }
+            case UrlGuard.ResolvedUrl.DnsFailure(String host) ->
+                    throw new FetchException("Couldn't resolve " + host + ".");
+            case UrlGuard.ResolvedUrl.Disallowed(String reason) ->
+                    throw new FetchException("I won't fetch that address: " + reason);
+        }
+        return uri;
+    }
+
+    private static URI guardParse(String url) throws FetchException {
+        UrlGuard.ParsedUrl parsed = UrlGuard.parse(url);
+        if (parsed instanceof UrlGuard.ParsedUrl.Rejected(String reason)) {
+            throw new FetchException("That isn't a usable feed URL — " + reason);
+        }
+        return ((UrlGuard.ParsedUrl.Ok) parsed).uri();
+    }
+
+    private static void closeQuietly(InputStream in) {
         try {
-            uri = new URI(trimmed);
-        } catch (URISyntaxException e) {
-            throw new FetchException("That isn't a valid URL.");
+            in.close();
+        } catch (IOException e) {
+            // Discarding this body anyway; nothing useful to do.
         }
-        String scheme = uri.getScheme() == null ? "" : uri.getScheme().toLowerCase(Locale.ROOT);
-        if (!"http".equals(scheme) && !"https".equals(scheme)) {
-            throw new FetchException("URL must start with http:// or https://.");
-        }
-        if (uri.getHost() == null || uri.getHost().isBlank()) {
-            throw new FetchException("URL is missing a host.");
-        }
-        return uri.toString();
     }
 
     private static String safeMessage(Throwable t) {

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/rss/RssFetcher.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/rss/RssFetcher.java
@@ -1,5 +1,6 @@
 package ca.ryanmorrison.chatterbox.features.rss;
 
+import ca.ryanmorrison.chatterbox.common.net.HttpClients;
 import ca.ryanmorrison.chatterbox.common.net.BoundedBody;
 import ca.ryanmorrison.chatterbox.common.net.SafeHttp;
 import ca.ryanmorrison.chatterbox.common.net.UrlGuard;
@@ -222,4 +223,10 @@ final class RssFetcher {
     static final class FetchException extends Exception {
         FetchException(String message) { super(message); }
     }
+
+    /** Releases the HTTP client's selector thread and executor. */
+    void close() {
+        HttpClients.closeQuietly(http);
+    }
+
 }

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/rss/RssFetcher.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/rss/RssFetcher.java
@@ -1,5 +1,6 @@
 package ca.ryanmorrison.chatterbox.features.rss;
 
+import ca.ryanmorrison.chatterbox.common.net.BoundedBody;
 import ca.ryanmorrison.chatterbox.common.net.SafeHttp;
 import ca.ryanmorrison.chatterbox.common.net.UrlGuard;
 import com.rometools.rome.feed.synd.SyndEntry;
@@ -149,7 +150,9 @@ final class RssFetcher {
 
         byte[] body;
         try (InputStream in = resp.body()) {
-            body = readCapped(in);
+            body = BoundedBody.read(in, MAX_RESPONSE_BYTES);
+        } catch (BoundedBody.TooLargeException e) {
+            throw new FetchException("Feed is larger than the " + e.maxKilobytes() + " KB limit.");
         } catch (IOException e) {
             throw new FetchException("Couldn't read the feed: " + safeMessage(e));
         }
@@ -157,29 +160,6 @@ final class RssFetcher {
             throw new FetchException("Server returned an empty response.");
         }
         return body;
-    }
-
-    /**
-     * Reads the body, aborting as soon as it exceeds
-     * {@link #MAX_RESPONSE_BYTES}. Streaming the cap matters: buffering the
-     * whole response first and checking its size afterwards means a host that
-     * streams gigabytes exhausts our heap before the check ever runs — and
-     * this URL is user-supplied.
-     */
-    private static byte[] readCapped(InputStream in) throws IOException, FetchException {
-        byte[] buf = new byte[8192];
-        var out = new ByteArrayOutputStream();
-        int total = 0;
-        int n;
-        while ((n = in.read(buf)) >= 0) {
-            total += n;
-            if (total > MAX_RESPONSE_BYTES) {
-                throw new FetchException(
-                        "Feed is larger than the " + (MAX_RESPONSE_BYTES / 1024) + " KB limit.");
-            }
-            out.write(buf, 0, n);
-        }
-        return out.toByteArray();
     }
 
     private static SyndFeed parse(byte[] body) throws FetchException {

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/rss/RssModule.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/rss/RssModule.java
@@ -23,6 +23,8 @@ import java.util.List;
 public final class RssModule implements Module {
 
     private RssScheduler scheduler;
+    /** Retained so {@link #onStop()} can release its HTTP client. */
+    private volatile RssFetcher fetcher;
 
     @Override public String name() { return "rss"; }
 
@@ -35,6 +37,7 @@ public final class RssModule implements Module {
     public List<EventListener> listeners(InitContext ctx) {
         var repo = new RssRepository(ctx.database());
         var fetcher = new RssFetcher();
+        this.fetcher = fetcher;
         this.scheduler = new RssScheduler(repo, fetcher);
         var pending = new PendingRssRemovals();
         return List.of(
@@ -72,6 +75,10 @@ public final class RssModule implements Module {
 
     @Override
     public void onStop() {
+        // Scheduler first: stop issuing new fetches before closing the client
+        // they run through.
         if (scheduler != null) scheduler.stop();
+        RssFetcher f = fetcher;
+        if (f != null) f.close();
     }
 }

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/rss/RssPublisher.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/rss/RssPublisher.java
@@ -7,7 +7,7 @@ import com.rometools.rome.feed.synd.SyndEntry;
 import com.rometools.rome.feed.synd.SyndPerson;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.MessageEmbed;
-import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.entities.channel.middleman.GuildMessageChannel;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -35,7 +35,7 @@ final class RssPublisher {
      * is the total number of new items in this batch including {@code latest};
      * the footer shows the surplus when {@code newCount > 1}.
      */
-    static void post(TextChannel channel, Feed feed, SyndEntry latest, int newCount) {
+    static void post(GuildMessageChannel channel, Feed feed, SyndEntry latest, int newCount) {
         channel.sendMessageEmbeds(buildEmbed(feed, latest, newCount)).queue();
     }
 

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/rss/RssScheduler.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/rss/RssScheduler.java
@@ -3,7 +3,7 @@ package ca.ryanmorrison.chatterbox.features.rss;
 import com.rometools.rome.feed.synd.SyndEntry;
 import com.rometools.rome.feed.synd.SyndFeed;
 import net.dv8tion.jda.api.JDA;
-import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.entities.channel.middleman.GuildMessageChannel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -144,8 +144,25 @@ final class RssScheduler {
 
     // ---- the actual refresh ----
 
-    /** Visible for tests. */
+    /**
+     * Visible for tests.
+     *
+     * <p>Catches everything: {@code scheduleAtFixedRate} cancels a task
+     * permanently the moment its runnable throws, so a single transient
+     * {@code DataAccessException} out of {@code repo.findById} used to kill
+     * that feed's refresh until the process restarted — silently, since
+     * nothing logged the throwable. Swallowing here is deliberate; the
+     * alternative is losing the schedule.
+     */
     void tick(long feedId) {
+        try {
+            refresh(feedId);
+        } catch (Throwable t) {
+            log.error("RSS tick for feed {} failed; keeping the schedule alive.", feedId, t);
+        }
+    }
+
+    private void refresh(long feedId) {
         Optional<Feed> opt = repo.findById(feedId);
         if (opt.isEmpty()) {
             cancel(feedId);
@@ -188,7 +205,13 @@ final class RssScheduler {
         }
 
         SyndEntry latest = fresh.get(0);
-        TextChannel channel = jda == null ? null : jda.getTextChannelById(feed.channelId());
+        // Resolve as GuildMessageChannel, not TextChannel: feeds registered in
+        // a thread, forum post, or announcement channel would otherwise never
+        // resolve, logging "unavailable" forever while markers still advanced
+        // below — silently dropping every item.
+        GuildMessageChannel channel = jda == null
+                ? null
+                : jda.getChannelById(GuildMessageChannel.class, feed.channelId());
         if (channel != null && channel.canTalk()) {
             try {
                 RssPublisher.post(channel, feed, latest, fresh.size());
@@ -247,8 +270,15 @@ final class RssScheduler {
     static final int MAX_NEW_PER_TICK = 25;
 
     /**
-     * Newest-first sort. Entries without a date are kept in source order at
-     * their original position (treated as newest if first in source).
+     * Newest-first sort by publish date.
+     *
+     * <p>Dateless entries sort <em>last</em>, and keep their source order
+     * relative to each other (the sort is stable). They used to sort first, on
+     * an "assume new" reading — but the head of this list becomes the stored
+     * marker, so on a feed that mixes dated and dateless items the marker was
+     * repeatedly overwritten with a null publish date, degrading the date-floor
+     * fallback in {@link #newSince}. A feed with no dates anywhere is
+     * unaffected: every comparison is 0, so source order survives intact.
      */
     static List<SyndEntry> sortNewestFirst(List<SyndEntry> entries) {
         List<SyndEntry> copy = new ArrayList<>(entries);
@@ -256,8 +286,8 @@ final class RssScheduler {
             OffsetDateTime da = publishedOf(a);
             OffsetDateTime db = publishedOf(b);
             if (da == null && db == null) return 0;
-            if (da == null) return -1; // unknown date wins (assume "new")
-            if (db == null) return 1;
+            if (da == null) return 1;
+            if (db == null) return -1;
             return db.compareTo(da);
         });
         return copy;

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/shortener/ShortenerModule.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/shortener/ShortenerModule.java
@@ -5,6 +5,7 @@ import ca.ryanmorrison.chatterbox.http.HttpRouter;
 import ca.ryanmorrison.chatterbox.module.InitContext;
 import ca.ryanmorrison.chatterbox.module.Module;
 import net.dv8tion.jda.api.hooks.EventListener;
+import net.dv8tion.jda.api.interactions.InteractionContextType;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
@@ -111,7 +112,12 @@ public final class ShortenerModule implements Module {
                         new SubcommandData(ShortenerHandler.SUB_STATS,
                                 "Show click stats for a short URL.")
                                 .addOption(OptionType.STRING, ShortenerHandler.OPTION_TARGET,
-                                        "Full short URL or 6-character short code.", true)));
+                                        "Full short URL or 6-character short code.", true))
+                // Guild-only: the delete/peek handlers gate on a per-channel
+                // Manage Messages check, which has no meaning in a DM. Without
+                // this, JDA defaults to {GUILD, BOT_DM} and the command shows up
+                // in the bot's DMs.
+                .setContexts(InteractionContextType.GUILD));
     }
 
     @Override

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/shortener/ShortenerRedirectHandler.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/shortener/ShortenerRedirectHandler.java
@@ -51,6 +51,16 @@ final class ShortenerRedirectHandler implements Handler {
     public void handle(Context ctx) {
         String token = ctx.pathParam(PATH_PARAM).toLowerCase(Locale.ROOT);
 
+        // This route sits at the web root and is internet-facing, so it absorbs
+        // every background scanner probing /wp-login.php, /.env and friends.
+        // Rejecting anything that can't be a token keeps that traffic off the
+        // database entirely — which matters because SQLite runs a single
+        // connection shared with the bot's message handling.
+        if (!isPlausibleToken(token)) {
+            ctx.status(HttpStatus.NOT_FOUND).result("Not found.");
+            return;
+        }
+
         Optional<ShortenedUrl> match = repository.findByTokenIncludingDeleted(token);
         if (match.isEmpty()) {
             ctx.status(HttpStatus.NOT_FOUND).result("Not found.");
@@ -71,10 +81,35 @@ final class ShortenerRedirectHandler implements Handler {
         }
 
         String url = entry.url();
+        // Re-check the scheme on the way out, not just on the way in. Both
+        // current write paths validate, so this can't fire today — but the
+        // stored value lands in a Location header and an href, and a new insert
+        // path or a hand-edited row would otherwise turn it straight into
+        // javascript: in an anchor. Cheap enough to not depend on that.
+        if (!UrlValidator.isValidHttpUrl(url)) {
+            log.error("Refusing to redirect token {}: stored URL is not http(s).", entry.token());
+            ctx.status(HttpStatus.NOT_FOUND).result("Not found.");
+            return;
+        }
+
         ctx.status(HttpStatus.MOVED_PERMANENTLY)
                 .header("Location", url)
                 .contentType("text/html; charset=utf-8")
                 .result("<html>\n<body><a href=\"" + escapeAttr(url) + "\">moved here</a></body>\n");
+    }
+
+    /**
+     * Shape check only — matches the generator's base36 alphabet and length.
+     * A real lookup still decides whether the token exists.
+     */
+    private static boolean isPlausibleToken(String token) {
+        if (token.length() != TokenGenerator.LENGTH) return false;
+        for (int i = 0; i < token.length(); i++) {
+            char c = token.charAt(i);
+            boolean base36 = (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9');
+            if (!base36) return false;
+        }
+        return true;
     }
 
     static String escapeAttr(String s) {

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/shortener/UrlValidator.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/shortener/UrlValidator.java
@@ -2,6 +2,7 @@ package ca.ryanmorrison.chatterbox.features.shortener;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Locale;
 
 /**
  * URL parsing + protocol gate. Accepts only absolute http(s) URLs with a host
@@ -23,7 +24,7 @@ final class UrlValidator {
         if (!uri.isAbsolute()) return false;
         String scheme = uri.getScheme();
         if (scheme == null) return false;
-        scheme = scheme.toLowerCase();
+        scheme = scheme.toLowerCase(Locale.ROOT);
         if (!scheme.equals("http") && !scheme.equals("https")) return false;
         String host = uri.getHost();
         return host != null && !host.isBlank();

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/stock/StockClient.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/stock/StockClient.java
@@ -1,5 +1,6 @@
 package ca.ryanmorrison.chatterbox.features.stock;
 
+import ca.ryanmorrison.chatterbox.common.net.HttpClients;
 import ca.ryanmorrison.chatterbox.common.net.BoundedBody;
 import ca.ryanmorrison.chatterbox.features.stock.dto.ChartMeta;
 import ca.ryanmorrison.chatterbox.features.stock.dto.ChartResponse;
@@ -175,4 +176,10 @@ final class StockClient {
     static final class StockException extends Exception {
         StockException(String message) { super(message); }
     }
+
+    /** Releases the HTTP client's selector thread and executor. */
+    void close() {
+        HttpClients.closeQuietly(http);
+    }
+
 }

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/stock/StockClient.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/stock/StockClient.java
@@ -1,5 +1,6 @@
 package ca.ryanmorrison.chatterbox.features.stock;
 
+import ca.ryanmorrison.chatterbox.common.net.BoundedBody;
 import ca.ryanmorrison.chatterbox.features.stock.dto.ChartMeta;
 import ca.ryanmorrison.chatterbox.features.stock.dto.ChartResponse;
 import tools.jackson.core.JacksonException;
@@ -8,6 +9,7 @@ import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.net.http.HttpClient;
@@ -97,9 +99,9 @@ final class StockClient {
                 .header("Accept", "application/json")
                 .GET()
                 .build();
-        HttpResponse<byte[]> resp;
+        HttpResponse<InputStream> resp;
         try {
-            resp = http.send(req, HttpResponse.BodyHandlers.ofByteArray());
+            resp = http.send(req, HttpResponse.BodyHandlers.ofInputStream());
         } catch (HttpTimeoutException e) {
             throw new StockException("Yahoo Finance didn't respond within "
                     + HTTP_TIMEOUT.toSeconds() + " seconds.");
@@ -110,9 +112,15 @@ final class StockClient {
             throw new StockException("Request was interrupted.");
         }
         int status = resp.statusCode();
-        byte[] body = resp.body() == null ? new byte[0] : resp.body();
-        if (body.length > MAX_RESPONSE_BYTES) {
+        // Cap while streaming: ofByteArray would buffer the whole response
+        // before any size check could run.
+        byte[] body;
+        try (InputStream in = resp.body()) {
+            body = BoundedBody.read(in, MAX_RESPONSE_BYTES);
+        } catch (BoundedBody.TooLargeException e) {
             throw new StockException("Yahoo Finance response was too large.");
+        } catch (IOException e) {
+            throw new StockException("Couldn't read the Yahoo Finance response.");
         }
 
         if (status == 429) {

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/stock/StockModule.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/stock/StockModule.java
@@ -27,6 +27,9 @@ public final class StockModule implements Module {
     static final String OPT_SYMBOL  = "symbol";
     static final String OPT_PRIVATE = "private";
 
+    /** Retained so {@link #onStop()} can release its HTTP client. */
+    private volatile StockClient client;
+
     @Override public String name() { return "stock"; }
 
     @Override
@@ -44,6 +47,15 @@ public final class StockModule implements Module {
 
     @Override
     public List<EventListener> listeners(InitContext ctx) {
-        return List.of(new StockHandler(new StockClient()));
+        StockClient c = new StockClient();
+        this.client = c;
+        return List.of(new StockHandler(c));
     }
+
+    @Override
+    public void onStop() {
+        StockClient c = client;
+        if (c != null) c.close();
+    }
+
 }

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/weather/WeatherClient.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/weather/WeatherClient.java
@@ -1,5 +1,6 @@
 package ca.ryanmorrison.chatterbox.features.weather;
 
+import ca.ryanmorrison.chatterbox.common.net.BoundedBody;
 import ca.ryanmorrison.chatterbox.features.weather.dto.WeatherResponse;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.DeserializationFeature;
@@ -7,6 +8,7 @@ import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.net.http.HttpClient;
@@ -95,9 +97,9 @@ final class WeatherClient {
                 .header("Accept", "application/json")
                 .GET()
                 .build();
-        HttpResponse<byte[]> resp;
+        HttpResponse<InputStream> resp;
         try {
-            resp = http.send(req, HttpResponse.BodyHandlers.ofByteArray());
+            resp = http.send(req, HttpResponse.BodyHandlers.ofInputStream());
         } catch (HttpTimeoutException e) {
             throw new WeatherException("wttr.in didn't respond within "
                     + HTTP_TIMEOUT.toSeconds() + " seconds.");
@@ -108,9 +110,15 @@ final class WeatherClient {
             throw new WeatherException("Request was interrupted.");
         }
         int status = resp.statusCode();
-        byte[] body = resp.body() == null ? new byte[0] : resp.body();
-        if (body.length > MAX_RESPONSE_BYTES) {
+        // Cap while streaming: ofByteArray would buffer the whole response
+        // before any size check could run.
+        byte[] body;
+        try (InputStream in = resp.body()) {
+            body = BoundedBody.read(in, MAX_RESPONSE_BYTES);
+        } catch (BoundedBody.TooLargeException e) {
             throw new WeatherException("wttr.in response was too large.");
+        } catch (IOException e) {
+            throw new WeatherException("Couldn't read the wttr.in response.");
         }
 
         if (status == 429) {

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/weather/WeatherClient.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/weather/WeatherClient.java
@@ -1,5 +1,6 @@
 package ca.ryanmorrison.chatterbox.features.weather;
 
+import ca.ryanmorrison.chatterbox.common.net.HttpClients;
 import ca.ryanmorrison.chatterbox.common.net.BoundedBody;
 import ca.ryanmorrison.chatterbox.features.weather.dto.WeatherResponse;
 import tools.jackson.core.JacksonException;
@@ -148,4 +149,10 @@ final class WeatherClient {
     static final class WeatherException extends Exception {
         WeatherException(String message) { super(message); }
     }
+
+    /** Releases the HTTP client's selector thread and executor. */
+    void close() {
+        HttpClients.closeQuietly(http);
+    }
+
 }

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/weather/WeatherModule.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/weather/WeatherModule.java
@@ -31,6 +31,9 @@ public final class WeatherModule implements Module {
     static final String UNITS_METRIC   = "metric";
     static final String UNITS_IMPERIAL = "imperial";
 
+    /** Retained so {@link #onStop()} can release its HTTP client. */
+    private volatile WeatherClient client;
+
     @Override public String name() { return "weather"; }
 
     @Override
@@ -51,6 +54,15 @@ public final class WeatherModule implements Module {
 
     @Override
     public List<EventListener> listeners(InitContext ctx) {
-        return List.of(new WeatherHandler(new WeatherClient()));
+        WeatherClient c = new WeatherClient();
+        this.client = c;
+        return List.of(new WeatherHandler(c));
     }
+
+    @Override
+    public void onStop() {
+        WeatherClient c = client;
+        if (c != null) c.close();
+    }
+
 }

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/when/TimeParser.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/when/TimeParser.java
@@ -60,6 +60,13 @@ public final class TimeParser {
     private static final Pattern BARE_TIME =
             Pattern.compile("^(\\d{1,2})(?::(\\d{2}))?\\s*(am|pm)?$", Pattern.CASE_INSENSITIVE);
 
+    /**
+     * Ceiling on "in N units" — a century. Well past any plausible use of
+     * {@code /when}, and far enough below {@code Instant}'s own range that the
+     * arithmetic can't get near an edge.
+     */
+    static final long MAX_RELATIVE_SECONDS = 100L * 365 * 86_400;
+
     /** "in 30m", "in 3 hours", "in 2 days". */
     private static final Pattern RELATIVE = Pattern.compile(
             "^in\\s+(\\d+)\\s*(m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days|w|week|weeks)$",
@@ -140,15 +147,33 @@ public final class TimeParser {
         if (n <= 0) return new Result.Failed("Relative offset must be positive.");
 
         String unit = m.group(2).toLowerCase(Locale.ROOT);
-        long seconds = switch (unit) {
-            case "m", "min", "mins", "minute", "minutes" -> n * 60L;
-            case "h", "hr", "hrs", "hour", "hours"       -> n * 3_600L;
-            case "d", "day", "days"                      -> n * 86_400L;
-            case "w", "week", "weeks"                    -> n * 604_800L;
+        long perUnit = switch (unit) {
+            case "m", "min", "mins", "minute", "minutes" -> 60L;
+            case "h", "hr", "hrs", "hour", "hours"       -> 3_600L;
+            case "d", "day", "days"                      -> 86_400L;
+            case "w", "week", "weeks"                    -> 604_800L;
             default -> -1L;
         };
-        if (seconds < 0) return new Result.Failed("Unknown time unit `" + unit + "`.");
-        return new Result.Ok(clock.instant().plusSeconds(seconds));
+        if (perUnit < 0) return new Result.Failed("Unknown time unit `" + unit + "`.");
+
+        // The regex captures unbounded digits, so the multiply overflows long
+        // before parseLong would complain: "in 20000000000000 weeks" wrapped to
+        // a negative and blew up inside Instant, escaping the listener as an
+        // unhandled exception ("The application did not respond").
+        long seconds;
+        try {
+            seconds = Math.multiplyExact(n, perUnit);
+        } catch (ArithmeticException e) {
+            return new Result.Failed("Relative offset is too large.");
+        }
+        if (seconds > MAX_RELATIVE_SECONDS) {
+            return new Result.Failed("Relative offset is too large.");
+        }
+        try {
+            return new Result.Ok(clock.instant().plusSeconds(seconds));
+        } catch (ArithmeticException | java.time.DateTimeException e) {
+            return new Result.Failed("Relative offset is too large.");
+        }
     }
 
     private static Result tryIsoDateTime(String s, Optional<ZoneId> zoneOpt) {

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/wiki/WikiClient.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/wiki/WikiClient.java
@@ -1,5 +1,6 @@
 package ca.ryanmorrison.chatterbox.features.wiki;
 
+import ca.ryanmorrison.chatterbox.common.net.BoundedBody;
 import ca.ryanmorrison.chatterbox.features.wiki.dto.PageSummary;
 import ca.ryanmorrison.chatterbox.features.wiki.dto.SearchHit;
 import ca.ryanmorrison.chatterbox.features.wiki.dto.SearchResponse;
@@ -9,6 +10,7 @@ import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.net.http.HttpClient;
@@ -81,13 +83,9 @@ final class WikiClient {
         String encoded = URLEncoder.encode(title.trim(), StandardCharsets.UTF_8).replace("+", "%20");
         byte[] body;
         int status;
-        try {
-            HttpResponse<byte[]> resp = send("/api/rest_v1/page/summary/" + encoded);
-            body = resp.body() == null ? new byte[0] : resp.body();
-            status = resp.statusCode();
-        } catch (WikiException e) {
-            throw e;
-        }
+        Body resp = send("/api/rest_v1/page/summary/" + encoded);
+        body = resp.bytes();
+        status = resp.status();
 
         if (status == 404) return Optional.empty();
         if (status == 429) throw new WikiException("Wikipedia is rate-limiting us. Try again in a minute.");
@@ -109,14 +107,9 @@ final class WikiClient {
         String encoded = URLEncoder.encode(query.trim(), StandardCharsets.UTF_8);
         byte[] body;
         int status;
-        try {
-            HttpResponse<byte[]> resp =
-                    send("/w/rest.php/v1/search/page?q=" + encoded + "&limit=" + limit);
-            body = resp.body() == null ? new byte[0] : resp.body();
-            status = resp.statusCode();
-        } catch (WikiException e) {
-            throw e;
-        }
+        Body resp = send("/w/rest.php/v1/search/page?q=" + encoded + "&limit=" + limit);
+        body = resp.bytes();
+        status = resp.status();
 
         if (status == 429) throw new WikiException("Wikipedia is rate-limiting us. Try again in a minute.");
         if (status / 100 != 2) throw new WikiException("Wikipedia returned HTTP " + status + ".");
@@ -128,7 +121,10 @@ final class WikiClient {
         }
     }
 
-    private HttpResponse<byte[]> send(String path) throws WikiException {
+    /** Status plus the size-capped body bytes. */
+    private record Body(int status, byte[] bytes) {}
+
+    private Body send(String path) throws WikiException {
         URI uri;
         try {
             uri = URI.create(baseUrl + path);
@@ -142,12 +138,16 @@ final class WikiClient {
                 .GET()
                 .build();
         try {
-            HttpResponse<byte[]> resp = http.send(req, HttpResponse.BodyHandlers.ofByteArray());
-            byte[] body = resp.body();
-            if (body != null && body.length > MAX_RESPONSE_BYTES) {
+            HttpResponse<InputStream> resp = http.send(req, HttpResponse.BodyHandlers.ofInputStream());
+            // Cap while streaming: ofByteArray would buffer the whole response
+            // before any size check could run.
+            byte[] body;
+            try (InputStream in = resp.body()) {
+                body = BoundedBody.read(in, MAX_RESPONSE_BYTES);
+            } catch (BoundedBody.TooLargeException e) {
                 throw new WikiException("Wikipedia response was too large.");
             }
-            return resp;
+            return new Body(resp.statusCode(), body);
         } catch (HttpTimeoutException e) {
             throw new WikiException("Wikipedia didn't respond within " + HTTP_TIMEOUT.toSeconds() + " seconds.");
         } catch (IOException e) {

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/wiki/WikiClient.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/wiki/WikiClient.java
@@ -1,5 +1,6 @@
 package ca.ryanmorrison.chatterbox.features.wiki;
 
+import ca.ryanmorrison.chatterbox.common.net.HttpClients;
 import ca.ryanmorrison.chatterbox.common.net.BoundedBody;
 import ca.ryanmorrison.chatterbox.features.wiki.dto.PageSummary;
 import ca.ryanmorrison.chatterbox.features.wiki.dto.SearchHit;
@@ -162,4 +163,10 @@ final class WikiClient {
     static final class WikiException extends Exception {
         WikiException(String message) { super(message); }
     }
+
+    /** Releases the HTTP client's selector thread and executor. */
+    void close() {
+        HttpClients.closeQuietly(http);
+    }
+
 }

--- a/src/main/java/ca/ryanmorrison/chatterbox/features/wiki/WikiModule.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/features/wiki/WikiModule.java
@@ -24,6 +24,9 @@ public final class WikiModule implements Module {
     static final String OPT_QUERY   = "query";
     static final String OPT_PRIVATE = "private";
 
+    /** Retained so {@link #onStop()} can release its HTTP client. */
+    private volatile WikiClient client;
+
     @Override public String name() { return "wiki"; }
 
     @Override
@@ -39,6 +42,15 @@ public final class WikiModule implements Module {
 
     @Override
     public List<EventListener> listeners(InitContext ctx) {
-        return List.of(new WikiHandler(new WikiClient()));
+        WikiClient c = new WikiClient();
+        this.client = c;
+        return List.of(new WikiHandler(c));
     }
+
+    @Override
+    public void onStop() {
+        WikiClient c = client;
+        if (c != null) c.close();
+    }
+
 }

--- a/src/main/java/ca/ryanmorrison/chatterbox/http/HttpServer.java
+++ b/src/main/java/ca/ryanmorrison/chatterbox/http/HttpServer.java
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 
 /**
@@ -15,23 +16,36 @@ import java.util.function.Consumer;
  * for modules to register routes against during bootstrap.
  *
  * <p>Lifecycle: build instance → modules register routes via {@link #router()} →
- * call {@link #start()} only if at least one route was registered. {@link #stop()}
- * is invoked from the shutdown hook regardless.
+ * call {@link #start()}. {@link #stop()} is invoked from the shutdown hook.
  *
  * <p>Routes are queued during the registration phase and applied when the
  * underlying Javalin instance is built in {@link #start()}, since Javalin 7
  * configures its router via the {@code Javalin.create(cfg -> ...)} callback.
  *
- * <p>The "start only if needed" check keeps the bot from binding port 8080 in
- * deployments where no module exposes HTTP endpoints.
+ * <p>The server always binds, because it always serves {@link #HEALTH_PATH}.
+ * That is a change from the previous "start only if a module registered a
+ * route": with no always-present endpoint there was nothing for a container
+ * healthcheck to probe, so a hung bot stayed "up" indefinitely and Traefik
+ * routed to it the moment the process started.
  */
 public final class HttpServer {
 
     private static final Logger log = LoggerFactory.getLogger(HttpServer.class);
 
+    /** Liveness/readiness endpoint. Owned here, not by a module, so it always exists. */
+    public static final String HEALTH_PATH = "/health";
+
     private final int port;
     private final List<Consumer<RoutesConfig>> pendingRoutes = new ArrayList<>();
     private final HttpRouter router = new RoutingProxy();
+
+    /**
+     * Reports whether the bot is actually usable. Defaults to "no": the server
+     * binds before JDA connects, and answering 200 during that window is what
+     * makes a healthcheck useless.
+     */
+    private volatile BooleanSupplier readiness = () -> false;
+
     private Javalin app;
     private boolean started;
 
@@ -49,16 +63,52 @@ public final class HttpServer {
         return !pendingRoutes.isEmpty();
     }
 
+    /**
+     * Sets the predicate behind {@link #HEALTH_PATH}. Bootstrap wires this to
+     * JDA's connection status once the gateway is up.
+     */
+    public void setReadiness(BooleanSupplier probe) {
+        this.readiness = probe == null ? () -> false : probe;
+    }
+
     public void start() {
         if (started) return;
         app = Javalin.create(cfg -> {
+            // Registered before module routes so it wins the match. The URL
+            // shortener claims GET /{token} at the root, and "health" is a
+            // syntactically valid 6-character token, so order decides this.
+            cfg.routes.get(HEALTH_PATH, ctx -> {
+                boolean ok = isReady();
+                ctx.status(ok ? 200 : 503)
+                        .contentType("text/plain; charset=utf-8")
+                        .result(ok ? "ok" : "starting");
+            });
             for (Consumer<RoutesConfig> r : pendingRoutes) {
                 r.accept(cfg.routes);
             }
         });
         app.start(port);
         started = true;
-        log.info("HTTP server listening on port {} ({} route(s) registered).", port, pendingRoutes.size());
+        log.info("HTTP server listening on port {} ({} module route(s) registered, plus {}).",
+                port, pendingRoutes.size(), HEALTH_PATH);
+    }
+
+    /**
+     * The bound port, or -1 if not started. Useful when the configured port is
+     * 0 and the OS picked one.
+     */
+    public int port() {
+        return started && app != null ? app.port() : -1;
+    }
+
+    private boolean isReady() {
+        try {
+            return readiness.getAsBoolean();
+        } catch (RuntimeException e) {
+            // A probe that throws is not a healthy bot.
+            log.warn("Readiness probe failed: {}", e.toString());
+            return false;
+        }
     }
 
     public void stop() {

--- a/src/main/resources/db/migration/shout/postgresql/V20260726000000__shouts_backfill_authored_at.sql
+++ b/src/main/resources/db/migration/shout/postgresql/V20260726000000__shouts_backfill_authored_at.sql
@@ -1,0 +1,16 @@
+-- Paired with the SQLite migration of the same version, which repairs rows left
+-- with an empty-string authored_at.
+--
+-- On PostgreSQL there is nothing to repair. V20260430130000__shouts_add_author.sql
+-- added authored_at as TIMESTAMPTZ NOT NULL with no DEFAULT, which PostgreSQL
+-- rejects outright against a non-empty table -- so any database that got past
+-- that migration had no rows at the time, and the column has never been able to
+-- hold the empty string the SQLite variant backfilled.
+--
+-- The file exists so both dialect trees stay version-for-version aligned, which
+-- is the invariant the rest of this migration set maintains. Flyway runs zero
+-- statements here and records the version.
+--
+-- Note for future schema work: adding a NOT NULL column without a DEFAULT is
+-- what made V20260430130000 undeployable against an existing PostgreSQL
+-- database. Give NOT NULL additions a DEFAULT, or backfill in a separate step.

--- a/src/main/resources/db/migration/shout/sqlite/V20260726000000__shouts_backfill_authored_at.sql
+++ b/src/main/resources/db/migration/shout/sqlite/V20260726000000__shouts_backfill_authored_at.sql
@@ -1,0 +1,22 @@
+-- Repairs rows left with an empty-string authored_at by
+-- V20260430130000__shouts_add_author.sql.
+--
+-- That migration added authored_at as NOT NULL DEFAULT '' on SQLite, so every
+-- pre-existing row was backfilled with '' -- which jOOQ then tries to read as
+-- an OffsetDateTime via SHOUTS.AUTHORED_AT (ShoutRepository, ShoutStatsRepository).
+--
+-- V20260430130000 is already applied in production, so it is deliberately left
+-- untouched: editing it would change its checksum and fail Flyway validation on
+-- every existing database. This forward migration repairs the data instead.
+--
+-- created_at is the best available approximation of authoring time: it was set
+-- by the insert that recorded the shout, which happens on the message-received
+-- event. Rows with a valid authored_at are left alone, so this is a no-op on a
+-- database created after V20260430130000.
+UPDATE shouts
+SET authored_at = created_at
+WHERE authored_at = '';
+
+-- author_id's 0 default is left as-is: 0 is not a valid Discord snowflake, so
+-- it already reads as an "unknown author" sentinel, and there is no source of
+-- truth to recover the real value from.

--- a/src/test/java/ca/ryanmorrison/chatterbox/common/net/BoundedBodyTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/common/net/BoundedBodyTest.java
@@ -1,0 +1,85 @@
+package ca.ryanmorrison.chatterbox.common.net;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BoundedBodyTest {
+
+    @Test
+    void readsABodyUnderTheCap() throws Exception {
+        byte[] payload = "hello world".getBytes(StandardCharsets.UTF_8);
+        assertArrayEquals(payload,
+                BoundedBody.read(new ByteArrayInputStream(payload), 1024));
+    }
+
+    @Test
+    void readsABodyExactlyAtTheCap() throws Exception {
+        byte[] payload = new byte[64];
+        assertEquals(64, BoundedBody.read(new ByteArrayInputStream(payload), 64).length);
+    }
+
+    @Test
+    void rejectsABodyOneByteOverTheCap() {
+        byte[] payload = new byte[65];
+        var e = assertThrows(BoundedBody.TooLargeException.class,
+                () -> BoundedBody.read(new ByteArrayInputStream(payload), 64));
+        assertEquals(64, e.maxBytes());
+    }
+
+    @Test
+    void handlesAnEmptyBody() throws Exception {
+        assertEquals(0, BoundedBody.read(new ByteArrayInputStream(new byte[0]), 64).length);
+    }
+
+    /**
+     * The whole point of the class. A post-hoc {@code body.length} check on an
+     * already-buffered array cannot do this: the heap is gone before it runs.
+     */
+    @Test
+    void abandonsAnEndlessStreamInsteadOfBufferingItAll() {
+        var consumed = new AtomicLong();
+        InputStream endless = new InputStream() {
+            @Override public int read() {
+                consumed.incrementAndGet();
+                return 0;
+            }
+            @Override public int read(byte[] b, int off, int len) {
+                consumed.addAndGet(len);
+                return len;
+            }
+        };
+
+        assertThrows(BoundedBody.TooLargeException.class,
+                () -> BoundedBody.read(endless, 4096));
+
+        // Bounded work, not "read forever then complain".
+        assertTrue(consumed.get() < 64 * 1024,
+                () -> "read " + consumed.get() + " bytes from an endless stream");
+    }
+
+    @Test
+    void propagatesUnderlyingIoFailures() {
+        InputStream broken = new InputStream() {
+            @Override public int read() throws IOException {
+                throw new IOException("connection reset");
+            }
+        };
+        var e = assertThrows(IOException.class, () -> BoundedBody.read(broken, 1024));
+        assertEquals("connection reset", e.getMessage());
+    }
+
+    @Test
+    void reportsTheCapInKilobytesForUserFacingMessages() {
+        assertEquals(2048, new BoundedBody.TooLargeException(2 * 1024 * 1024).maxKilobytes());
+    }
+}

--- a/src/test/java/ca/ryanmorrison/chatterbox/common/net/UrlGuardTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/common/net/UrlGuardTest.java
@@ -1,4 +1,4 @@
-package ca.ryanmorrison.chatterbox.features.isitdown;
+package ca.ryanmorrison.chatterbox.common.net;
 
 import org.junit.jupiter.api.Test;
 
@@ -129,6 +129,45 @@ class UrlGuardTest {
         // Cloud-metadata service — the canonical SSRF target.
         assertEquals("link-local address",
                 UrlGuard.denyReason(InetAddress.getByName("169.254.169.254")));
+    }
+
+    @Test
+    void carrierGradeNatRejected() throws Exception {
+        // 100.64.0.0/10 (RFC 6598) routes inside ISP and cloud networks but
+        // isn't covered by any of InetAddress's built-in predicates.
+        assertEquals("carrier-grade NAT address",
+                UrlGuard.denyReason(InetAddress.getByName("100.64.0.1")));
+        assertEquals("carrier-grade NAT address",
+                UrlGuard.denyReason(InetAddress.getByName("100.127.255.254")));
+        // Boundaries: 100.63.x and 100.128.x are outside the /10 and stay allowed.
+        assertNull(UrlGuard.denyReason(InetAddress.getByName("100.63.255.255")));
+        assertNull(UrlGuard.denyReason(InetAddress.getByName("100.128.0.1")));
+    }
+
+    @Test
+    void ietfProtocolAssignmentRejected() throws Exception {
+        assertEquals("IETF protocol assignment address",
+                UrlGuard.denyReason(InetAddress.getByName("192.0.0.1")));
+        // 192.0.1.x is outside the /24.
+        assertNull(UrlGuard.denyReason(InetAddress.getByName("192.0.1.1")));
+    }
+
+    @Test
+    void benchmarkingRangeRejected() throws Exception {
+        assertEquals("benchmarking address",
+                UrlGuard.denyReason(InetAddress.getByName("198.18.0.1")));
+        assertEquals("benchmarking address",
+                UrlGuard.denyReason(InetAddress.getByName("198.19.255.254")));
+        assertNull(UrlGuard.denyReason(InetAddress.getByName("198.20.0.1")));
+    }
+
+    @Test
+    void ipv4MappedIpv6IsNormalisedBeforeTheDenyCheck() throws Exception {
+        // Both spellings must reach the same verdict; if InetAddress ever stops
+        // normalising these, the mapped form would otherwise skip every IPv4 range.
+        assertEquals("loopback address",
+                UrlGuard.denyReason(InetAddress.getByName("::ffff:127.0.0.1")));
+        assertNotNull(UrlGuard.denyReason(InetAddress.getByName("::ffff:100.64.0.1")));
     }
 
     @Test

--- a/src/test/java/ca/ryanmorrison/chatterbox/common/permissions/PermissionsTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/common/permissions/PermissionsTest.java
@@ -1,0 +1,127 @@
+package ca.ryanmorrison.chatterbox.common.permissions;
+
+import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
+import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback;
+import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Authorization logic, so it gets direct coverage.
+ *
+ * <p>The DM cases matter most: JDA's {@code getGuildChannel()} throws
+ * {@link IllegalStateException} outside a guild rather than returning null, so
+ * reading it before checking {@code isFromGuild()} let the exception escape
+ * the listener — the user saw "The application did not respond" instead of a
+ * rejection. These tests stub that throwing behaviour explicitly.
+ */
+class PermissionsTest {
+
+    /** An interaction that is not in a guild, mirroring JDA's throwing accessor. */
+    private static IReplyCallback dmEvent() {
+        IReplyCallback event = mock(IReplyCallback.class);
+        when(event.isFromGuild()).thenReturn(false);
+        lenient().when(event.getMember()).thenReturn(null);
+        lenient().when(event.getGuildChannel())
+                .thenThrow(new IllegalStateException("This interaction did not happen in a guild"));
+        ReplyCallbackAction action = mock(ReplyCallbackAction.class, org.mockito.Answers.RETURNS_SELF);
+        lenient().when(event.reply(anyString())).thenReturn(action);
+        return event;
+    }
+
+    private static IReplyCallback guildEvent(boolean hasPermission) {
+        IReplyCallback event = mock(IReplyCallback.class);
+        Member member = mock(Member.class);
+        GuildChannel channel = mock(GuildChannel.class);
+        when(event.isFromGuild()).thenReturn(true);
+        when(event.getMember()).thenReturn(member);
+        when(event.getGuildChannel()).thenReturn(channel);
+        lenient().when(member.hasPermission(channel, Permission.MESSAGE_MANAGE))
+                .thenReturn(hasPermission);
+        ReplyCallbackAction action = mock(ReplyCallbackAction.class, org.mockito.Answers.RETURNS_SELF);
+        lenient().when(event.reply(anyString())).thenReturn(action);
+        return event;
+    }
+
+    // ---- canManageMessages ----
+
+    @Test
+    void canManageMessagesIsFalseInDmRatherThanThrowing() {
+        assertFalse(Permissions.canManageMessages(dmEvent()));
+    }
+
+    @Test
+    void canManageMessagesReflectsThePermissionInAGuild() {
+        assertTrue(Permissions.canManageMessages(guildEvent(true)));
+        assertFalse(Permissions.canManageMessages(guildEvent(false)));
+    }
+
+    @Test
+    void canManageMessagesToleratesNullInputs() {
+        assertFalse(Permissions.canManageMessages(null, mock(GuildChannel.class)));
+        assertFalse(Permissions.canManageMessages(mock(Member.class), null));
+    }
+
+    // ---- requireManageMessages ----
+
+    @Test
+    void requireManageMessagesRejectsInDmWithAMessage() {
+        IReplyCallback event = dmEvent();
+
+        assertFalse(Permissions.requireManageMessages(event));
+
+        // The point of the fix: the user gets told why, instead of the
+        // interaction dying with an unhandled exception.
+        verify(event).reply("This command is only available in servers.");
+    }
+
+    @Test
+    void requireManageMessagesRejectsWhenPermissionIsMissing() {
+        IReplyCallback event = guildEvent(false);
+
+        assertFalse(Permissions.requireManageMessages(event));
+
+        verify(event).reply(
+                "You need the **Manage Messages** permission in this channel to do that.");
+    }
+
+    @Test
+    void requireManageMessagesPassesForAModerator() {
+        IReplyCallback event = guildEvent(true);
+
+        assertTrue(Permissions.requireManageMessages(event));
+
+        verify(event, never()).reply(anyString());
+    }
+
+    // ---- requireAdministrator ----
+
+    @Test
+    void requireAdministratorRejectsInDm() {
+        IReplyCallback event = dmEvent();
+
+        assertFalse(Permissions.requireAdministrator(event));
+
+        verify(event).reply("This command is only available in servers.");
+    }
+
+    @Test
+    void requireAdministratorPassesForAnAdmin() {
+        IReplyCallback event = mock(IReplyCallback.class);
+        Member member = mock(Member.class);
+        when(event.getMember()).thenReturn(member);
+        when(member.hasPermission(Permission.ADMINISTRATOR)).thenReturn(true);
+
+        assertTrue(Permissions.requireAdministrator(event));
+    }
+}

--- a/src/test/java/ca/ryanmorrison/chatterbox/config/ConfigTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/config/ConfigTest.java
@@ -19,7 +19,6 @@ class ConfigTest {
         )::get);
         assertEquals("abc", cfg.discordToken());
         assertFalse(cfg.devMode());
-        assertEquals("INFO", cfg.logLevel());
         assertTrue(cfg.database().isSqlite());
         assertEquals("", cfg.database().user());
     }

--- a/src/test/java/ca/ryanmorrison/chatterbox/config/runtime/RuntimeConfigCachePublishTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/config/runtime/RuntimeConfigCachePublishTest.java
@@ -1,0 +1,121 @@
+package ca.ryanmorrison.chatterbox.config.runtime;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Pins the one guarantee that was lost by moving the config load out of
+ * {@code computeIfAbsent}.
+ *
+ * <p>Holding the map's bin lock across the load used to make invalidation
+ * race-free for free: {@code cache.remove} could not slip between a stale read
+ * and its put. Loading outside the lock reopens that window, so a version
+ * counter closes it. This test drives the interleaving deterministically with
+ * a latch rather than hoping a thread race reproduces — a timing-based version
+ * of this test passes even with the guard removed, which is worse than no test.
+ */
+class RuntimeConfigCachePublishTest {
+
+    private static final long GUILD = 42L;
+    private static final long ADMIN = 7L;
+
+    private static final ConfigKey<Integer> THRESHOLD = ConfigKey.positiveInt(
+            "autoshorten.threshold", "CHATTERBOX_AUTOSHORTEN_THRESHOLD", "160", "Min URL length.");
+
+    @Test
+    void aLoadThatStartedBeforeAWriteDoesNotPublishOverIt() throws Exception {
+        var repo = mock(RuntimeConfigRepository.class);
+        var loadStarted = new CountDownLatch(1);
+        var writeDone = new CountDownLatch(1);
+
+        // First load blocks until the write has completed, then returns the
+        // value that was current when it began. Later loads see the new value.
+        when(repo.findAllForGuild(GUILD))
+                .thenAnswer(invocation -> {
+                    loadStarted.countDown();
+                    assertTrue(writeDone.await(5, TimeUnit.SECONDS), "write never completed");
+                    return Map.of("autoshorten.threshold", "160");
+                })
+                .thenReturn(Map.of("autoshorten.threshold", "999"));
+
+        var registry = new ConfigRegistry(List.of(THRESHOLD));
+        var runtime = new RuntimeConfig(registry, repo, name -> null,
+                Clock.fixed(java.time.Instant.EPOCH, ZoneOffset.UTC));
+
+        var reader = new Thread(() -> runtime.integer(GUILD, THRESHOLD), "stale-reader");
+        reader.start();
+        assertTrue(loadStarted.await(5, TimeUnit.SECONDS), "load never started");
+
+        // The write lands while that load is still in flight.
+        runtime.set(GUILD, THRESHOLD, "999", ADMIN);
+        writeDone.countDown();
+        reader.join(5_000);
+
+        // Without the version guard the in-flight load publishes 160 back into
+        // the cache here, and this read returns the overwritten value.
+        assertEquals(999, runtime.integer(GUILD, THRESHOLD),
+                "a load that began before the write published stale config over it");
+    }
+
+    @Test
+    void anUncontendedLoadStillPopulatesTheCache() {
+        var repo = mock(RuntimeConfigRepository.class);
+        when(repo.findAllForGuild(GUILD)).thenReturn(Map.of("autoshorten.threshold", "321"));
+
+        var registry = new ConfigRegistry(List.of(THRESHOLD));
+        var runtime = new RuntimeConfig(registry, repo, name -> null,
+                Clock.fixed(java.time.Instant.EPOCH, ZoneOffset.UTC));
+
+        assertEquals(321, runtime.integer(GUILD, THRESHOLD));
+        assertEquals(321, runtime.integer(GUILD, THRESHOLD));
+
+        // Second read must come from the cache, not the repository.
+        org.mockito.Mockito.verify(repo, org.mockito.Mockito.times(1)).findAllForGuild(GUILD);
+    }
+
+    @Test
+    void writesInvalidateSoTheNextReadSeesThem() {
+        var repo = mock(RuntimeConfigRepository.class);
+        when(repo.findAllForGuild(GUILD))
+                .thenReturn(Map.of("autoshorten.threshold", "100"))
+                .thenReturn(Map.of("autoshorten.threshold", "200"));
+        when(repo.delete(anyLong(), anyString())).thenReturn(true);
+
+        var registry = new ConfigRegistry(List.of(THRESHOLD));
+        var runtime = new RuntimeConfig(registry, repo, name -> null,
+                Clock.fixed(java.time.Instant.EPOCH, ZoneOffset.UTC));
+
+        assertEquals(100, runtime.integer(GUILD, THRESHOLD));
+        runtime.set(GUILD, THRESHOLD, "200", ADMIN);
+        assertEquals(200, runtime.integer(GUILD, THRESHOLD));
+    }
+
+    @Test
+    void aFailingRepositoryDegradesToDefaultsInsteadOfThrowing() {
+        var repo = mock(RuntimeConfigRepository.class);
+        when(repo.findAllForGuild(anyLong()))
+                .thenThrow(new org.jooq.exception.DataAccessException("pool exhausted"));
+
+        var registry = new ConfigRegistry(List.of(THRESHOLD));
+        var runtime = new RuntimeConfig(registry, repo, name -> null,
+                Clock.fixed(java.time.Instant.EPOCH, ZoneOffset.UTC));
+
+        // This runs on a JDA listener thread in production; throwing here kills
+        // message handling for the whole guild.
+        assertEquals(160, runtime.integer(GUILD, THRESHOLD));
+    }
+}

--- a/src/test/java/ca/ryanmorrison/chatterbox/config/runtime/RuntimeConfigRepositoryPostgresTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/config/runtime/RuntimeConfigRepositoryPostgresTest.java
@@ -1,43 +1,44 @@
 package ca.ryanmorrison.chatterbox.config.runtime;
 
-import ca.ryanmorrison.chatterbox.db.SqliteRepositoryTestBase;
+import ca.ryanmorrison.chatterbox.db.PostgresRepositoryTestBase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/** Verifies the SQLite migration is wire-compatible with the generated jOOQ classes. */
-class RuntimeConfigRepositorySqliteTest extends SqliteRepositoryTestBase {
+/**
+ * Dialect-parity coverage for {@link RuntimeConfigRepository}, previously
+ * verified against SQLite only. The upsert goes through
+ * {@code onConflict().doUpdate()}, whose rendered SQL differs by dialect.
+ */
+class RuntimeConfigRepositoryPostgresTest extends PostgresRepositoryTestBase {
 
     private static final long GUILD = 12345L;
     private static final long ADMIN = 9999L;
     private static final OffsetDateTime NOW =
-            OffsetDateTime.of(2026, 5, 7, 12, 0, 0, 0, ZoneOffset.UTC);
-    private static final OffsetDateTime LATER =
-            OffsetDateTime.of(2026, 5, 7, 13, 0, 0, 0, ZoneOffset.UTC);
+            OffsetDateTime.of(2026, 5, 7, 10, 0, 0, 0, ZoneOffset.UTC);
+    private static final OffsetDateTime LATER = NOW.plusHours(1);
 
     private RuntimeConfigRepository repo;
 
     @Override
     protected String migrationLocation() {
-        return "classpath:db/migration/runtime-config/sqlite";
+        return "classpath:db/migration/runtime-config/postgresql";
     }
 
     @BeforeEach
-    void createRepositories() {
+    void createRepository() {
         repo = new RuntimeConfigRepository(dsl);
     }
 
-
     @Test
-    void putThenFindReturnsValue() {
+    void putThenReadBack() {
         repo.put(GUILD, "autoshorten.enabled", "false", ADMIN, NOW);
         assertEquals("false", repo.findAllForGuild(GUILD).get("autoshorten.enabled"));
     }
@@ -47,34 +48,31 @@ class RuntimeConfigRepositorySqliteTest extends SqliteRepositoryTestBase {
         assertNull(repo.findAllForGuild(GUILD).get("nope"));
     }
 
+    /** The upsert: a second put for the same key must update, not duplicate. */
     @Test
     void putUpdatesExistingRow() {
         repo.put(GUILD, "autoshorten.threshold", "200", ADMIN, NOW);
         repo.put(GUILD, "autoshorten.threshold", "300", ADMIN, LATER);
+
         assertEquals("300", repo.findAllForGuild(GUILD).get("autoshorten.threshold"));
+        assertEquals(1, repo.findAllForGuild(GUILD).size());
     }
 
     @Test
-    void findAllForGuildReturnsEverythingForOneGuild() {
-        repo.put(GUILD, "autoshorten.enabled",   "false", ADMIN, NOW);
-        repo.put(GUILD, "autoshorten.threshold", "200",   ADMIN, NOW);
-        repo.put(99L,   "autoshorten.threshold", "999",   ADMIN, NOW); // other guild
+    void overridesAreScopedPerGuild() {
+        repo.put(GUILD, "autoshorten.threshold", "200", ADMIN, NOW);
+        repo.put(99L, "autoshorten.threshold", "999", ADMIN, NOW);
 
-        Map<String, String> got = repo.findAllForGuild(GUILD);
-        assertEquals(2, got.size());
-        assertEquals("false", got.get("autoshorten.enabled"));
-        assertEquals("200",   got.get("autoshorten.threshold"));
+        assertEquals("200", repo.findAllForGuild(GUILD).get("autoshorten.threshold"));
+        assertEquals("999", repo.findAllForGuild(99L).get("autoshorten.threshold"));
     }
 
     @Test
-    void deleteReturnsTrueWhenRowExisted() {
+    void deleteReportsWhetherARowExisted() {
         repo.put(GUILD, "autoshorten.enabled", "false", ADMIN, NOW);
-        assertTrue(repo.delete(GUILD, "autoshorten.enabled"));
-        assertNull(repo.findAllForGuild(GUILD).get("autoshorten.enabled"));
-    }
 
-    @Test
-    void deleteReturnsFalseWhenRowAbsent() {
-        assertFalse(repo.delete(GUILD, "missing"));
+        assertTrue(repo.delete(GUILD, "autoshorten.enabled"));
+        assertFalse(repo.delete(GUILD, "autoshorten.enabled"));
+        assertNull(repo.findAllForGuild(GUILD).get("autoshorten.enabled"));
     }
 }

--- a/src/test/java/ca/ryanmorrison/chatterbox/config/runtime/RuntimeConfigRepositorySqliteTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/config/runtime/RuntimeConfigRepositorySqliteTest.java
@@ -18,6 +18,7 @@ import java.time.ZoneOffset;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -65,19 +66,19 @@ class RuntimeConfigRepositorySqliteTest {
     @Test
     void putThenFindReturnsValue() {
         repo.put(GUILD, "autoshorten.enabled", "false", ADMIN, NOW);
-        assertEquals("false", repo.findValue(GUILD, "autoshorten.enabled").orElseThrow());
+        assertEquals("false", repo.findAllForGuild(GUILD).get("autoshorten.enabled"));
     }
 
     @Test
-    void findValueIsEmptyWhenAbsent() {
-        assertTrue(repo.findValue(GUILD, "nope").isEmpty());
+    void lookupIsEmptyWhenAbsent() {
+        assertNull(repo.findAllForGuild(GUILD).get("nope"));
     }
 
     @Test
     void putUpdatesExistingRow() {
         repo.put(GUILD, "autoshorten.threshold", "200", ADMIN, NOW);
         repo.put(GUILD, "autoshorten.threshold", "300", ADMIN, LATER);
-        assertEquals("300", repo.findValue(GUILD, "autoshorten.threshold").orElseThrow());
+        assertEquals("300", repo.findAllForGuild(GUILD).get("autoshorten.threshold"));
     }
 
     @Test
@@ -96,7 +97,7 @@ class RuntimeConfigRepositorySqliteTest {
     void deleteReturnsTrueWhenRowExisted() {
         repo.put(GUILD, "autoshorten.enabled", "false", ADMIN, NOW);
         assertTrue(repo.delete(GUILD, "autoshorten.enabled"));
-        assertTrue(repo.findValue(GUILD, "autoshorten.enabled").isEmpty());
+        assertNull(repo.findAllForGuild(GUILD).get("autoshorten.enabled"));
     }
 
     @Test

--- a/src/test/java/ca/ryanmorrison/chatterbox/config/runtime/RuntimeConfigTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/config/runtime/RuntimeConfigTest.java
@@ -163,4 +163,17 @@ class RuntimeConfigTest {
         runtime.set(GUILD, ENABLED, "false", ADMIN);
         assertFalse(runtime.bool(GUILD, ENABLED));
     }
+
+    @Test
+    void readsFallBackToEnvAndDefaultWhenTheDatabaseIsUnavailable() {
+        // A DB failure on the read path used to propagate into the JDA
+        // listener thread. It should degrade to env/default instead.
+        dataSource.close();
+
+        env.put("CHATTERBOX_AUTOSHORTEN_THRESHOLD", "512");
+        assertEquals(512, runtime.integer(GUILD, THRESHOLD));
+
+        env.remove("CHATTERBOX_AUTOSHORTEN_THRESHOLD");
+        assertEquals(160, runtime.integer(GUILD, THRESHOLD));
+    }
 }

--- a/src/test/java/ca/ryanmorrison/chatterbox/db/DatabaseTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/db/DatabaseTest.java
@@ -1,0 +1,105 @@
+package ca.ryanmorrison.chatterbox.db;
+
+import ca.ryanmorrison.chatterbox.config.Config;
+import org.jooq.SQLDialect;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DatabaseTest {
+
+    private static Config.DatabaseConfig sqlite(Path file) {
+        return new Config.DatabaseConfig("jdbc:sqlite:" + file, "", "");
+    }
+
+    /**
+     * The SQLite init SQL sets three PRAGMAs in one statement string. Whether
+     * the driver accepts a multi-statement init is not obvious from the Hikari
+     * API, and getting it wrong fails at first connection — i.e. at startup, in
+     * production. So actually open a connection and read the settings back.
+     */
+    @Test
+    void sqlitePoolAppliesItsInitPragmas() throws Exception {
+        Path file = Files.createTempFile("chatterbox-db-test", ".db");
+        Files.delete(file);
+        try (var db = new Database(sqlite(file));
+             var conn = db.dataSource().getConnection();
+             var st = conn.createStatement()) {
+
+            try (var rs = st.executeQuery("PRAGMA foreign_keys")) {
+                assertTrue(rs.next());
+                assertEquals(1, rs.getInt(1), "ON DELETE CASCADE depends on this");
+            }
+            try (var rs = st.executeQuery("PRAGMA journal_mode")) {
+                assertTrue(rs.next());
+                assertEquals("wal", rs.getString(1).toLowerCase(java.util.Locale.ROOT));
+            }
+            try (var rs = st.executeQuery("PRAGMA busy_timeout")) {
+                assertTrue(rs.next());
+                assertEquals(5000, rs.getInt(1));
+            }
+        } finally {
+            Files.deleteIfExists(file);
+            Files.deleteIfExists(Path.of(file + "-wal"));
+            Files.deleteIfExists(Path.of(file + "-shm"));
+        }
+    }
+
+    @Test
+    void detectsDialectFromTheUrl() throws Exception {
+        Path file = Files.createTempFile("chatterbox-db-dialect", ".db");
+        Files.delete(file);
+        try (var db = new Database(sqlite(file))) {
+            assertEquals(SQLDialect.SQLITE, db.dialect());
+        } finally {
+            Files.deleteIfExists(file);
+        }
+    }
+
+    @Test
+    void rejectsAnUnsupportedUrlWithoutLeakingCredentials() {
+        var cfg = new Config.DatabaseConfig(
+                "jdbc:mysql://chatterbox:hunter2@db/chatterbox", "", "");
+
+        var e = assertThrows(RuntimeException.class, () -> new Database(cfg));
+
+        // Main logs this message on a fatal startup error, so the password
+        // must not ride along into the container log.
+        assertFalse(String.valueOf(e.getMessage()).contains("hunter2"),
+                () -> "credential leaked into: " + e.getMessage());
+    }
+
+    // ---- redact ----
+
+    @Test
+    void redactMasksThePasswordQueryParameter() {
+        assertEquals("jdbc:postgresql://db/chatterbox?user=bot&password=***",
+                Database.redact("jdbc:postgresql://db/chatterbox?user=bot&password=hunter2"));
+    }
+
+    @Test
+    void redactMasksUserInfoCredentials() {
+        // The form the original pattern missed entirely.
+        assertEquals("jdbc:postgresql://bot:***@db/chatterbox",
+                Database.redact("jdbc:postgresql://bot:hunter2@db/chatterbox"));
+    }
+
+    @Test
+    void redactLeavesCredentialFreeUrlsAlone() {
+        assertEquals("jdbc:sqlite:/data/chatterbox.db",
+                Database.redact("jdbc:sqlite:/data/chatterbox.db"));
+        assertEquals("jdbc:postgresql://db:5432/chatterbox",
+                Database.redact("jdbc:postgresql://db:5432/chatterbox"));
+    }
+
+    @Test
+    void redactToleratesNull() {
+        assertEquals("", Database.redact(null));
+    }
+}

--- a/src/test/java/ca/ryanmorrison/chatterbox/db/MigrationsTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/db/MigrationsTest.java
@@ -1,0 +1,112 @@
+package ca.ryanmorrison.chatterbox.db;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.jooq.SQLDialect;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers the location-resolution logic, which is the part that silently
+ * mis-migrates rather than failing loudly: a wrong dialect subfolder or a
+ * missing {@code classpath:} prefix resolves to nothing, and Flyway reports
+ * zero migrations applied rather than an error.
+ */
+class MigrationsTest {
+
+    private Path dbFile;
+    private HikariDataSource dataSource;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbFile = Files.createTempFile("chatterbox-migrations-test", ".db");
+        Files.delete(dbFile);
+        var hc = new HikariConfig();
+        hc.setJdbcUrl("jdbc:sqlite:" + dbFile);
+        hc.setMaximumPoolSize(1);
+        dataSource = new HikariDataSource(hc);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (dataSource != null) dataSource.close();
+        if (dbFile != null) Files.deleteIfExists(dbFile);
+    }
+
+    private boolean tableExists(String name) throws Exception {
+        try (var conn = dataSource.getConnection();
+             var st = conn.prepareStatement(
+                     "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?")) {
+            st.setString(1, name);
+            try (var rs = st.executeQuery()) {
+                return rs.next();
+            }
+        }
+    }
+
+    @Test
+    void resolvesTheDialectSubfolderAndAppliesMigrations() throws Exception {
+        Migrations.run(dataSource, List.of("db/migration/shout"), SQLDialect.SQLITE);
+
+        assertTrue(tableExists("shouts"), "expected the sqlite variant to be applied");
+        assertTrue(tableExists("shout_history"));
+    }
+
+    @Test
+    void acceptsLocationsThatAlreadyCarryTheClasspathPrefix() throws Exception {
+        // Bootstrap passes one of each: module-declared locations are bare,
+        // but the runtime-config location is written with the prefix.
+        Migrations.run(dataSource, List.of("classpath:db/migration/runtime-config"),
+                SQLDialect.SQLITE);
+
+        assertTrue(tableExists("runtime_config"));
+    }
+
+    @Test
+    void appliesEveryModuleLocationIntoOneHistory() throws Exception {
+        Migrations.run(dataSource,
+                List.of("db/migration/shout", "classpath:db/migration/runtime-config",
+                        "db/migration/rss"),
+                SQLDialect.SQLITE);
+
+        assertTrue(tableExists("shouts"));
+        assertTrue(tableExists("runtime_config"));
+        assertTrue(tableExists("rss_feeds"));
+        // All modules deliberately share a single history table, which is why
+        // migration versions are timestamps.
+        assertTrue(tableExists("flyway_schema_history"));
+    }
+
+    @Test
+    void doesNothingWhenNoLocationsAreRegistered() throws Exception {
+        assertDoesNotThrow(() -> Migrations.run(dataSource, List.of(), SQLDialect.SQLITE));
+        assertEquals(false, tableExists("flyway_schema_history"));
+    }
+
+    @Test
+    void rejectsADialectWithNoMigrationSubfolder() {
+        // Better to fail loudly than to resolve to a folder that doesn't exist
+        // and quietly apply nothing.
+        var e = assertThrows(IllegalArgumentException.class,
+                () -> Migrations.run(dataSource, List.of("db/migration/shout"), SQLDialect.MYSQL));
+        assertTrue(e.getMessage().contains("MYSQL"));
+    }
+
+    @Test
+    void isIdempotentAcrossRuns() throws Exception {
+        Migrations.run(dataSource, List.of("db/migration/shout"), SQLDialect.SQLITE);
+        assertDoesNotThrow(
+                () -> Migrations.run(dataSource, List.of("db/migration/shout"), SQLDialect.SQLITE));
+        assertTrue(tableExists("shouts"));
+    }
+}

--- a/src/test/java/ca/ryanmorrison/chatterbox/db/PostgresRepositoryTestBase.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/db/PostgresRepositoryTestBase.java
@@ -1,0 +1,93 @@
+package ca.ryanmorrison.chatterbox.db;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.flywaydb.core.Flyway;
+import org.jooq.DSLContext;
+import org.jooq.SQLDialect;
+import org.jooq.impl.DSL;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+/**
+ * Base for repository tests that run against a real PostgreSQL container.
+ *
+ * <p>Exists for two reasons. The obvious one is that the Hikari + Flyway +
+ * {@code DSL.using} setup was copy-pasted verbatim across every repository
+ * test. The important one is dialect parity: the generated jOOQ classes are
+ * produced against PostgreSQL but executed against SQLite in most deployments,
+ * so a repository verified against only one dialect is only half verified.
+ * Subclass this <em>and</em> {@link SqliteRepositoryTestBase} for anything
+ * using constructs whose SQL differs by dialect — {@code charLength},
+ * {@code countDistinct}, {@code onConflict}, multi-column {@code GROUP BY}.
+ *
+ * <p>Subclasses declare which migration folder to apply via
+ * {@link #migrationLocation()}.
+ */
+public abstract class PostgresRepositoryTestBase {
+
+    /**
+     * Matches the image used in production (see docker-compose.yml). Tests
+     * previously ran 17 while production ran 18.
+     */
+    private static final String IMAGE = "postgres:18-alpine";
+
+    private static PostgreSQLContainer<?> postgres;
+    private static HikariDataSource dataSource;
+
+    protected static DSLContext dsl;
+
+    /** Classpath location of this feature's PostgreSQL migrations. */
+    protected abstract String migrationLocation();
+
+    @BeforeAll
+    static void startContainer() {
+        postgres = new PostgreSQLContainer<>(IMAGE)
+                .withDatabaseName("chatterbox_test")
+                .withUsername("test")
+                .withPassword("test");
+        postgres.start();
+
+        var hc = new HikariConfig();
+        hc.setJdbcUrl(postgres.getJdbcUrl());
+        hc.setUsername(postgres.getUsername());
+        hc.setPassword(postgres.getPassword());
+        dataSource = new HikariDataSource(hc);
+
+        dsl = DSL.using(dataSource, SQLDialect.POSTGRES);
+    }
+
+    @AfterAll
+    static void stopContainer() {
+        if (dataSource != null) dataSource.close();
+        if (postgres != null) postgres.stop();
+    }
+
+    /**
+     * Migrates and truncates before each test. Flyway is idempotent, so running
+     * it per-test costs nothing after the first and keeps the base usable
+     * without subclasses ordering their own setup.
+     */
+    @BeforeEach
+    void migrateAndReset() {
+        Flyway.configure()
+                .dataSource(dataSource)
+                .locations(migrationLocation())
+                .load()
+                .migrate();
+        truncateAll();
+    }
+
+    /** Empties every table Flyway created, leaving the schema in place. */
+    private void truncateAll() {
+        var tables = dsl.fetch(
+                "SELECT tablename FROM pg_tables WHERE schemaname = 'public' "
+                        + "AND tablename <> 'flyway_schema_history'");
+        for (var record : tables) {
+            String table = record.get(0, String.class);
+            dsl.execute("TRUNCATE TABLE " + dsl.render(DSL.name(table)) + " RESTART IDENTITY CASCADE");
+        }
+    }
+}

--- a/src/test/java/ca/ryanmorrison/chatterbox/db/SqliteRepositoryTestBase.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/db/SqliteRepositoryTestBase.java
@@ -1,0 +1,75 @@
+package ca.ryanmorrison.chatterbox.db;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.flywaydb.core.Flyway;
+import org.jooq.DSLContext;
+import org.jooq.SQLDialect;
+import org.jooq.conf.Settings;
+import org.jooq.impl.DSL;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Base for repository tests that run against a file-backed SQLite database.
+ *
+ * <p>Collapses the Hikari + Flyway + {@code DSL.using} block that was
+ * copy-pasted across every {@code *SqliteTest}. The three settings that matter
+ * and are easy to get wrong are fixed here: a pool of one (SQLite serialises
+ * writes), {@code foreign_keys} on (off per-connection by default, so
+ * {@code ON DELETE CASCADE} silently does nothing without it), and
+ * {@code withRenderSchema(false)} (the generated classes embed a {@code public}
+ * schema that SQLite doesn't have).
+ *
+ * <p>Subclasses declare which migration folder to apply via
+ * {@link #migrationLocation()}.
+ */
+public abstract class SqliteRepositoryTestBase {
+
+    private Path dbFile;
+    private HikariDataSource dataSource;
+
+    protected DSLContext dsl;
+
+    /** Classpath location of this feature's SQLite migrations. */
+    protected abstract String migrationLocation();
+
+    @BeforeEach
+    void openDatabase() throws Exception {
+        dbFile = Files.createTempFile("chatterbox-test", ".db");
+        Files.delete(dbFile);
+
+        var hc = new HikariConfig();
+        hc.setJdbcUrl("jdbc:sqlite:" + dbFile);
+        hc.setMaximumPoolSize(1);
+        hc.addDataSourceProperty("foreign_keys", "true");
+        dataSource = new HikariDataSource(hc);
+
+        Flyway.configure()
+                .dataSource(dataSource)
+                .locations(migrationLocation())
+                .load()
+                .migrate();
+
+        dsl = DSL.using(dataSource, SQLDialect.SQLITE, new Settings().withRenderSchema(false));
+    }
+
+    @AfterEach
+    void closeDatabase() throws Exception {
+        if (dataSource != null) dataSource.close();
+        if (dbFile != null) {
+            Files.deleteIfExists(dbFile);
+            // WAL leaves sidecar files behind.
+            Files.deleteIfExists(Path.of(dbFile + "-wal"));
+            Files.deleteIfExists(Path.of(dbFile + "-shm"));
+        }
+    }
+
+    /** The live datasource, for the rare test that needs raw JDBC. */
+    protected HikariDataSource dataSource() {
+        return dataSource;
+    }
+}

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/autoreply/AutoReplyRepositorySqliteTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/autoreply/AutoReplyRepositorySqliteTest.java
@@ -1,18 +1,9 @@
 package ca.ryanmorrison.chatterbox.features.autoreply;
 
-import com.zaxxer.hikari.HikariConfig;
-import com.zaxxer.hikari.HikariDataSource;
-import org.flywaydb.core.Flyway;
-import org.jooq.DSLContext;
-import org.jooq.SQLDialect;
-import org.jooq.conf.Settings;
-import org.jooq.impl.DSL;
-import org.junit.jupiter.api.AfterEach;
+import ca.ryanmorrison.chatterbox.db.SqliteRepositoryTestBase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Optional;
 
 import static ca.ryanmorrison.chatterbox.db.generated.Tables.AUTO_REPLIES;
@@ -20,43 +11,24 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Verifies the SQLite migration is wire-compatible with the generated jOOQ classes. */
-class AutoReplyRepositorySqliteTest {
+class AutoReplyRepositorySqliteTest extends SqliteRepositoryTestBase {
 
     private static final long CHANNEL = 1L;
     private static final long AUTHOR  = 7777L;
     private static final long EDITOR  = 9999L;
 
-    private Path dbFile;
-    private HikariDataSource dataSource;
-    private DSLContext dsl;
     private AutoReplyRepository repo;
 
+    @Override
+    protected String migrationLocation() {
+        return "classpath:db/migration/autoreply/sqlite";
+    }
+
     @BeforeEach
-    void setUp() throws Exception {
-        dbFile = Files.createTempFile("chatterbox-test", ".db");
-        Files.delete(dbFile);
-
-        var hc = new HikariConfig();
-        hc.setJdbcUrl("jdbc:sqlite:" + dbFile);
-        hc.setMaximumPoolSize(1);
-        hc.setConnectionInitSql("PRAGMA foreign_keys = ON");
-        dataSource = new HikariDataSource(hc);
-
-        Flyway.configure()
-                .dataSource(dataSource)
-                .locations("classpath:db/migration/autoreply/sqlite")
-                .load()
-                .migrate();
-
-        dsl = DSL.using(dataSource, SQLDialect.SQLITE, new Settings().withRenderSchema(false));
+    void createRepositories() {
         repo = new AutoReplyRepository(dsl);
     }
 
-    @AfterEach
-    void tearDown() throws Exception {
-        if (dataSource != null) dataSource.close();
-        if (dbFile != null) Files.deleteIfExists(dbFile);
-    }
 
     @Test
     void insertAndFetchAgainstSqlite() {

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/decide/DecideModuleTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/decide/DecideModuleTest.java
@@ -35,4 +35,32 @@ class DecideModuleTest {
         assertFalse(rendered.length() > 2000,
                 "rendered message must remain under Discord's 2000 char cap");
     }
+
+    @Test
+    void oversizedSingleOptionIsTruncatedToDiscordsLimit() {
+        // One whitespace-free option means options.size() == 1, which skips the
+        // truncated "from" line -- nothing else used to bound the output.
+        String huge = "x".repeat(6000);
+        String out = DecideModule.renderResult(huge, java.util.List.of(huge));
+        assertTrue(out.length() <= DecideModule.MAX_MESSAGE_LENGTH,
+                () -> "rendered " + out.length() + " chars");
+    }
+
+    @Test
+    void oversizedManyOptionsAreTruncatedToDiscordsLimit() {
+        java.util.List<String> many = new java.util.ArrayList<>();
+        for (int i = 0; i < 400; i++) many.add("option-" + i + "-" + "y".repeat(20));
+        String out = DecideModule.renderResult(many.get(0), many);
+        assertTrue(out.length() <= DecideModule.MAX_MESSAGE_LENGTH,
+                () -> "rendered " + out.length() + " chars");
+    }
+
+    @Test
+    void truncationNeverSplitsASurrogatePair() {
+        String emoji = "\uD83C\uDF89".repeat(2000); // party popper
+        String out = DecideModule.renderResult(emoji, java.util.List.of(emoji));
+        assertTrue(out.length() <= DecideModule.MAX_MESSAGE_LENGTH);
+        assertFalse(Character.isHighSurrogate(out.charAt(out.length() - 2)),
+                "a lone high surrogate would render as a replacement char");
+    }
 }

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/format/TextStyleTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/format/TextStyleTest.java
@@ -3,6 +3,8 @@ package ca.ryanmorrison.chatterbox.features.format;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class TextStyleTest {
@@ -104,5 +106,27 @@ class TextStyleTest {
                     s.value() != null && !s.value().isBlank(),
                     "style " + s.name() + " missing a value");
         }
+    }
+
+    @Test
+    void clapExpansionIsTruncatedToDiscordsLimit() {
+        // clap replaces each whitespace run with " \uD83D\uDC4F " -- 4 UTF-16 units --
+        // so a 1500-char input of single-character words expands well past 2000.
+        String input = ("a ".repeat(750)).trim();
+        String expanded = TextStyle.CLAP.apply(input);
+        assertTrue(expanded.length() > FormatModule.MAX_MESSAGE_LENGTH,
+                "precondition: the style must actually overflow");
+
+        String out = FormatModule.truncate(expanded, FormatModule.MAX_MESSAGE_LENGTH);
+
+        assertTrue(out.length() <= FormatModule.MAX_MESSAGE_LENGTH,
+                () -> "truncated to " + out.length() + " chars");
+        assertFalse(Character.isHighSurrogate(out.charAt(out.length() - 2)),
+                "a lone high surrogate would render as a replacement char");
+    }
+
+    @Test
+    void truncateLeavesShortStringsAlone() {
+        assertEquals("hello", FormatModule.truncate("hello", FormatModule.MAX_MESSAGE_LENGTH));
     }
 }

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/isitdown/IsItDownCheckerTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/isitdown/IsItDownCheckerTest.java
@@ -8,9 +8,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.URI;
+import java.net.UnknownHostException;
 import java.net.http.HttpClient;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicReference;
@@ -35,9 +37,24 @@ class IsItDownCheckerTest {
         // Tight timeouts on the test client so timeout cases don't drag.
         HttpClient http = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(2))
-                .followRedirects(HttpClient.Redirect.NORMAL)
+                .followRedirects(HttpClient.Redirect.NEVER)
                 .build();
-        checker = new IsItDownChecker(http, 5);
+        // The test server is on loopback, which UrlGuard denies — so redirect
+        // hops are vetted through a resolver that reports a public address.
+        // Only redirect targets are resolved, so this is inert for every test
+        // that doesn't redirect. Deny-list behaviour is covered separately by
+        // redirectToBlockedAddressIsRefused and by UrlGuardTest.
+        checker = new IsItDownChecker(http, 5, IsItDownCheckerTest::publicAddress);
+    }
+
+    /** Pretends every host resolves to a routable public address (example.com's). */
+    private static InetAddress[] publicAddress(String host) {
+        try {
+            return new InetAddress[]{
+                    InetAddress.getByAddress(host, new byte[]{93, (byte) 184, (byte) 216, 34})};
+        } catch (UnknownHostException e) {
+            throw new IllegalStateException(e);
+        }
     }
 
     @AfterEach
@@ -82,6 +99,53 @@ class IsItDownCheckerTest {
         });
         serve("/to", 200, new byte[0]);
         assertInstanceOf(CheckResult.Live.class, checker.check(url("/from")));
+    }
+
+    /**
+     * The SSRF regression test. Before redirects were re-validated, a public
+     * host could 302 to a denied address and the client would follow it,
+     * turning /isitdown into an internal-service oracle. Uses the real
+     * resolver, so the loopback redirect target is genuinely denied.
+     */
+    @Test
+    void redirectToBlockedAddressIsRefused() {
+        serve("/evil", ex -> {
+            ex.getResponseHeaders().add("Location", "http://127.0.0.1:1/secret");
+            ex.sendResponseHeaders(302, -1);
+            ex.close();
+        });
+        IsItDownChecker guarded = new IsItDownChecker(HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(2))
+                .followRedirects(HttpClient.Redirect.NEVER)
+                .build(), 5);
+
+        var result = guarded.check(url("/evil"));
+
+        var disallowed = assertInstanceOf(CheckResult.Disallowed.class, result);
+        assertTrue(disallowed.reason().contains("loopback"),
+                () -> "expected the loopback deny reason, got: " + disallowed.reason());
+    }
+
+    @Test
+    void redirectWithoutLocationIsRefused() {
+        serve("/nowhere", ex -> {
+            ex.sendResponseHeaders(301, -1);
+            ex.close();
+        });
+        assertInstanceOf(CheckResult.Disallowed.class, checker.check(url("/nowhere")));
+    }
+
+    @Test
+    void redirectLoopStopsAtTheHopLimit() {
+        serve("/loop", ex -> {
+            ex.getResponseHeaders().add("Location", "/loop");
+            ex.sendResponseHeaders(302, -1);
+            ex.close();
+        });
+        var result = checker.check(url("/loop"));
+        var disallowed = assertInstanceOf(CheckResult.Disallowed.class, result);
+        assertTrue(disallowed.reason().contains("too many redirects"),
+                () -> "got: " + disallowed.reason());
     }
 
     @Test
@@ -136,7 +200,7 @@ class IsItDownCheckerTest {
         });
         IsItDownChecker fast = new IsItDownChecker(HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(1))
-                .followRedirects(HttpClient.Redirect.NORMAL)
+                .followRedirects(HttpClient.Redirect.NEVER)
                 .build(), 1);
         var result = fast.check(url("/slow"));
         var timeout = assertInstanceOf(CheckResult.Timeout.class, result);

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/rss/RssFetcherTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/rss/RssFetcherTest.java
@@ -1,12 +1,15 @@
 package ca.ryanmorrison.chatterbox.features.rss;
 
+import ca.ryanmorrison.chatterbox.common.net.UrlGuard;
 import com.sun.net.httpserver.HttpServer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -25,7 +28,29 @@ class RssFetcherTest {
         server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
         port = server.getAddress().getPort();
         server.start();
-        fetcher = new RssFetcher();
+        // The test server is on loopback, which UrlGuard denies outright, so
+        // the deny check is fed a resolver reporting a public address. The
+        // request still goes to loopback. Deny-list behaviour itself is covered
+        // by refusesPrivateAddress below and by UrlGuardTest.
+        fetcher = new RssFetcher(RssFetcherTest::publicAddress);
+    }
+
+    /**
+     * Reports the loopback test server as a public address, and resolves
+     * everything else for real. Faking <em>every</em> host would also whitelist
+     * redirect targets and quietly disarm the check the redirect test exists to
+     * prove.
+     */
+    private static InetAddress[] publicAddress(String host) {
+        if (!"127.0.0.1".equals(host)) {
+            return UrlGuard.systemResolver(host);
+        }
+        try {
+            return new InetAddress[]{
+                    InetAddress.getByAddress(host, new byte[]{93, (byte) 184, (byte) 216, 34})};
+        } catch (UnknownHostException e) {
+            throw new IllegalStateException(e);
+        }
     }
 
     @AfterEach
@@ -139,6 +164,81 @@ class RssFetcherTest {
         var ex = assertThrows(RssFetcher.FetchException.class,
                 () -> fetcher.validate(url("/notitle")));
         assertTrue(ex.getMessage().toLowerCase().contains("title"));
+    }
+
+    // ---- SSRF ----
+
+    /**
+     * The core SSRF regression: /rss add is reachable by any guild member, so
+     * the fetcher must refuse private address space. Uses the real resolver, so
+     * loopback is genuinely denied.
+     */
+    @Test
+    void refusesPrivateAddress() {
+        RssFetcher guarded = new RssFetcher();
+        var ex = assertThrows(RssFetcher.FetchException.class,
+                () -> guarded.validate(url("/rss")));
+        assertTrue(ex.getMessage().contains("loopback"),
+                () -> "expected the loopback deny reason, got: " + ex.getMessage());
+    }
+
+    @Test
+    void refusesCloudMetadataAddress() {
+        RssFetcher guarded = new RssFetcher();
+        var ex = assertThrows(RssFetcher.FetchException.class,
+                () -> guarded.validate("http://169.254.169.254/latest/meta-data/"));
+        assertTrue(ex.getMessage().contains("link-local"),
+                () -> "got: " + ex.getMessage());
+    }
+
+    /** The scheduler path must be guarded too, not just /rss add. */
+    @Test
+    void fetchAlsoRefusesPrivateAddress() {
+        RssFetcher guarded = new RssFetcher();
+        assertThrows(RssFetcher.FetchException.class, () -> guarded.fetch(url("/rss")));
+    }
+
+    @Test
+    void redirectToBlockedAddressIsRefused() {
+        server.createContext("/redirect", ex -> {
+            ex.getResponseHeaders().add("Location", "http://169.254.169.254/latest/meta-data/");
+            ex.sendResponseHeaders(302, -1);
+            ex.close();
+        });
+        var ex = assertThrows(RssFetcher.FetchException.class,
+                () -> fetcher.validate(url("/redirect")));
+        assertTrue(ex.getMessage().contains("link-local"),
+                () -> "expected the redirect target to be denied, got: " + ex.getMessage());
+    }
+
+    // ---- parser hardening ----
+
+    @Test
+    void rejectsDoctypeSoExternalEntitiesNeverResolve() {
+        // XXE probe: if doctypes were allowed, the parser would try to read
+        // /etc/passwd. Rejecting the document outright is the desired outcome.
+        String xxe = """
+                <?xml version="1.0"?>
+                <!DOCTYPE rss [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>
+                <rss version="2.0"><channel>
+                  <title>&xxe;</title><link>x</link><description>y</description>
+                </channel></rss>
+                """;
+        serve("/xxe", 200, "application/rss+xml", xxe);
+        assertThrows(RssFetcher.FetchException.class, () -> fetcher.validate(url("/xxe")));
+    }
+
+    @Test
+    void rejectsBodyOverTheSizeCap() {
+        // Padding inside a comment keeps the document well-formed, so the only
+        // thing that can reject it is the size cap.
+        StringBuilder sb = new StringBuilder("<?xml version=\"1.0\"?><!--");
+        sb.append("x".repeat(RssFetcher.MAX_RESPONSE_BYTES + 1024));
+        sb.append("--><rss version=\"2.0\"><channel><title>t</title></channel></rss>");
+        serve("/huge", 200, "application/rss+xml", sb.toString());
+        var ex = assertThrows(RssFetcher.FetchException.class,
+                () -> fetcher.validate(url("/huge")));
+        assertTrue(ex.getMessage().contains("larger than"), () -> "got: " + ex.getMessage());
     }
 
     @Test

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/rss/RssRepositorySqliteTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/rss/RssRepositorySqliteTest.java
@@ -1,18 +1,9 @@
 package ca.ryanmorrison.chatterbox.features.rss;
 
-import com.zaxxer.hikari.HikariConfig;
-import com.zaxxer.hikari.HikariDataSource;
-import org.flywaydb.core.Flyway;
-import org.jooq.DSLContext;
-import org.jooq.SQLDialect;
-import org.jooq.conf.Settings;
-import org.jooq.impl.DSL;
-import org.junit.jupiter.api.AfterEach;
+import ca.ryanmorrison.chatterbox.db.SqliteRepositoryTestBase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Optional;
 
 import static ca.ryanmorrison.chatterbox.db.generated.Tables.RSS_FEEDS;
@@ -20,43 +11,24 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Verifies the SQLite migration is wire-compatible with the generated jOOQ classes. */
-class RssRepositorySqliteTest {
+class RssRepositorySqliteTest extends SqliteRepositoryTestBase {
 
     private static final long GUILD   = 100L;
     private static final long CHANNEL = 1L;
     private static final long USER    = 7777L;
 
-    private Path dbFile;
-    private HikariDataSource dataSource;
-    private DSLContext dsl;
     private RssRepository repo;
 
+    @Override
+    protected String migrationLocation() {
+        return "classpath:db/migration/rss/sqlite";
+    }
+
     @BeforeEach
-    void setUp() throws Exception {
-        dbFile = Files.createTempFile("chatterbox-rss-test", ".db");
-        Files.delete(dbFile);
-
-        var hc = new HikariConfig();
-        hc.setJdbcUrl("jdbc:sqlite:" + dbFile);
-        hc.setMaximumPoolSize(1);
-        hc.setConnectionInitSql("PRAGMA foreign_keys = ON");
-        dataSource = new HikariDataSource(hc);
-
-        Flyway.configure()
-                .dataSource(dataSource)
-                .locations("classpath:db/migration/rss/sqlite")
-                .load()
-                .migrate();
-
-        dsl = DSL.using(dataSource, SQLDialect.SQLITE, new Settings().withRenderSchema(false));
+    void createRepositories() {
         repo = new RssRepository(dsl);
     }
 
-    @AfterEach
-    void tearDown() throws Exception {
-        if (dataSource != null) dataSource.close();
-        if (dbFile != null) Files.deleteIfExists(dbFile);
-    }
 
     @Test
     void insertAndFetchAgainstSqlite() {

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/rss/RssSchedulerDiffTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/rss/RssSchedulerDiffTest.java
@@ -34,6 +34,36 @@ class RssSchedulerDiffTest {
     }
 
     @Test
+    void datelessEntriesSortLastSoTheyNeverBecomeTheMarker() {
+        // The head of this list is what gets persisted as the marker. A
+        // dateless entry landing there wipes the stored publish date and
+        // degrades the date-floor fallback, so dated entries must win.
+        OffsetDateTime t0 = OffsetDateTime.parse("2026-01-01T00:00:00Z");
+        var undated = entry("no-date", null);
+        var older = entry("older", t0);
+        var newer = entry("newer", t0.plusHours(1));
+
+        List<SyndEntry> sorted = RssScheduler.sortNewestFirst(List.of(undated, older, newer));
+
+        assertEquals("newer", RssScheduler.entryId(sorted.get(0)));
+        assertEquals("older", RssScheduler.entryId(sorted.get(1)));
+        assertEquals("no-date", RssScheduler.entryId(sorted.get(2)));
+    }
+
+    @Test
+    void aFeedWithNoDatesAtAllKeepsSourceOrder() {
+        var a = entry("a", null);
+        var b = entry("b", null);
+        var c = entry("c", null);
+
+        List<SyndEntry> sorted = RssScheduler.sortNewestFirst(List.of(a, b, c));
+
+        assertEquals("a", RssScheduler.entryId(sorted.get(0)));
+        assertEquals("b", RssScheduler.entryId(sorted.get(1)));
+        assertEquals("c", RssScheduler.entryId(sorted.get(2)));
+    }
+
+    @Test
     void stopsAtMarker() {
         OffsetDateTime t0 = OffsetDateTime.parse("2026-01-01T00:00:00Z");
         var newer1 = entry("c", t0.plusMinutes(20));

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/rss/RssSchedulerResilienceTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/rss/RssSchedulerResilienceTest.java
@@ -1,0 +1,70 @@
+package ca.ryanmorrison.chatterbox.features.rss;
+
+import org.jooq.exception.DataAccessException;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * The scheduler drives ticks through {@code scheduleAtFixedRate}, which
+ * <em>permanently cancels</em> a task the first time its runnable throws. So
+ * "tick doesn't propagate" is exactly equivalent to "the feed keeps
+ * refreshing" — a single transient DB error used to silently retire a feed
+ * until the process restarted.
+ *
+ * <p>Each test pokes a different unguarded call site; before the fix only the
+ * fetch itself was inside a try/catch.
+ */
+class RssSchedulerResilienceTest {
+
+    private static final long FEED_ID = 7L;
+
+    private static Feed feed() {
+        return new Feed(FEED_ID, 100L, 200L, "https://example.com/feed.xml", "Example",
+                300L, 60, Optional.empty(), Optional.empty(), Optional.empty(),
+                OffsetDateTime.parse("2026-01-01T00:00:00Z"));
+    }
+
+    private static RssScheduler scheduler(RssRepository repo) {
+        return new RssScheduler(repo, mock(RssFetcher.class));
+    }
+
+    @Test
+    void tickSurvivesFailureLoadingTheFeed() {
+        RssRepository repo = mock(RssRepository.class);
+        when(repo.findById(FEED_ID))
+                .thenThrow(new DataAccessException("connection pool exhausted"));
+
+        assertDoesNotThrow(() -> scheduler(repo).tick(FEED_ID));
+    }
+
+    @Test
+    void tickSurvivesFailureStampingTheRefreshTime() throws Exception {
+        RssRepository repo = mock(RssRepository.class);
+        when(repo.findById(FEED_ID)).thenReturn(Optional.of(feed()));
+        doThrow(new DataAccessException("database is locked"))
+                .when(repo).touchRefreshedAt(anyLong(), any(OffsetDateTime.class));
+
+        RssFetcher fetcher = mock(RssFetcher.class);
+        when(fetcher.fetch(any())).thenThrow(new RssFetcher.FetchException("unreachable"));
+
+        var scheduler = new RssScheduler(repo, fetcher);
+        assertDoesNotThrow(() -> scheduler.tick(FEED_ID));
+    }
+
+    @Test
+    void tickSurvivesAnErrorNotJustAnException() {
+        RssRepository repo = mock(RssRepository.class);
+        when(repo.findById(FEED_ID)).thenThrow(new StackOverflowError("deep"));
+
+        assertDoesNotThrow(() -> scheduler(repo).tick(FEED_ID));
+    }
+}

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/shortener/ShortenerRedirectHandlerTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/shortener/ShortenerRedirectHandlerTest.java
@@ -161,6 +161,37 @@ class ShortenerRedirectHandlerTest {
     }
 
     @Test
+    void implausibleTokensAreRejectedWithoutTouchingTheDatabase() throws Exception {
+        // Scanner traffic (/.env, /wp-login.php) must be turned away on shape
+        // alone — the DB is a single SQLite connection shared with the bot.
+        var rejected = new String[]{
+                "wp-login.php",   // wrong length, illegal chars
+                ".env",           // wrong length
+                "abcde",          // one char short
+                "abcdefg",        // one char long
+                "abc-12",         // hyphen isn't in the base36 alphabet
+        };
+        for (String token : rejected) {
+            assertEquals(404, get(token).statusCode(), () -> "expected 404 for " + token);
+        }
+    }
+
+    @Test
+    void storedNonHttpUrlIsRefusedRatherThanRedirectedTo() throws Exception {
+        // Defence in depth: both write paths validate, so this row can only
+        // appear via a new insert path or a hand-edited database. It must never
+        // reach a Location header or an href.
+        dsl.execute("INSERT INTO shortened_urls (token, url, created_by, created_at, click_count) "
+                + "VALUES ('evilaa', 'javascript:alert(1)', " + USER + ", '2026-05-09T20:00:00.000Z', 0)");
+
+        HttpResponse<String> res = get("evilaa");
+
+        assertEquals(404, res.statusCode());
+        assertTrue(res.headers().firstValue("Location").isEmpty(),
+                "a rejected target must not leak into the Location header");
+    }
+
+    @Test
     void uppercasePathIsNormalisedToLowercase() throws Exception {
         // Tokens are stored lowercase; the handler should be case-insensitive
         // so users typing the URL by hand still land on the destination AND

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/shortener/ShortenerRepositoryPostgresTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/shortener/ShortenerRepositoryPostgresTest.java
@@ -1,0 +1,94 @@
+package ca.ryanmorrison.chatterbox.features.shortener;
+
+import ca.ryanmorrison.chatterbox.db.PostgresRepositoryTestBase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Dialect-parity coverage for {@link ShortenerRepository}, previously verified
+ * against SQLite only. Exercises the two constructs whose rendered SQL differs
+ * by dialect: {@code returning().fetchOne()} on insert and the
+ * {@code CLICK_COUNT.plus(1)} atomic increment.
+ */
+class ShortenerRepositoryPostgresTest extends PostgresRepositoryTestBase {
+
+    private static final long USER = 4242L;
+    private static final long MOD = 9999L;
+    private static final OffsetDateTime NOW =
+            OffsetDateTime.of(2026, 5, 9, 20, 0, 0, 0, ZoneOffset.UTC);
+
+    private ShortenerRepository repo;
+
+    @Override
+    protected String migrationLocation() {
+        return "classpath:db/migration/shortener/postgresql";
+    }
+
+    @BeforeEach
+    void createRepository() {
+        repo = new ShortenerRepository(dsl);
+    }
+
+    /** insert(...).returning().fetchOne() — the generated-key path. */
+    @Test
+    void insertReturnsTheStoredRow() {
+        var created = repo.insert("abc123", "https://example.com/x", USER, NOW).orElseThrow();
+
+        assertEquals("abc123", created.token());
+        assertEquals("https://example.com/x", created.url());
+        assertTrue(created.id() > 0, "expected a generated id");
+    }
+
+    @Test
+    void findByTokenReturnsLiveRowsOnly() {
+        long id = repo.insert("abc123", "https://example.com/x", USER, NOW).orElseThrow().id();
+        assertTrue(repo.findByToken("abc123").isPresent());
+
+        repo.softDelete(id, MOD, NOW);
+
+        assertTrue(repo.findByToken("abc123").isEmpty());
+        assertTrue(repo.findByTokenIncludingDeleted("abc123").isPresent());
+    }
+
+    @Test
+    void duplicateTokenIsRejected() {
+        repo.insert("abc123", "https://example.com/x", USER, NOW).orElseThrow();
+        assertTrue(repo.insert("abc123", "https://example.com/y", USER, NOW).isEmpty(),
+                "the unique constraint should surface as an empty Optional");
+    }
+
+    /** CLICK_COUNT.plus(1) — the atomic in-place increment. */
+    @Test
+    void incrementClicksAccumulates() {
+        long id = repo.insert("abc123", "https://example.com/x", USER, NOW).orElseThrow().id();
+
+        repo.incrementClicks(id, NOW);
+        repo.incrementClicks(id, NOW.plusMinutes(1));
+        repo.incrementClicks(id, NOW.plusMinutes(2));
+
+        var after = repo.findByIdIncludingDeleted(id).orElseThrow();
+        assertEquals(3L, after.clickCount());
+        assertEquals(NOW.plusMinutes(2), after.lastClickedAt().orElseThrow());
+    }
+
+    @Test
+    void softDeleteIsIdempotent() {
+        long id = repo.insert("abc123", "https://example.com/x", USER, NOW).orElseThrow().id();
+
+        assertEquals(1, repo.softDelete(id, MOD, NOW));
+        assertEquals(0, repo.softDelete(id, 1234L, NOW.plusHours(1)),
+                "a second delete must not overwrite the original deleter");
+    }
+
+    @Test
+    void findByUrlLocatesAnExistingLiveShortening() {
+        repo.insert("abc123", "https://example.com/x", USER, NOW).orElseThrow();
+        assertEquals("abc123", repo.findByUrl("https://example.com/x").orElseThrow().token());
+    }
+}

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/shortener/ShortenerRepositorySqliteTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/shortener/ShortenerRepositorySqliteTest.java
@@ -1,18 +1,9 @@
 package ca.ryanmorrison.chatterbox.features.shortener;
 
-import com.zaxxer.hikari.HikariConfig;
-import com.zaxxer.hikari.HikariDataSource;
-import org.flywaydb.core.Flyway;
-import org.jooq.DSLContext;
-import org.jooq.SQLDialect;
-import org.jooq.conf.Settings;
-import org.jooq.impl.DSL;
-import org.junit.jupiter.api.AfterEach;
+import ca.ryanmorrison.chatterbox.db.SqliteRepositoryTestBase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Optional;
@@ -23,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Verifies the SQLite migrations are wire-compatible with the generated jOOQ classes. */
-class ShortenerRepositorySqliteTest {
+class ShortenerRepositorySqliteTest extends SqliteRepositoryTestBase {
 
     private static final long USER = 4242L;
     private static final long MOD = 9999L;
@@ -32,37 +23,18 @@ class ShortenerRepositorySqliteTest {
     private static final OffsetDateTime LATER =
             OffsetDateTime.of(2026, 5, 3, 13, 0, 0, 0, ZoneOffset.UTC);
 
-    private Path dbFile;
-    private HikariDataSource dataSource;
-    private DSLContext dsl;
     private ShortenerRepository repo;
 
+    @Override
+    protected String migrationLocation() {
+        return "classpath:db/migration/shortener/sqlite";
+    }
+
     @BeforeEach
-    void setUp() throws Exception {
-        dbFile = Files.createTempFile("chatterbox-shortener-test", ".db");
-        Files.delete(dbFile);
-
-        var hc = new HikariConfig();
-        hc.setJdbcUrl("jdbc:sqlite:" + dbFile);
-        hc.setMaximumPoolSize(1);
-        hc.setConnectionInitSql("PRAGMA foreign_keys = ON");
-        dataSource = new HikariDataSource(hc);
-
-        Flyway.configure()
-                .dataSource(dataSource)
-                .locations("classpath:db/migration/shortener/sqlite")
-                .load()
-                .migrate();
-
-        dsl = DSL.using(dataSource, SQLDialect.SQLITE, new Settings().withRenderSchema(false));
+    void createRepositories() {
         repo = new ShortenerRepository(dsl);
     }
 
-    @AfterEach
-    void tearDown() throws Exception {
-        if (dataSource != null) dataSource.close();
-        if (dbFile != null) Files.deleteIfExists(dbFile);
-    }
 
     @Test
     void insertAndLookupByToken() {

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/shout/ShoutHistoryRepositorySqliteTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/shout/ShoutHistoryRepositorySqliteTest.java
@@ -1,18 +1,9 @@
 package ca.ryanmorrison.chatterbox.features.shout;
 
-import com.zaxxer.hikari.HikariConfig;
-import com.zaxxer.hikari.HikariDataSource;
-import org.flywaydb.core.Flyway;
-import org.jooq.DSLContext;
-import org.jooq.SQLDialect;
-import org.jooq.conf.Settings;
-import org.jooq.impl.DSL;
-import org.junit.jupiter.api.AfterEach;
+import ca.ryanmorrison.chatterbox.db.SqliteRepositoryTestBase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 
@@ -27,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Hikari's connection-init {@code PRAGMA foreign_keys = ON} actually applies
  * — without it, SQLite silently ignores the constraint.
  */
-class ShoutHistoryRepositorySqliteTest {
+class ShoutHistoryRepositorySqliteTest extends SqliteRepositoryTestBase {
 
     private static final OffsetDateTime AUTHORED_AT =
             OffsetDateTime.of(2026, 4, 30, 12, 0, 0, 0, ZoneOffset.UTC);
@@ -36,39 +27,20 @@ class ShoutHistoryRepositorySqliteTest {
     private static final boolean MOD = true;
     private static final boolean NON_MOD = false;
 
-    private Path dbFile;
-    private HikariDataSource dataSource;
-    private DSLContext dsl;
     private ShoutRepository shouts;
     private ShoutHistoryRepository history;
 
+    @Override
+    protected String migrationLocation() {
+        return "classpath:db/migration/shout/sqlite";
+    }
+
     @BeforeEach
-    void setUp() throws Exception {
-        dbFile = Files.createTempFile("chatterbox-test", ".db");
-        Files.delete(dbFile);
-
-        var hc = new HikariConfig();
-        hc.setJdbcUrl("jdbc:sqlite:" + dbFile);
-        hc.setMaximumPoolSize(1);
-        hc.setConnectionInitSql("PRAGMA foreign_keys = ON");
-        dataSource = new HikariDataSource(hc);
-
-        Flyway.configure()
-                .dataSource(dataSource)
-                .locations("classpath:db/migration/shout/sqlite")
-                .load()
-                .migrate();
-
-        dsl = DSL.using(dataSource, SQLDialect.SQLITE, new Settings().withRenderSchema(false));
+    void createRepositories() {
         shouts = new ShoutRepository(dsl);
         history = new ShoutHistoryRepository(dsl);
     }
 
-    @AfterEach
-    void tearDown() throws Exception {
-        if (dataSource != null) dataSource.close();
-        if (dbFile != null) Files.deleteIfExists(dbFile);
-    }
 
     private long shout(long channelId, long messageId, String content) {
         shouts.tryInsert(channelId, messageId, content, AUTHOR, AUTHORED_AT);

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/shout/ShoutRepositorySqliteTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/shout/ShoutRepositorySqliteTest.java
@@ -1,18 +1,9 @@
 package ca.ryanmorrison.chatterbox.features.shout;
 
-import com.zaxxer.hikari.HikariConfig;
-import com.zaxxer.hikari.HikariDataSource;
-import org.flywaydb.core.Flyway;
-import org.jooq.DSLContext;
-import org.jooq.SQLDialect;
-import org.jooq.conf.Settings;
-import org.jooq.impl.DSL;
-import org.junit.jupiter.api.AfterEach;
+import ca.ryanmorrison.chatterbox.db.SqliteRepositoryTestBase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Optional;
@@ -26,43 +17,24 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * enough that {@link ShoutRepository} works against either dialect using the
  * Postgres-generated jOOQ classes.
  */
-class ShoutRepositorySqliteTest {
+class ShoutRepositorySqliteTest extends SqliteRepositoryTestBase {
 
     private static final OffsetDateTime AUTHORED_AT =
             OffsetDateTime.of(2026, 4, 30, 12, 0, 0, 0, ZoneOffset.UTC);
     private static final long AUTHOR = 7777L;
 
-    private Path dbFile;
-    private HikariDataSource dataSource;
-    private DSLContext dsl;
     private ShoutRepository repo;
 
+    @Override
+    protected String migrationLocation() {
+        return "classpath:db/migration/shout/sqlite";
+    }
+
     @BeforeEach
-    void setUp() throws Exception {
-        dbFile = Files.createTempFile("chatterbox-test", ".db");
-        Files.delete(dbFile);
-
-        var hc = new HikariConfig();
-        hc.setJdbcUrl("jdbc:sqlite:" + dbFile);
-        hc.setMaximumPoolSize(1);
-        hc.setConnectionInitSql("PRAGMA foreign_keys = ON");
-        dataSource = new HikariDataSource(hc);
-
-        Flyway.configure()
-                .dataSource(dataSource)
-                .locations("classpath:db/migration/shout/sqlite")
-                .load()
-                .migrate();
-
-        dsl = DSL.using(dataSource, SQLDialect.SQLITE, new Settings().withRenderSchema(false));
+    void createRepositories() {
         repo = new ShoutRepository(dsl);
     }
 
-    @AfterEach
-    void tearDown() throws Exception {
-        if (dataSource != null) dataSource.close();
-        if (dbFile != null) Files.deleteIfExists(dbFile);
-    }
 
     @Test
     void insertAndFetchAgainstSqlite() {

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/shout/ShoutStatsRepositoryPostgresTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/shout/ShoutStatsRepositoryPostgresTest.java
@@ -1,0 +1,147 @@
+package ca.ryanmorrison.chatterbox.features.shout;
+
+import ca.ryanmorrison.chatterbox.db.PostgresRepositoryTestBase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Dialect-parity coverage for {@link ShoutStatsRepository}, which was verified
+ * against SQLite only.
+ *
+ * <p>It is the highest-risk repository for that gap: the generated jOOQ classes
+ * are produced against PostgreSQL but executed against SQLite, and this class
+ * leans on {@code charLength}, {@code countDistinct}, and a multi-column
+ * {@code GROUP BY} — exactly the constructs whose rendered SQL differs between
+ * the two.
+ */
+class ShoutStatsRepositoryPostgresTest extends PostgresRepositoryTestBase {
+
+    private static final long CHANNEL = 1L;
+    private static final long OTHER_CHANNEL = 2L;
+    private static final OffsetDateTime T0 =
+            OffsetDateTime.of(2026, 5, 1, 12, 0, 0, 0, ZoneOffset.UTC);
+
+    private ShoutRepository shouts;
+    private ShoutHistoryRepository history;
+    private ShoutStatsRepository stats;
+
+    @Override
+    protected String migrationLocation() {
+        return "classpath:db/migration/shout/postgresql";
+    }
+
+    @BeforeEach
+    void createRepositories() {
+        shouts = new ShoutRepository(dsl);
+        history = new ShoutHistoryRepository(dsl);
+        stats = new ShoutStatsRepository(dsl);
+    }
+
+    private void shout(long messageId, String content, long author, OffsetDateTime at) {
+        shouts.tryInsert(CHANNEL, messageId, content, author, at);
+    }
+
+    @Test
+    void countsLiveShouts() {
+        shout(100L, "HELLO", 10L, T0);
+        shout(101L, "GOODBYE", 11L, T0);
+        shouts.tryInsert(OTHER_CHANNEL, 102L, "ELSEWHERE", 12L, T0);
+
+        assertEquals(2, stats.countLive(CHANNEL));
+    }
+
+    /** countDistinct renders differently per dialect. */
+    @Test
+    void countsDistinctShouters() {
+        shout(100L, "ONE", 10L, T0);
+        shout(101L, "TWO", 10L, T0);
+        shout(102L, "THREE", 11L, T0);
+
+        assertEquals(2, stats.countDistinctShouters(CHANNEL));
+    }
+
+    @Test
+    void countsShoutsSinceATimestamp() {
+        shout(100L, "OLD", 10L, T0.minusDays(30));
+        shout(101L, "RECENT", 10L, T0.minusHours(1));
+
+        assertEquals(1, stats.countLiveSince(CHANNEL, T0.minusDays(1)));
+    }
+
+    /** GROUP BY plus ordering on an aggregate. */
+    @Test
+    void ranksTopShouters() {
+        shout(100L, "ONE", 10L, T0);
+        shout(101L, "TWO", 10L, T0);
+        shout(102L, "THREE", 11L, T0);
+
+        var top = stats.topShouters(CHANNEL, 5);
+
+        assertEquals(2, top.size());
+        assertEquals(10L, top.get(0).userId());
+        assertEquals(2, top.get(0).count());
+    }
+
+    @Test
+    void findsOldestAndNewestByAuthoredAt() {
+        shout(100L, "FIRST", 10L, T0.minusDays(2));
+        shout(101L, "LAST", 11L, T0);
+
+        assertEquals("FIRST", stats.oldest(CHANNEL).orElseThrow().content());
+        assertEquals("LAST", stats.newest(CHANNEL).orElseThrow().content());
+    }
+
+    /** charLength is the construct most likely to differ across dialects. */
+    @Test
+    void findsTheLongestShoutByCharacterLength() {
+        shout(100L, "SHORT", 10L, T0);
+        shout(101L, "A MUCH LONGER SHOUT THAN THE OTHER ONE", 11L, T0);
+
+        assertEquals("A MUCH LONGER SHOUT THAN THE OTHER ONE",
+                stats.longest(CHANNEL).orElseThrow().content());
+    }
+
+    @Test
+    void findsTheMostReplayedShout() {
+        shout(100L, "POPULAR", 10L, T0);
+        shout(101L, "IGNORED", 11L, T0);
+        long popularId = shouts.randomPeer(CHANNEL, 101L).orElseThrow().shoutId();
+
+        history.record(CHANNEL, popularId);
+        history.record(CHANNEL, popularId);
+
+        var most = stats.mostReplayed(CHANNEL).orElseThrow();
+        assertEquals(2, most.replayCount());
+    }
+
+    /** The 8-query aggregate that backs the /shout stats embed. */
+    @Test
+    void loadAllReturnsACoherentSnapshot() {
+        shout(100L, "HELLO THERE", 10L, T0.minusDays(3));
+        shout(101L, "GOODBYE NOW", 11L, T0.minusHours(2));
+
+        var all = stats.loadAll(CHANNEL, T0, 5);
+
+        assertEquals(2, all.totalShouts());
+        assertEquals(2, all.distinctShouters());
+        assertTrue(all.oldest().isPresent());
+        assertTrue(all.newest().isPresent());
+        assertTrue(all.longest().isPresent());
+    }
+
+    @Test
+    void softDeletedShoutsAreExcluded() {
+        shout(100L, "VISIBLE", 10L, T0);
+        shout(101L, "DELETED", 11L, T0);
+        long id = shouts.randomPeer(CHANNEL, 100L).orElseThrow().shoutId();
+        shouts.softDelete(id, 99L);
+
+        assertEquals(1, stats.countLive(CHANNEL));
+    }
+}

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/shout/ShoutStatsRepositorySqliteTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/shout/ShoutStatsRepositorySqliteTest.java
@@ -1,18 +1,9 @@
 package ca.ryanmorrison.chatterbox.features.shout;
 
-import com.zaxxer.hikari.HikariConfig;
-import com.zaxxer.hikari.HikariDataSource;
-import org.flywaydb.core.Flyway;
-import org.jooq.DSLContext;
-import org.jooq.SQLDialect;
-import org.jooq.conf.Settings;
-import org.jooq.impl.DSL;
-import org.junit.jupiter.api.AfterEach;
+import ca.ryanmorrison.chatterbox.db.SqliteRepositoryTestBase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
@@ -27,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * query both compiles against the generated jOOQ classes and produces the
  * expected aggregate against a real schema.
  */
-class ShoutStatsRepositorySqliteTest {
+class ShoutStatsRepositorySqliteTest extends SqliteRepositoryTestBase {
 
     private static final long CHANNEL = 1L;
     private static final long OTHER_CHANNEL = 2L;
@@ -35,41 +26,22 @@ class ShoutStatsRepositorySqliteTest {
     private static final OffsetDateTime BASE =
             OffsetDateTime.of(2026, 5, 1, 12, 0, 0, 0, ZoneOffset.UTC);
 
-    private Path dbFile;
-    private HikariDataSource dataSource;
-    private DSLContext dsl;
     private ShoutRepository shouts;
     private ShoutHistoryRepository history;
     private ShoutStatsRepository stats;
 
+    @Override
+    protected String migrationLocation() {
+        return "classpath:db/migration/shout/sqlite";
+    }
+
     @BeforeEach
-    void setUp() throws Exception {
-        dbFile = Files.createTempFile("chatterbox-stats-test", ".db");
-        Files.delete(dbFile);
-
-        var hc = new HikariConfig();
-        hc.setJdbcUrl("jdbc:sqlite:" + dbFile);
-        hc.setMaximumPoolSize(1);
-        hc.setConnectionInitSql("PRAGMA foreign_keys = ON");
-        dataSource = new HikariDataSource(hc);
-
-        Flyway.configure()
-                .dataSource(dataSource)
-                .locations("classpath:db/migration/shout/sqlite")
-                .load()
-                .migrate();
-
-        dsl = DSL.using(dataSource, SQLDialect.SQLITE, new Settings().withRenderSchema(false));
+    void createRepositories() {
         shouts = new ShoutRepository(dsl);
         history = new ShoutHistoryRepository(dsl);
         stats = new ShoutStatsRepository(dsl);
     }
 
-    @AfterEach
-    void tearDown() throws Exception {
-        if (dataSource != null) dataSource.close();
-        if (dbFile != null) Files.deleteIfExists(dbFile);
-    }
 
     @Test
     void emptyChannelHasZeroes() {

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/shout/ShoutsBackfillMigrationSqliteTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/shout/ShoutsBackfillMigrationSqliteTest.java
@@ -1,0 +1,109 @@
+package ca.ryanmorrison.chatterbox.features.shout;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.flywaydb.core.Flyway;
+import org.jooq.DSLContext;
+import org.jooq.SQLDialect;
+import org.jooq.conf.Settings;
+import org.jooq.impl.DSL;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * Covers V20260726000000__shouts_backfill_authored_at.sql.
+ *
+ * <p>V20260430130000 added {@code authored_at} as {@code NOT NULL DEFAULT ''}
+ * on SQLite, so every row that predated it was backfilled with the empty
+ * string — which jOOQ then tries to read as an {@code OffsetDateTime}. The
+ * original migration is already applied in production and must not be edited
+ * (that would change its checksum), so the repair is a forward migration.
+ *
+ * <p>This reconstructs that history: migrate to the broken state, insert a row
+ * the way the old schema would have left it, then migrate the rest of the way
+ * and assert the repair landed.
+ */
+class ShoutsBackfillMigrationSqliteTest {
+
+    private static final String LOCATION = "classpath:db/migration/shout/sqlite";
+    private static final String BROKEN_VERSION = "20260430150000";
+
+    private Path dbFile;
+    private HikariDataSource dataSource;
+    private DSLContext dsl;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbFile = Files.createTempFile("chatterbox-backfill-test", ".db");
+        Files.delete(dbFile);
+
+        var hc = new HikariConfig();
+        hc.setJdbcUrl("jdbc:sqlite:" + dbFile);
+        hc.setMaximumPoolSize(1);
+        dataSource = new HikariDataSource(hc);
+        dsl = DSL.using(dataSource, SQLDialect.SQLITE, new Settings().withRenderSchema(false));
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (dataSource != null) dataSource.close();
+        if (dbFile != null) Files.deleteIfExists(dbFile);
+    }
+
+    private void migrateTo(String target) {
+        Flyway.configure().dataSource(dataSource).locations(LOCATION).target(target)
+                .load().migrate();
+    }
+
+    @Test
+    void backfillRepairsEmptyStringAuthoredAt() {
+        // Stop just before the repair, so authored_at still carries the '' default.
+        migrateTo(BROKEN_VERSION);
+        dsl.execute("INSERT INTO shouts (channel_id, message_id, content, created_at, "
+                + "author_id, authored_at) VALUES (1, 100, 'HELLO WORLD', "
+                + "'2026-04-30T12:00:00.000Z', 0, '')");
+        assertEquals("", authoredAt(100L), "precondition: the broken state must reproduce");
+
+        migrateTo("latest");
+
+        assertEquals("2026-04-30T12:00:00.000Z", authoredAt(100L),
+                "authored_at should fall back to created_at");
+    }
+
+    @Test
+    void backfillLeavesGoodRowsAlone() {
+        migrateTo(BROKEN_VERSION);
+        dsl.execute("INSERT INTO shouts (channel_id, message_id, content, created_at, "
+                + "author_id, authored_at) VALUES (1, 200, 'REAL SHOUT', "
+                + "'2026-04-30T12:00:00.000Z', 7777, '2026-05-01T09:30:00.000Z')");
+
+        migrateTo("latest");
+
+        assertEquals("2026-05-01T09:30:00.000Z", authoredAt(200L));
+        assertNotEquals("2026-04-30T12:00:00.000Z", authoredAt(200L));
+    }
+
+    @Test
+    void backfillIsANoOpOnAFreshDatabase() {
+        // A database created after the fix has no bad rows; the migration must
+        // still apply cleanly and change nothing.
+        migrateTo("latest");
+        dsl.execute("INSERT INTO shouts (channel_id, message_id, content, created_at, "
+                + "author_id, authored_at) VALUES (1, 300, 'FRESH', "
+                + "'2026-07-01T00:00:00.000Z', 42, '2026-07-01T00:00:00.000Z')");
+
+        assertEquals("2026-07-01T00:00:00.000Z", authoredAt(300L));
+    }
+
+    private String authoredAt(long messageId) {
+        return dsl.fetchOne("SELECT authored_at FROM shouts WHERE message_id = ?", messageId)
+                .get(0, String.class);
+    }
+}

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/timezone/UserTimezonesRepositoryPostgresTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/timezone/UserTimezonesRepositoryPostgresTest.java
@@ -1,0 +1,64 @@
+package ca.ryanmorrison.chatterbox.features.timezone;
+
+import ca.ryanmorrison.chatterbox.db.PostgresRepositoryTestBase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Dialect-parity coverage for {@link UserTimezonesRepository}, previously
+ * verified against SQLite only. Like the runtime-config repository it upserts
+ * via {@code onConflict().doUpdate()}.
+ */
+class UserTimezonesRepositoryPostgresTest extends PostgresRepositoryTestBase {
+
+    private static final long USER = 4242L;
+    private static final OffsetDateTime NOW =
+            OffsetDateTime.of(2026, 5, 9, 8, 0, 0, 0, ZoneOffset.UTC);
+
+    private UserTimezonesRepository repo;
+
+    @Override
+    protected String migrationLocation() {
+        return "classpath:db/migration/user-timezones/postgresql";
+    }
+
+    @BeforeEach
+    void createRepository() {
+        repo = new UserTimezonesRepository(dsl);
+    }
+
+    @Test
+    void putThenFind() {
+        repo.put(USER, "America/Toronto", NOW);
+        assertEquals("America/Toronto", repo.find(USER).orElseThrow());
+    }
+
+    @Test
+    void findIsEmptyForAnUnknownUser() {
+        assertTrue(repo.find(USER).isEmpty());
+    }
+
+    @Test
+    void putUpdatesTheExistingRow() {
+        repo.put(USER, "America/Toronto", NOW);
+        repo.put(USER, "Europe/Berlin", NOW.plusHours(1));
+
+        assertEquals("Europe/Berlin", repo.find(USER).orElseThrow());
+    }
+
+    @Test
+    void deleteReportsWhetherARowExisted() {
+        repo.put(USER, "America/Toronto", NOW);
+
+        assertTrue(repo.delete(USER));
+        assertFalse(repo.delete(USER));
+        assertTrue(repo.find(USER).isEmpty());
+    }
+}

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/timezone/UserTimezonesRepositorySqliteTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/timezone/UserTimezonesRepositorySqliteTest.java
@@ -1,18 +1,9 @@
 package ca.ryanmorrison.chatterbox.features.timezone;
 
-import com.zaxxer.hikari.HikariConfig;
-import com.zaxxer.hikari.HikariDataSource;
-import org.flywaydb.core.Flyway;
-import org.jooq.DSLContext;
-import org.jooq.SQLDialect;
-import org.jooq.conf.Settings;
-import org.jooq.impl.DSL;
-import org.junit.jupiter.api.AfterEach;
+import ca.ryanmorrison.chatterbox.db.SqliteRepositoryTestBase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 
@@ -21,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Verifies the SQLite migration is wire-compatible with the generated jOOQ classes. */
-class UserTimezonesRepositorySqliteTest {
+class UserTimezonesRepositorySqliteTest extends SqliteRepositoryTestBase {
 
     private static final long USER = 4242L;
     private static final OffsetDateTime NOW =
@@ -29,36 +20,18 @@ class UserTimezonesRepositorySqliteTest {
     private static final OffsetDateTime LATER =
             OffsetDateTime.of(2026, 5, 9, 1, 0, 0, 0, ZoneOffset.UTC);
 
-    private Path dbFile;
-    private HikariDataSource dataSource;
-    private DSLContext dsl;
     private UserTimezonesRepository repo;
 
+    @Override
+    protected String migrationLocation() {
+        return "classpath:db/migration/user-timezones/sqlite";
+    }
+
     @BeforeEach
-    void setUp() throws Exception {
-        dbFile = Files.createTempFile("chatterbox-user-tz-test", ".db");
-        Files.delete(dbFile);
-
-        var hc = new HikariConfig();
-        hc.setJdbcUrl("jdbc:sqlite:" + dbFile);
-        hc.setMaximumPoolSize(1);
-        dataSource = new HikariDataSource(hc);
-
-        Flyway.configure()
-                .dataSource(dataSource)
-                .locations("classpath:db/migration/user-timezones/sqlite")
-                .load()
-                .migrate();
-
-        dsl = DSL.using(dataSource, SQLDialect.SQLITE, new Settings().withRenderSchema(false));
+    void createRepositories() {
         repo = new UserTimezonesRepository(dsl);
     }
 
-    @AfterEach
-    void tearDown() throws Exception {
-        if (dataSource != null) dataSource.close();
-        if (dbFile != null) Files.deleteIfExists(dbFile);
-    }
 
     @Test
     void putThenFindRoundTrips() {

--- a/src/test/java/ca/ryanmorrison/chatterbox/features/when/TimeParserTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/features/when/TimeParserTest.java
@@ -314,4 +314,34 @@ class TimeParserTest {
         Instant got = parseOk("2026-03-08 02:30", ZoneId.of("America/New_York"));
         assertEquals(Instant.parse("2026-03-08T07:30:00Z"), got);
     }
+
+    // ---- relative offset overflow ----
+
+    @Test
+    void hugeRelativeOffsetFailsCleanlyInsteadOfOverflowing() {
+        // 2e13 weeks * 604800 wraps a long to a negative, which used to blow up
+        // inside Instant.plusSeconds and escape the listener as an unhandled
+        // exception -- the user saw "The application did not respond".
+        assertEquals("Relative offset is too large.",
+                parseFailReason("in 20000000000000 weeks", UTC));
+    }
+
+    @Test
+    void relativeOffsetsBeyondTheCenturyCapAreRejected() {
+        assertEquals("Relative offset is too large.",
+                parseFailReason("in 999999 days", UTC));
+    }
+
+    @Test
+    void digitStringTooLongForALongStillFailsCleanly() {
+        assertEquals("Relative offset is too large.",
+                parseFailReason("in 99999999999999999999999 weeks", UTC));
+    }
+
+    @Test
+    void ordinaryRelativeOffsetsStillWork() {
+        assertEquals(NOW.plusSeconds(30 * 60), parseOk("in 30m", UTC));
+        assertEquals(NOW.plusSeconds(2 * 86_400), parseOk("in 2 days", UTC));
+        assertEquals(NOW.plusSeconds(604_800), parseOk("in 1 week", UTC));
+    }
 }

--- a/src/test/java/ca/ryanmorrison/chatterbox/http/HttpServerTest.java
+++ b/src/test/java/ca/ryanmorrison/chatterbox/http/HttpServerTest.java
@@ -1,0 +1,109 @@
+package ca.ryanmorrison.chatterbox.http;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HttpServerTest {
+
+    private HttpServer server;
+
+    private final HttpClient http = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(2))
+            .followRedirects(HttpClient.Redirect.NEVER)
+            .build();
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) server.stop();
+    }
+
+    private HttpResponse<String> get(String path) throws Exception {
+        URI uri = URI.create("http://localhost:" + port() + path);
+        return http.send(HttpRequest.newBuilder(uri).GET().build(),
+                HttpResponse.BodyHandlers.ofString());
+    }
+
+    /** Javalin picks the port when configured with 0. */
+    private int port() {
+        return server.port();
+    }
+
+    @Test
+    void healthReportsNotReadyBeforeTheProbeIsWired() throws Exception {
+        // The window between binding the port and JDA connecting. Answering
+        // 200 here is exactly what makes a container healthcheck worthless.
+        server = new HttpServer(0);
+        server.start();
+
+        HttpResponse<String> res = get(HttpServer.HEALTH_PATH);
+
+        assertEquals(503, res.statusCode());
+        assertEquals("starting", res.body());
+    }
+
+    @Test
+    void healthReportsReadyOnceTheProbePasses() throws Exception {
+        var ready = new AtomicBoolean(false);
+        server = new HttpServer(0);
+        server.setReadiness(ready::get);
+        server.start();
+
+        assertEquals(503, get(HttpServer.HEALTH_PATH).statusCode());
+
+        ready.set(true);
+        HttpResponse<String> res = get(HttpServer.HEALTH_PATH);
+        assertEquals(200, res.statusCode());
+        assertEquals("ok", res.body());
+    }
+
+    @Test
+    void aThrowingProbeReportsUnhealthyRatherThanErroring() throws Exception {
+        server = new HttpServer(0);
+        server.setReadiness(() -> { throw new IllegalStateException("jda exploded"); });
+        server.start();
+
+        assertEquals(503, get(HttpServer.HEALTH_PATH).statusCode());
+    }
+
+    @Test
+    void healthWinsOverAModuleRouteThatCouldMatchIt() throws Exception {
+        // The shortener registers GET /{token} at the root, and "health" is a
+        // valid 6-character base36 token, so this is a genuine collision.
+        server = new HttpServer(0);
+        server.router().get("/{token}", ctx -> ctx.status(200).result("shortener"));
+        server.setReadiness(() -> true);
+        server.start();
+
+        assertEquals("ok", get(HttpServer.HEALTH_PATH).body());
+        assertEquals("shortener", get("/abc123").body());
+    }
+
+    @Test
+    void serverStartsEvenWithNoModuleRoutes() throws Exception {
+        server = new HttpServer(0);
+        assertFalse(server.hasRoutes());
+
+        server.start();
+
+        // Previously the bot skipped the bind entirely in this case, leaving
+        // nothing to probe.
+        assertTrue(get(HttpServer.HEALTH_PATH).statusCode() > 0);
+    }
+
+    @Test
+    void stopIsSafeToCallWhenNeverStarted() {
+        server = new HttpServer(0);
+        server.stop();
+    }
+}


### PR DESCRIPTION
Acts on a review of the Java sources, migrations, and CI config. Seven commits, each independently reviewable and landing in order of severity.

## The headline issue

`/rss add` was an unauthenticated SSRF primitive. `RssFetcher.normaliseUrl` checked only the scheme and that a host existed — it never resolved the address — and any guild member can add a feed. Fetched content is posted back into the channel on every refresh tick, so it was a read primitive with a built-in exfil path, plus a port scanner via the distinct error messages.

The repo already contained a correct SSRF guard; it was just package-private to `isitdown` and unused elsewhere. It now lives in `common/net` and is applied to RSS on **both** the `/rss add` and scheduler paths — a host that is public when a feed is added can start resolving privately later.

Two things compounded it, both fixed:

- **Redirects defeated the guard entirely.** Both fetchers used `HttpClient.Redirect.NORMAL`, so the URL that was validated is not the URL that gets connected to once a `302` is followed. `SafeHttp` now walks the chain manually and re-runs the guard on every hop; both clients use `Redirect.NEVER`.
- **The 2 MB body cap enforced nothing.** It was checked after `ofByteArray()` had already buffered the whole response, so a host streaming gigabytes exhausted the heap before the check ran. Now capped while streaming, along with the five other clients doing the same thing.

## Also fixed

**`Permissions` crashed in DMs.** `requireManageMessages` read `event.getGuildChannel()` before its null check, but JDA throws there outside a guild rather than returning null — so the "only available in servers" branch was dead code and the exception escaped the listener. Reachable because `ShortenerModule` never set an interaction context, putting `/shorten delete` in the bot's DMs.

**One DB blip permanently retired an RSS feed.** `scheduleAtFixedRate` cancels a task the first time its runnable throws, and only the fetch was inside a try/catch — `repo.findById` at the top and `repo.updateMarkers` at the bottom were bare. Silently, since nothing logged the throwable.

**Blocking DB I/O under a `ConcurrentHashMap` bin lock.** `RuntimeConfig.cacheFor` and `AutoReplyMatcher.firstMatch` both ran a database round-trip inside `computeIfAbsent`. `RuntimeConfig` is consulted on every message, and on SQLite the pool is one connection.

**Production deploys were not gated on tests.** `deploy.yml` triggered on push to `main` with no `needs:` on the CI job, so the two workflows raced, and the image builds with `-DskipTests`. A commit with failing tests deployed anyway. CI also only ran `mvn test`, so nothing exercised the shade plugin — including the `ServicesResourceTransformer` the entire ServiceLoader module system depends on.

Plus: `/when` integer overflow escaping the listener, `/decide` and `/format` exceeding Discord's 2000-char limit, a `HashMap` read outside its lock in `FrinkiacSessions`, JDA's async `shutdown()` racing the pool close, credentials reaching the log on the startup failure path, and explicit XXE hardening in the feed parser (Rome defaults to it, but the old comment described protection the code did not perform).

## Two findings the review missed, caught by the new tests

- The SQLite `PRAGMA` tuning **silently did not work**. sqlite-jdbc executes only the first statement of a multi-statement string, so `journal_mode` was still `delete`. They are driver properties now, and `DatabaseTest` reads all three back from a live connection.
- My first concurrency test for the cache rework **passed even with the guard removed** — worse than no test. Replaced with a latch-driven one, verified to fail without the fix (`expected: <999> but was: <160>`).

## A migration, handled carefully

`V20260430130000` added `authored_at` as `NOT NULL DEFAULT ''` on SQLite, and jOOQ reads that column as an `OffsetDateTime`. It is already applied in production, so it is **left untouched** — editing it would change its checksum and fail validation everywhere. The repair is a forward migration. The Postgres side is a no-op by construction and exists to keep the dialect trees version-aligned; confirmed empirically that Flyway applies comment-only migrations.

## Two deliberate behaviour changes

1. **The HTTP server now always binds.** Previously it skipped the bind entirely if no module registered a route. Nothing in the chain had a healthcheck — not the Dockerfile, not the compose service, and no endpoint to probe — so a hung bot stayed "up" indefinitely and Traefik routed to it the instant the process started. `GET /health` returns `503` until JDA connects and `200` after; an endpoint that sometimes doesn't exist cannot back a healthcheck. It is registered ahead of module routes because `health` is a valid 6-character token for the shortener's `GET /{token}` — that collision has a test.
2. **`/shorten` is now guild-only**, matching `/autoreply`, `/rss`, `/shout` and `/config`.

## Out of scope by request

Two reviewed items were declined and are **not** in this PR:

- No permission gate on `/rss add` — it stays open to every guild member, so the SSRF guard above is the only thing standing there.
- No `setAllowedMentions` on the six sites that replay user-controlled text. A stored shout containing `<@123>` still pings that user on every replay.

Also skipped: `-Werror`, CodeQL, and JaCoCo.

## Testing

**637 tests pass in CI, zero failures.** 568 of those run locally; the rest need Docker.

The four new PostgreSQL parity tests had never executed when this PR was opened — this machine has no Docker, so every Testcontainers class skips locally. They have now run in CI and all pass, including `ShoutStatsRepositoryPostgresTest`, the one carrying the highest risk (`charLength`, `countDistinct`, multi-column `GROUP BY`). No dialect differences surfaced, which is the result worth having: the architecture runs PostgreSQL-generated jOOQ classes against SQLite, and that assumption is now checked on both sides rather than assumed.

The pre-existing Postgres tests were left on their own setup rather than refactored onto the new shared base — at the time that refactor could not be verified locally.

CI also now publishes Surefire results as inline annotations and a run summary via `ScalableCapital/action-surefire-report@v2.0.4`, so a red build is readable from the run page instead of by downloading the XML artifact. It runs in `workflow` mode rather than the default `auto`: `auto` publishes through the Checks API, which needs `checks: write`, and Dependabot triggers runs with a read-only `GITHUB_TOKEN` regardless of what the workflow requests — so `auto` would 403 and fail CI on every Dependabot PR, which this repo gets weekly. `workflow` mode needs no permission beyond the existing `contents: read` and behaves identically when `deploy.yml` calls this workflow. The XML artifact upload stays for when raw reports are needed.

## Follow-up worth considering

Staging's `jdbc:sqlite::memory:` was left as-is per instruction. Be aware that Hikari retires the connection at `maxLifetime` and an in-memory SQLite database dies with its connection, so it currently resets ~30 minutes in rather than once per deploy. `maxLifetime(0)` would give the "ephemeral per deploy" behaviour if that was the intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QNeed2mGvU7eukU6qiUfCS
